### PR TITLE
Move MigrationMeta, add a handy command helper for MigrationMeta, and util trait for avoiding copy pasta

### DIFF
--- a/src/Command/AttachmentsMigrator.php
+++ b/src/Command/AttachmentsMigrator.php
@@ -8,32 +8,13 @@
 namespace Newspack\MigrationTools\Command;
 
 use Newspack\MigrationTools\Log\FileLogger;
-use Newspack\MigrationTools\Log\Log;
 
 /**
  * Attachments general Migrator command class.
  */
 class AttachmentsMigrator implements WpCliCommandInterface {
 
-
-	/**
-	 * Private constructor.
-	 */
-	private function __construct() {
-		// I don't do anything right now.
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public static function get_instance(): self {
-		static $instance = null;
-		if ( null === $instance ) {
-			$instance = new self();
-		}
-
-		return $instance;
-	}
+	use WpCliCommandTrait;
 
 	/**
 	 * {@inheritDoc}

--- a/src/Command/WpCliCommandTrait.php
+++ b/src/Command/WpCliCommandTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Newspack\MigrationTools\Command;
+
+/**
+ * Utility trait for implementing the WpCliCommandInterface interface.
+ *
+ * Use this trait so you don't have to copy-paste the singleton instance code and constructor.
+ */
+trait WpCliCommandTrait {
+
+	/**
+	 * Private constructor.
+	 *
+	 * I don't do anything, and it's on purpose. If you need a lot of initialization in your class,
+	 * then make a method for it and call it when you start your command. The reason is that the
+	 * get_instance() method will instantiate the class, even if you don't need it. So, use the
+	 * constructor sparingly.
+	 */
+	private function __construct() {
+		// Nothing.
+	}
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return self
+	 */
+	public static function get_instance(): self {
+		static $instance = null;
+		if ( null === $instance ) {
+			$instance = new self();
+		}
+
+		return $instance;
+	}
+}

--- a/src/Log/CliLogger.php
+++ b/src/Log/CliLogger.php
@@ -47,7 +47,7 @@ class CliLogger extends Log {
 	 *
 	 * @return void
 	 */
-	public static function log( string $message, string $level, bool $exit_on_error ): void {
+	public static function log( string $message, string $level = self::INFO, bool $exit_on_error = false ): void {
 		/**
 		 * Fires before default logging to CLI.
 		 *

--- a/src/Log/FileLogger.php
+++ b/src/Log/FileLogger.php
@@ -15,7 +15,7 @@ class FileLogger extends Log {
 	 * @param string $level         Log level. See constants in this class.
 	 * @param bool   $exit_on_error Whether to exit on error.
 	 */
-	public static function log( string $file, string $message, string $level = 'line', bool $exit_on_error = false ): void {
+	public static function log( string $file, string $message, string $level = self::LINE, bool $exit_on_error = false ): void {
 		/**
 		 * Filter the file path for the log file.
 		 *

--- a/src/Util/MigrationMeta.php
+++ b/src/Util/MigrationMeta.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Newspack\MigrationTools\Util;
+
+use InvalidArgumentException;
+
+/**
+ * Helper class to help managing metadata for migrations.
+ *
+ * It uses a single meta key stored as an array. Please don't use this class to
+ * store large amounts of data, but rather stuff like migration status or
+ * version for a command for a post. E.g.: 'update_authors' => 'v1'.
+ */
+class MigrationMeta {
+
+	/**
+	 * The meta key used to store the migration meta.
+	 */
+	public const META_KEY = 'newspack_migration_meta';
+
+	/**
+	 * Get the value for a given key from the metadata array.
+	 *
+	 * @param int|string $object_id post, user or term id.
+	 * @param string     $key       The key in the array in the metadata row.
+	 * @param string     $type      One of post, term, or user.
+	 *
+	 * @return mixed|null The meta value, or null if not found.
+	 */
+	public static function get( int|string $object_id, string $key, string $type ): mixed {
+		self::validate_type( $type );
+
+		$meta = call_user_func( "get_{$type}_meta", $object_id, self::META_KEY, true );
+
+		return $meta[ $key ] ?? null;
+	}
+
+	/**
+	 * Update a value for a given key in the metadata array.
+	 *
+	 * @param int|string $object_id post, user or term id.
+	 * @param string     $key       The key in the array in the metadata row.
+	 * @param string     $type      One of post, term, or user.
+	 * @param mixed      $value     Value to set.
+	 *
+	 * @return void
+	 */
+	public static function update( int|string $object_id, string $key, string $type, mixed $value ): void {
+		self::validate_type( $type );
+
+		$full_meta = call_user_func( "get_{$type}_meta", $object_id, self::META_KEY, true );
+		if ( ! is_array( $full_meta ) ) {
+			$full_meta = [];
+		}
+		$full_meta[ $key ] = $value;
+
+		call_user_func( "update_{$type}_meta", $object_id, self::META_KEY, $full_meta );
+	}
+
+
+	/**
+	 * Delete a value for a given key in the metadata array.
+	 *
+	 * @param int|string $object_id post, user or term id.
+	 * @param string     $key       The key in the array in the metadata row.
+	 * @param string     $type      One of post, term, or user.
+	 *
+	 * @return void
+	 */
+	public static function delete( int|string $object_id, string $key, string $type ): void {
+		self::validate_type( $type );
+
+		$full_meta = call_user_func( "get_{$type}_meta", $object_id, self::META_KEY, true );
+		if ( is_array( $full_meta ) ) {
+			unset( $full_meta[ $key ] );
+		}
+		if ( empty( $full_meta ) ) {
+			call_user_func( "delete_{$type}_meta", $object_id, self::META_KEY );
+
+			return;
+		}
+
+		call_user_func( "update_{$type}_meta", $object_id, self::META_KEY, $full_meta );
+	}
+
+	/**
+	 * Check that type is one of post, term, or user.
+	 *
+	 * @param string $type Object type.
+	 *
+	 * @return void
+	 *
+	 * @throws InvalidArgumentException If the type is not valid.
+	 */
+	private static function validate_type( string $type ): void {
+		if ( ! in_array( $type, [ 'post', 'term', 'user' ] ) ) {
+			throw new InvalidArgumentException( sprintf( 'Invalid type %s', esc_html( $type ) ) );
+		}
+	}
+}

--- a/src/Util/MigrationMetaForCommand.php
+++ b/src/Util/MigrationMetaForCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Newspack\MigrationTools\Util;
+
+use Newspack\MigrationTools\Log\CliLogger;
+
+class MigrationMetaForCommand {
+	private string $command_name;
+	private int $command_version;
+
+	private bool $refresh_existing = false;
+
+	public function __construct( string $command_name, int $command_version ) {
+		$this->command_name    = $command_name;
+		$this->command_version = $command_version;
+	}
+
+	public function set_refresh_existing( bool $refresh_existing ): void {
+		$this->refresh_existing = $refresh_existing;
+	}
+
+	public function get_suggested_logfile_name(): string {
+		$logfile_name = $this->command_name . '-' . $this->command_version;
+		if ( $this->refresh_existing ) {
+			$logfile_name .= '-refresh-existing';
+		}
+
+		return str_replace( '_', '-', sanitize_title( $logfile_name ) ) . '.log';
+	}
+
+	public function should_skip_post( int $post_id ): bool {
+		if ( $this->refresh_existing ) {
+			return false;
+		}
+		$post_version = MigrationMeta::get( $post_id, $this->command_name, 'post' );
+		if ( empty( $post_version ) ) {
+			// No metadata set for that command at all – we should not skip.
+			return false;
+		}
+
+		// If the post version is higher than the command version, we should skip.
+		return $post_version > $this->command_version;
+	}
+
+	public function log_skip_post_id( int $post_id ): void {
+		CliLogger::line(
+			sprintf(
+				'Skipping post %d, already at MigrationMeta %s for command %s.',
+				$post_id,
+				$this->command_version,
+				$this->command_name
+			)
+		);
+	}
+
+	/**
+	 * Set the next version numnber on a post.
+	 *
+	 * Please note that this will always simply add 1 to the instance of this class's command version.
+	 * That means if you call this over and over you will still update to the same version.
+	 *
+	 * @param int $post_id The post ID.
+	 */
+	public function set_next_version_on_post( int $post_id ): void {
+		MigrationMeta::update( $post_id, $this->command_name, 'post', ( $this->command_version + 1 ) );
+	}
+}

--- a/tests/Util/MigrationMetaForCommandTest.php
+++ b/tests/Util/MigrationMetaForCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Newspack\MigrationTools\Tests\Util;
+
+use Newspack\MigrationTools\Util\MigrationMeta;
+use Newspack\MigrationTools\Util\MigrationMetaForCommand;
+use WP_UnitTestCase;
+
+class MigrationMetaForCommandTest extends WP_UnitTestCase {
+
+	/**
+	 * Test that we get a nice log file name.
+	 *
+	 * @return void
+	 */
+	public function test_get_suggested_logfile_name() {
+		$command_meta       = new MigrationMetaForCommand( 'test_myself_with_a_log_file_name', 1 );
+		$expected_file_name = 'test-myself-with-a-log-file-name-1.log';
+		$this->assertEquals( $expected_file_name, $command_meta->get_suggested_logfile_name() );
+	}
+
+	/**
+	 * Test if a post should be skipped for processing if it has already been processed.
+	 *
+	 * @return void
+	 */
+	public function test_should_skip_post() {
+		$post_id      = 1;
+		$cmd_version  = 'test_skips';
+		$command_meta = new MigrationMetaForCommand( $cmd_version, 1 );
+		// The post has not been processed, so it should not be skipped.
+		$this->assertFalse( $command_meta->should_skip_post( $post_id ) );
+
+		// Now set a higher version number and we should skip.
+		MigrationMeta::update( $post_id, $cmd_version, 'post', 2 );
+		$this->assertTrue( $command_meta->should_skip_post( $post_id ) );
+
+		// If we insist on refreshing existing posts with refresh existing, it should not be skipped though.
+		$command_meta->set_refresh_existing( true );
+		$this->assertFalse( $command_meta->should_skip_post( $post_id ) );
+
+		MigrationMeta::delete( $post_id, $cmd_version, 'post' );
+	}
+
+	/**
+	 * Test the set next version sets the MigrationMeta version number correctly.
+	 *
+	 * @return void
+	 */
+	public function test_set_next_version() {
+		$post_id        = 1;
+		$cmd_version    = 'test_bump';
+		$version_number = 1;
+		$command_meta   = new MigrationMetaForCommand( $cmd_version, $version_number );
+		$command_meta->set_next_version_on_post( $post_id );
+		$this->assertEquals( $version_number + 1, MigrationMeta::get( $post_id, $cmd_version, 'post' ) );
+
+		// No matter how many times we call this, it should be the MigrationMetaForCommand's version number + 1.
+		$command_meta->set_next_version_on_post( $post_id );
+		$command_meta->set_next_version_on_post( $post_id );
+		$this->assertEquals( $version_number + 1, MigrationMeta::get( $post_id, $cmd_version, 'post' ) );
+	}
+}

--- a/tests/Util/MigrationMetaTest.php
+++ b/tests/Util/MigrationMetaTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Newspack\MigrationTools\Tests\Util;
+
+use Newspack\MigrationTools\Util\MigrationMeta;
+use InvalidArgumentException;
+use WP_UnitTestCase;
+
+class MigrationMetaTest extends WP_UnitTestCase {
+
+	private int $post_id = 1;
+
+	/**
+	 * Test CRUD operations on MigrationMeta.
+	 *
+	 * @return void
+	 */
+	public function testCrud() {
+		$this->assertNull( MigrationMeta::get( $this->post_id, 'non_existent_key', 'post' ) );
+
+		MigrationMeta::update( $this->post_id, 'first_key', 'post', 3 );
+		MigrationMeta::update( $this->post_id, 'second_key', 'post', 2 );
+
+		$this->assertEquals( 3, MigrationMeta::get( $this->post_id, 'first_key', 'post' ) );
+		$this->assertEquals( 2, MigrationMeta::get( $this->post_id, 'second_key', 'post' ) );
+
+		MigrationMeta::update( $this->post_id, 'first_key', 'post', 30 );
+		MigrationMeta::update( $this->post_id, 'second_key', 'post', 20 );
+
+		$this->assertEquals( 30, MigrationMeta::get( $this->post_id, 'first_key', 'post' ) );
+		$this->assertEquals( 20, MigrationMeta::get( $this->post_id, 'second_key', 'post' ) );
+
+		MigrationMeta::delete( $this->post_id, 'first_key', 'post' );
+		$this->assertNull( MigrationMeta::get( $this->post_id, 'first_key', 'post' ) );
+		$this->assertEquals( 20, MigrationMeta::get( $this->post_id, 'second_key', 'post' ) );
+	}
+
+	/**
+	 * Test that we can only update with valid types.
+	 *
+	 * @return void
+	 */
+	public function testValidate() {
+		$this->expectException( InvalidArgumentException::class );
+		MigrationMeta::update( $this->post_id, 'first_key', 'type_that_is_NOT_valid', 1 );
+	}
+}


### PR DESCRIPTION
This PR:
- adds a new trail `WpCliCommandTrait` that we can use to implement the `WpCliCommandInterface` without having to copy paste all the time.
- An util class that makes MigrationMeta easier to work with on commands
- Tests for the MigrationMeta stuff I added

No test for the trait - that doesn't make much sense.