### PR TITLE
Fix: Remove trait when command classes use static methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,21 @@ You can load this package in your PHP project as follows:
 
 _composer.json_
 
-```
+```json
 "repositories": [
     {
         "type": "git",
         "url": "https://github.com/Automattic/newspack-migration-tools.git"
     }
 ],
+"require": {
+    "automattic/newspack-migration-tools": "dev-trunk"
+}
 ```
 
 _my-plugin-file.php_
 
-```
+```php
 // Loading the attachments helper class.
 use Newspack\MigrationTools\Logic\AttachmentHelper;
 // Example call.
@@ -38,11 +41,16 @@ $attachment_id = AttachmentHelper::import_attachment_for_post( ... your argument
 ## Registering the WP CLI commands in this package
 If you want to use the WP CLI commands in this package, you can do so by adding the following code to your plugin:
 ```php
+use Newspack\MigrationTools\Command\WpCliCommands;
+use Newspack\MigrationTools\Command\WpCliCommandInterface;
 
 // Add your command class names in the array.
 $cli_commands = [ Newspack\MigrationTools\Commands\MyCommand::class ];
 
-foreach ( cli_commands as $command_class ) {
+// Or add all classes:
+// $cli_commands = WpCliCommands::get_classes_with_cli_commands();
+
+foreach ( $cli_commands as $command_class ) {
     if ( is_a( $command_class, WpCliCommandInterface::class, true ) ) {
             array_map( function ( $command ) {
             WP_CLI::add_command( ...$command );

--- a/src/Command/AttachmentsMigrator.php
+++ b/src/Command/AttachmentsMigrator.php
@@ -14,8 +14,6 @@ use Newspack\MigrationTools\Log\FileLogger;
  */
 class AttachmentsMigrator implements WpCliCommandInterface {
 
-	use WpCliCommandTrait;
-
 	/**
 	 * {@inheritDoc}
 	 */

--- a/src/Command/NewspaperThemeCommand.php
+++ b/src/Command/NewspaperThemeCommand.php
@@ -8,8 +8,6 @@ use Newspack\MigrationTools\Util\MigrationMetaForCommand;
 
 class NewspaperThemeCommand implements WpCliCommandInterface {
 
-	use WpCliCommandTrait;
-
 	/**
 	 * {@inheritDoc}
 	 */
@@ -72,7 +70,7 @@ class NewspaperThemeCommand implements WpCliCommandInterface {
 	 * @param array $pos_args   Positional arguments.
 	 * @param array $assoc_args Associative arguments.
 	 */
-	public function cmd_list_post_settings( array $pos_args, array $assoc_args ): void {
+	public static function cmd_list_post_settings( array $pos_args, array $assoc_args ): void {
 		$theme_settings = [];
 
 		global $wpdb;

--- a/src/Command/WpCliCommandTrait.php
+++ b/src/Command/WpCliCommandTrait.php
@@ -8,8 +8,7 @@ use ErrorException;
 /**
  * Utility trait for ensuring singleton instances of WP CLI commands.
  *
- * If your command class uses static functions for commands – don't use this trait as it will cause a fatal error
- * in WP_CLI because WP_CLI will try to call the private __construct() method before calling your static command.
+ * If your command class uses static functions for commands – you shouldn't use this trait.
  */
 trait WpCliCommandTrait {
 

--- a/src/Command/WpCliCommandTrait.php
+++ b/src/Command/WpCliCommandTrait.php
@@ -8,7 +8,9 @@ use ErrorException;
 /**
  * Utility trait for ensuring singleton instances of WP CLI commands.
  *
- * If your command class uses static functions for commands – you probably don't need this trait.
+ * If your command class uses static functions for commands – don't use this trait as it will cause a fatal error
+ * in WP_CLI because WP_CLI will try to call the private __construct() method before calling your static command.
+ *
  */
 trait WpCliCommandTrait {
 

--- a/src/Command/WpCliCommandTrait.php
+++ b/src/Command/WpCliCommandTrait.php
@@ -10,7 +10,6 @@ use ErrorException;
  *
  * If your command class uses static functions for commands – don't use this trait as it will cause a fatal error
  * in WP_CLI because WP_CLI will try to call the private __construct() method before calling your static command.
- *
  */
 trait WpCliCommandTrait {
 


### PR DESCRIPTION
This PR will remove the trait from the command classes that use static methods.  The trait was causing a fatal error when run in a WP_CLI context.

Test command:  `wp newspack-migration-tools attachments-get-ids-by-years`

Error:  `PHP Fatal error:  Uncaught Error: Call to private __construct() from scope WP_CLI\Dispatcher\CommandFactory in phar://.../bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:99`

The conflicting line of code: (line 99): `$callable[0] = is_object( $callable[0] ) ? $callable[0] : new $callable[0]();`

It seems that WP_CLI will try to instantiate a new instance when the trait exists on a command class that uses static methods.

The trait has been removed, and doc blocks updated.

If you'd like to test, please follow the "Development" section in the README.md to create a testing plugin, then run the "test command" above again.

---

Tested with WP_CLI version: `WP-CLI 2.11.0`