### PR TITLE
Move GutenbergBlockGenerator from NCCM

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,8 @@
         "php": ">=8.1"
     },
     "require-dev": {
+        "ext-libxml": "*",
+        "ext-dom": "*",
         "wp-coding-standards/wpcs": "^3.0",
         "automattic/vipwpcs": "^3.0",
         "phpcompatibility/phpcompatibility-wp": "*",

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -249,13 +249,19 @@ class GutenbergBlockGenerator {
 	 * @param string   $size                   Image size, full by default.
 	 * @param bool     $link_to_attachment_url Whether to link to the attachment URL or not.
 	 * @param string   $classname              Media HTML class.
+	 * @param string   $align                  Image alignment (left, right).
 	 *
 	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
 	 */
-	public function get_image( $attachment_post, $size = 'full', $link_to_attachment_url = true, $classname = null ) {
+	public function get_image( $attachment_post, $size = 'full', $link_to_attachment_url = true, $classname = null, $align = null ) {
+		// Validate size.
+		if ( ! in_array( $size, [ 'thumbnail', 'medium', 'large', 'full' ] ) ) {
+			$size = 'full';
+		}
+
 		$caption_tag = ! empty( $attachment_post->post_excerpt ) ? '<figcaption class="wp-element-caption">' . $attachment_post->post_excerpt . '</figcaption>' : '';
 		$image_alt   = get_post_meta( $attachment_post->ID, '_wp_attachment_image_alt', true );
-		$image_url   = wp_get_attachment_url( $attachment_post->ID );
+		$image_url   = wp_get_attachment_image_src( $attachment_post->ID, $size )[0];
 
 		$attrs = [
 			'id'       => $attachment_post->ID,
@@ -274,7 +280,11 @@ class GutenbergBlockGenerator {
 			$attrs['className'] = $classname;
 		}
 
-		$figure_class = 'wp-block-image size-' . $size . ( $classname ? " $classname" : '' );
+		if ( $align ) {
+			$attrs['align'] = $align;
+		}
+
+		$figure_class = 'wp-block-image size-' . $size . ( $classname ? " $classname" : '' ) . ( $align ? " align$align" : '' );
 
 		$content = '<figure class="' . $figure_class . '">' . $a_opening_tag . '<img src="' . $image_url . '" alt="' . $image_alt . '" class="wp-image-' . $attachment_post->ID . '"/>' . $a_closing_tag . $caption_tag . '</figure>';
 
@@ -759,15 +769,27 @@ class GutenbergBlockGenerator {
 	 * Generate a Newspack Iframe block.
 	 *
 	 * @param string $src URL.
+	 * @param string $width Width.
+	 * @param string $height Height.
 	 *
 	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
 	 */
-	public function get_iframe( $src ) {
+	public function get_iframe( $src, $width = null, $height = null ) {
+		$attrs = [
+			'src' => $src,
+		];
+
+		if ( $width ) {
+			$attrs['width'] = $width;
+		}
+
+		if ( $height ) {
+			$attrs['height'] = $height;
+		}
+
 		return [
 			'blockName'    => 'newspack-blocks/iframe',
-			'attrs'        => [
-				'src' => $src,
-			],
+			'attrs'        => $attrs,
 			'innerBlocks'  => [],
 			'innerHTML'    => '',
 			'innerContent' => [],

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -340,6 +340,7 @@ VIDEO;
 			'href'           => $attachment_url,
 			'displayPreview' => true,
 			'previewHeight'  => $height,
+			'showDownloadButton'   => $show_download_button,
 		];
 
 		$download_button = $show_download_button ? '<a href="' . $attachment_url . '" class="wp-block-file__button wp-element-button" download aria-describedby="wp-block-file--media-' . $uuid . '">Download</a>' : '';

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -260,12 +260,13 @@ class GutenbergBlockGenerator {
 			$size = 'full';
 		}
 
-		$caption_tag = ! empty( $attachment_post->post_excerpt ) ? '<figcaption class="wp-element-caption">' . $attachment_post->post_excerpt . '</figcaption>' : '';
-		$image_alt   = get_post_meta( $attachment_post->ID, '_wp_attachment_image_alt', true );
-		$image_url   = wp_get_attachment_image_src( $attachment_post->ID, $size )[0];
+		$caption_tag   = ! empty( $attachment_post->post_excerpt ) ? '<figcaption class="wp-element-caption">' . $attachment_post->post_excerpt . '</figcaption>' : '';
+		$image_alt     = get_post_meta( $attachment_post->ID, '_wp_attachment_image_alt', true );
+		$image_url     = wp_get_attachment_image_src( $attachment_post->ID, $size )[0];
+		$attachment_id = intval( $attachment_post->ID );
 
 		$attrs = [
-			'id'       => $attachment_post->ID,
+			'id'       => $attachment_id,
 			'sizeSlug' => $size,
 		];
 
@@ -287,7 +288,7 @@ class GutenbergBlockGenerator {
 
 		$figure_class = 'wp-block-image size-' . $size . ( $classname ? " $classname" : '' ) . ( $align ? " align$align" : '' );
 
-		$content = '<figure class="' . $figure_class . '">' . $a_opening_tag . '<img src="' . $image_url . '" alt="' . $image_alt . '" class="wp-image-' . $attachment_post->ID . '"/>' . $a_closing_tag . $caption_tag . '</figure>';
+		$content = '<figure class="' . $figure_class . '">' . $a_opening_tag . '<img src="' . $image_url . '" alt="' . $image_alt . '" class="wp-image-' . $attachment_id . '"/>' . $a_closing_tag . $caption_tag . '</figure>';
 
 		return [
 			'blockName'    => 'core/image',
@@ -306,8 +307,8 @@ class GutenbergBlockGenerator {
 	 * @return array
 	 */
 	public function get_video( WP_Post $attachment_post ): array {
-		$video_url   = wp_get_attachment_url( $attachment_post->ID);
-		$content = <<<VIDEO
+		$video_url = wp_get_attachment_url( $attachment_post->ID );
+		$content   = <<<VIDEO
 <figure class="wp-block-video"><video controls src="$video_url"></video></figure>
 VIDEO;
 		return [
@@ -674,6 +675,7 @@ VIDEO;
 	 *
 	 * @param array $inner_blocks   Inner blocks.
 	 * @param array $custom_classes Custom classes to be added to the group block.
+	 * @param array $attrs          Attributes to be added to the group block.
 	 *
 	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
 	 */
@@ -979,7 +981,7 @@ VIDEO;
 	/**
 	 * Generate a Newspack Homepage Articles Block with specific posts.
 	 *
-	 * @param array $category_ids array of post IDs.
+	 * @param array $post_ids array of post IDs.
 	 * @param array $args args to pass to the block.
 	 *
 	 * @return array

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -262,7 +262,7 @@ class GutenbergBlockGenerator {
 
 		$caption_tag   = ! empty( $attachment_post->post_excerpt ) ? '<figcaption class="wp-element-caption">' . $attachment_post->post_excerpt . '</figcaption>' : '';
 		$image_alt     = get_post_meta( $attachment_post->ID, '_wp_attachment_image_alt', true );
-		$image_url     = wp_get_attachment_image_src( $attachment_post->ID, $size )[0];
+		$image_url     = Attachments::get_attachment_image_src( $attachment_post->ID, $size )[0];
 		$attachment_id = intval( $attachment_post->ID );
 
 		$attrs = [

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -24,7 +24,7 @@ use \WP_CLI;
  * @package NewspackCustomContentMigrator\Logic
  */
 class GutenbergBlockGenerator {
-    /**
+	/**
 	 * @var Logger.
 	 */
 	private $logger;
@@ -36,39 +36,39 @@ class GutenbergBlockGenerator {
 		$this->logger = new Logger();
 	}
 
-    /**
-     * Generate a Jetpack Tiled Gallery Block.
-     *
-     * @param int[]    $attachment_ids Attachments IDs to be used in the tiled gallery.
-     * @param string[] $tile_sizes_list List of tiles sizes in percentages (e.g. ['50', '50']).
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_jetpack_tiled_gallery( $attachment_ids, $tile_sizes_list = [ '66.79014', '33.20986', '33.33333', '33.33333', '33.33333', '50.00000', '50.00000' ] ) {
-        $gallery_content = '
+	/**
+	 * Generate a Jetpack Tiled Gallery Block.
+	 *
+	 * @param int[]    $attachment_ids Attachments IDs to be used in the tiled gallery.
+	 * @param string[] $tile_sizes_list List of tiles sizes in percentages (e.g. ['50', '50']).
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_jetpack_tiled_gallery( $attachment_ids, $tile_sizes_list = [ '66.79014', '33.20986', '33.33333', '33.33333', '33.33333', '50.00000', '50.00000' ] ) {
+		$gallery_content = '
         <div class="wp-block-jetpack-tiled-gallery aligncenter is-style-rectangular">
             <div class="tiled-gallery__gallery">
                 <div class="tiled-gallery__row">
         ';
 
-        $tile_sizes                      = [];
-        $non_existing_attachment_indexes = [];
+		$tile_sizes                      = [];
+		$non_existing_attachment_indexes = [];
 
 		$gallery_content .= join(
-            ' ',
-            array_filter(
-                array_map(
-                    function( $index, $attachment_id ) use ( &$tile_sizes, &$non_existing_attachment_indexes, $tile_sizes_list ) {
-                        $attachment_url = wp_get_attachment_url( $attachment_id );
+			' ',
+			array_filter(
+				array_map(
+					function( $index, $attachment_id ) use ( &$tile_sizes, &$non_existing_attachment_indexes, $tile_sizes_list ) {
+						$attachment_url = wp_get_attachment_url( $attachment_id );
 
-                        if ( ! $attachment_url ) {
-                            $non_existing_attachment_indexes[] = $index;
-                            $this->logger->log( 'jetpack_tiled_gallery_migrator.log', sprintf( "Attachment %d doesn't exist!", $attachment_id ), Logger::WARNING );
-                            return null;
-                        }
+						if ( ! $attachment_url ) {
+							$non_existing_attachment_indexes[] = $index;
+							$this->logger->log( 'jetpack_tiled_gallery_migrator.log', sprintf( "Attachment %d doesn't exist!", $attachment_id ), Logger::WARNING );
+							return null;
+						}
 
-                        $tile_size    = $this->get_tile_image_size_by_index( $index, $tile_sizes_list );
-                        $tile_sizes[] = $tile_size;
-                        return '
+						$tile_size    = $this->get_tile_image_size_by_index( $index, $tile_sizes_list );
+						$tile_sizes[] = $tile_size;
+						return '
                             <div class="tiled-gallery__col" style="flex-basis: ' . $tile_size . '%">
                             <figure class="tiled-gallery__item">
                                 <img
@@ -81,11 +81,11 @@ class GutenbergBlockGenerator {
                                 />
                             </figure>
                             </div>';
-                    },
-                    array_keys( $attachment_ids ),
-                    $attachment_ids
-                )
-            )
+					},
+					array_keys( $attachment_ids ),
+					$attachment_ids
+				)
+			)
 		);
 
 		$gallery_content .= '
@@ -94,10 +94,10 @@ class GutenbergBlockGenerator {
         </div>
         ';
 
-        // delete unexisting attachments.
-        foreach ( $non_existing_attachment_indexes as $non_existing_attachment_index ) {
-            unset( $attachment_ids[ $non_existing_attachment_index ] );
-        }
+		// delete unexisting attachments.
+		foreach ( $non_existing_attachment_indexes as $non_existing_attachment_index ) {
+			unset( $attachment_ids[ $non_existing_attachment_index ] );
+		}
 
 		return [
 			'blockName'    => 'jetpack/tiled-gallery',
@@ -108,199 +108,199 @@ class GutenbergBlockGenerator {
 			'innerBlocks'  => [],
 			'innerHTML'    => $gallery_content,
 			'innerContent' => [ $gallery_content ],
-        ];
-    }
+		];
+	}
 
-    /**
-     * Generate a Jetpack Slideshow Block.
-     *
-     * @param int[]     $attachment_ids Attachments IDs to be used in the tiled gallery.
-     * @param string    $transition Slideshow transition (slide or fade).
-     * @param int|false $autoplay False de disable, on the delay in seconds.
-     * @param string    $image_size Image size (thumbnail, medium, large, full).
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_jetpack_slideshow( $attachment_ids, $transition = 'slide', $autoplay = false, $image_size = 'large' ) {
-        $data_autoplay = is_numeric( $autoplay ) ? 'data-autoplay="true" data-delay="' . $autoplay . '"' : '';
-        $data_effect   = 'data-effect="' . $transition . '"';
+	/**
+	 * Generate a Jetpack Slideshow Block.
+	 *
+	 * @param int[]     $attachment_ids Attachments IDs to be used in the tiled gallery.
+	 * @param string    $transition Slideshow transition (slide or fade).
+	 * @param int|false $autoplay False de disable, on the delay in seconds.
+	 * @param string    $image_size Image size (thumbnail, medium, large, full).
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_jetpack_slideshow( $attachment_ids, $transition = 'slide', $autoplay = false, $image_size = 'large' ) {
+		$data_autoplay = is_numeric( $autoplay ) ? 'data-autoplay="true" data-delay="' . $autoplay . '"' : '';
+		$data_effect   = 'data-effect="' . $transition . '"';
 
-        $attachment_posts = [];
+		$attachment_posts = [];
 		foreach ( $attachment_ids as $attachment_id ) {
-            $attachment_post = get_post( $attachment_id );
-            if ( ! $attachment_post ) {
-                $this->logger->log( 'jetpack_slideshow_migrator.log', sprintf( "Attachment %d doesn't exist!", $attachment_id ), Logger::WARNING );
-                continue;
-            }
+			$attachment_post = get_post( $attachment_id );
+			if ( ! $attachment_post ) {
+				$this->logger->log( 'jetpack_slideshow_migrator.log', sprintf( "Attachment %d doesn't exist!", $attachment_id ), Logger::WARNING );
+				continue;
+			}
 
 			$attachment_posts[] = $attachment_post;
 		}
 
-        $slideshow_content = '
+		$slideshow_content = '
             <div class="wp-block-jetpack-slideshow aligncenter" ' . $data_autoplay . ' ' . $data_effect . '>
                 <div class="wp-block-jetpack-slideshow_container swiper-container">
                     <ul class="wp-block-jetpack-slideshow_swiper-wrapper swiper-wrapper">
         ';
 
-        foreach ( $attachment_posts as $attachment_post ) {
-            $caption = ! empty( $attachment_post->post_excerpt ) ? $attachment_post->post_excerpt : $attachment_post->post_title;
+		foreach ( $attachment_posts as $attachment_post ) {
+			$caption = ! empty( $attachment_post->post_excerpt ) ? $attachment_post->post_excerpt : $attachment_post->post_title;
 
-            $slideshow_content .= '<li class="wp-block-jetpack-slideshow_slide swiper-slide">
+			$slideshow_content .= '<li class="wp-block-jetpack-slideshow_slide swiper-slide">
             <figure>
             <img alt="' . $attachment_post->post_title . '" class="wp-block-jetpack-slideshow_image wp-image-' . $attachment_post->ID . '" data-id="' . $attachment_post->ID . '" src="' . wp_get_attachment_url( $attachment_post->ID ) . '"/>
             <figcaption class="wp-block-jetpack-slideshow_caption gallery-caption">' . $caption . '</figcaption>
             </figure>
             </li>';
-        }
+		}
 
-        $slideshow_content .= '</ul>
+		$slideshow_content .= '</ul>
                     <a class="wp-block-jetpack-slideshow_button-prev swiper-button-prev swiper-button-white" role="button"></a>
                     <a class="wp-block-jetpack-slideshow_button-next swiper-button-next swiper-button-white" role="button"></a>
                     <a aria-label="Pause Slideshow" class="wp-block-jetpack-slideshow_button-pause" role="button"></a>
                     <div class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-white"></div>
                 </div>
             </div>';
-        return [
-            'blockName'    => 'jetpack/slideshow',
-            'attrs'        => [
-                'ids'      => $attachment_ids,
-                'sizeSlug' => $image_size,
-                'effect'   => $transition,
-                'autoplay' => $autoplay,
-            ],
-            'innerBlocks'  => [],
-            'innerHTML'    => $slideshow_content,
-            'innerContent' => [ $slideshow_content ],
-        ];
-    }
+		return [
+			'blockName'    => 'jetpack/slideshow',
+			'attrs'        => [
+				'ids'      => $attachment_ids,
+				'sizeSlug' => $image_size,
+				'effect'   => $transition,
+				'autoplay' => $autoplay,
+			],
+			'innerBlocks'  => [],
+			'innerHTML'    => $slideshow_content,
+			'innerContent' => [ $slideshow_content ],
+		];
+	}
 
-    /**
-     * Generate a Jetpack Slideshow Block.
-     *
-     * @param int[]   $attachment_ids Attachments IDs to be used in the tiled gallery.
-     * @param int     $images_per_row Images per row.
-     * @param string  $image_size Image size (thumbnail, medium, large, full), full by default.
-     * @param string  $image_link_to Link images to `none`, `media`, or to `attachment`.
-     * @param boolean $crop_images To crop the gallery images or not.
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_gallery( $attachment_ids, $images_per_row = 3, $image_size = 'full', $image_link_to = 'none', $crop_images = false ) {
-        $attachment_posts = [];
-        $image_blocks     = [];
+	/**
+	 * Generate a Jetpack Slideshow Block.
+	 *
+	 * @param int[]   $attachment_ids Attachments IDs to be used in the tiled gallery.
+	 * @param int     $images_per_row Images per row.
+	 * @param string  $image_size Image size (thumbnail, medium, large, full), full by default.
+	 * @param string  $image_link_to Link images to `none`, `media`, or to `attachment`.
+	 * @param boolean $crop_images To crop the gallery images or not.
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_gallery( $attachment_ids, $images_per_row = 3, $image_size = 'full', $image_link_to = 'none', $crop_images = false ) {
+		$attachment_posts = [];
+		$image_blocks     = [];
 		foreach ( $attachment_ids as $attachment_id ) {
-            $attachment_post = get_post( $attachment_id );
-            if ( ! $attachment_post ) {
-                $this->logger->log( 'gallery_migrator.log', sprintf( "Attachment %d doesn't exist!", $attachment_id ), Logger::WARNING );
-                continue;
-            }
+			$attachment_post = get_post( $attachment_id );
+			if ( ! $attachment_post ) {
+				$this->logger->log( 'gallery_migrator.log', sprintf( "Attachment %d doesn't exist!", $attachment_id ), Logger::WARNING );
+				continue;
+			}
 
 			$attachment_posts[] = $attachment_post;
 		}
 
-        foreach ( $attachment_posts as $attachment_post ) {
-            $image_blocks[] = $this->get_image( $attachment_post );
-        }
+		foreach ( $attachment_posts as $attachment_post ) {
+			$image_blocks[] = $this->get_image( $attachment_post );
+		}
 
-        // Inner content.
+		// Inner content.
 		$inner_content = array_fill( 1, count( $attachment_posts ), null );
 		array_unshift( $inner_content, '<figure class="wp-block-gallery has-nested-images columns-' . $images_per_row . '">' );
 		array_push( $inner_content, '</figure>' );
 
-        return [
-            'blockName'    => 'core/gallery',
-            'attrs'        => [
+		return [
+			'blockName'    => 'core/gallery',
+			'attrs'        => [
 				'columns'   => $images_per_row,
 				'imageCrop' => $crop_images,
 				'linkTo'    => $image_link_to,
 				'sizeSlug'  => $image_size,
-            ],
-            'innerBlocks'  => $image_blocks,
-            'innerHTML'    => '<figure class="wp-block-gallery has-nested-images columns-' . $images_per_row . '"></figure>',
-            'innerContent' => $inner_content,
+			],
+			'innerBlocks'  => $image_blocks,
+			'innerHTML'    => '<figure class="wp-block-gallery has-nested-images columns-' . $images_per_row . '"></figure>',
+			'innerContent' => $inner_content,
 		];
-    }
+	}
 
-    /**
-     * Generate a List Block item.
-     *
-     * @param \WP_Post $attachment_post Image Post.
-     * @param string   $size Image size, full by default.
-     *
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_image( $attachment_post, $size = 'full' ) {
-        $caption_tag = ! empty( $attachment_post->post_excerpt ) ? '<figcaption class="wp-element-caption">' . $attachment_post->post_excerpt . '</figcaption>' : '';
-        $image_alt   = get_post_meta( $attachment_post->ID, '_wp_attachment_image_alt', true );
+	/**
+	 * Generate a List Block item.
+	 *
+	 * @param \WP_Post $attachment_post Image Post.
+	 * @param string   $size Image size, full by default.
+	 *
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_image( $attachment_post, $size = 'full' ) {
+		$caption_tag = ! empty( $attachment_post->post_excerpt ) ? '<figcaption class="wp-element-caption">' . $attachment_post->post_excerpt . '</figcaption>' : '';
+		$image_alt   = get_post_meta( $attachment_post->ID, '_wp_attachment_image_alt', true );
 
-        $attrs = [
-            'sizeSlug' => $size,
-        ];
+		$attrs = [
+			'sizeSlug' => $size,
+		];
 
-        $content = '<figure class="wp-block-image size-' . $size . '"><img src="' . wp_get_attachment_url( $attachment_post->ID ) . '" alt="' . $image_alt . '"/>' . $caption_tag . '</figure>';
+		$content = '<figure class="wp-block-image size-' . $size . '"><img src="' . wp_get_attachment_url( $attachment_post->ID ) . '" alt="' . $image_alt . '"/>' . $caption_tag . '</figure>';
 
-        return [
+		return [
 			'blockName'    => 'core/image',
 			'attrs'        => $attrs,
 			'innerBlocks'  => [],
 			'innerHTML'    => $content,
 			'innerContent' => [ $content ],
 		];
-    }
+	}
 
-    /**
-     * Generate a Header Block.
-     *
-     * @param string $heading_content Paragraph content.
-     * @param string $heading_level Heading level (h1, h2, h3, h4, h5, h6), defaults to h2.
-     * @param string $anchor Paragraph anchor.
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_heading( $heading_content, $heading_level = 'h2', $anchor = '' ) {
-        $anchor_attribute = ! empty( $anchor ) ? ' id="' . $anchor . '"' : '';
-        $content          = "<$heading_level" . $anchor_attribute . '>' . $heading_content . "</$heading_level>";
-        return [
-            'blockName'    => 'core/heading',
+	/**
+	 * Generate a Header Block.
+	 *
+	 * @param string $heading_content Paragraph content.
+	 * @param string $heading_level Heading level (h1, h2, h3, h4, h5, h6), defaults to h2.
+	 * @param string $anchor Paragraph anchor.
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_heading( $heading_content, $heading_level = 'h2', $anchor = '' ) {
+		$anchor_attribute = ! empty( $anchor ) ? ' id="' . $anchor . '"' : '';
+		$content          = "<$heading_level" . $anchor_attribute . '>' . $heading_content . "</$heading_level>";
+		return [
+			'blockName'    => 'core/heading',
 			'attrs'        => [],
 			'innerBlocks'  => [],
 			'innerHTML'    => $content,
 			'innerContent' => [ $content ],
 		];
-    }
+	}
 
-    /**
-     * Generate a Paragraph Block.
-     *
-     * @param string $paragraph_content Paragraph content.
-     * @param string $anchor Paragraph anchor.
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_paragraph( $paragraph_content, $anchor = '' ) {
-        $anchor_attribute = ! empty( $anchor ) ? ' id="' . $anchor . '"' : '';
-        $content          = '<p' . $anchor_attribute . '>' . $paragraph_content . '</p>';
+	/**
+	 * Generate a Paragraph Block.
+	 *
+	 * @param string $paragraph_content Paragraph content.
+	 * @param string $anchor Paragraph anchor.
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_paragraph( $paragraph_content, $anchor = '' ) {
+		$anchor_attribute = ! empty( $anchor ) ? ' id="' . $anchor . '"' : '';
+		$content          = '<p' . $anchor_attribute . '>' . $paragraph_content . '</p>';
 
-        return [
-            'blockName'    => 'core/paragraph',
-            'attrs'        => [],
-            'innerBlocks'  => [],
-            'innerHTML'    => $content,
-            'innerContent' => [ $content ],
+		return [
+			'blockName'    => 'core/paragraph',
+			'attrs'        => [],
+			'innerBlocks'  => [],
+			'innerHTML'    => $content,
+			'innerContent' => [ $content ],
 		];
-    }
+	}
 
-    /**
-     * Generate a Quote Block.
-     *
-     * @param string $quote_content Quote content.
-     * @param string $cite_content Quote cite.
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_quote( $quote_content, $cite_content = '' ) {
-        $content = '<p>' . $quote_content . '</p>';
-        $cite    = ! empty( $cite_content ) ? "<cite>$cite_content</cite>" : '';
+	/**
+	 * Generate a Quote Block.
+	 *
+	 * @param string $quote_content Quote content.
+	 * @param string $cite_content Quote cite.
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_quote( $quote_content, $cite_content = '' ) {
+		$content = '<p>' . $quote_content . '</p>';
+		$cite    = ! empty( $cite_content ) ? "<cite>$cite_content</cite>" : '';
 
-        return [
-            'blockName'    => 'core/quote',
-            'attrs'        => [],
-            'innerBlocks'  => [
+		return [
+			'blockName'    => 'core/quote',
+			'attrs'        => [],
+			'innerBlocks'  => [
 				[
 					'blockName'    => 'core/paragraph',
 					'attrs'        => [],
@@ -308,139 +308,139 @@ class GutenbergBlockGenerator {
 					'innerHTML'    => $content,
 					'innerContent' => [ $content ],
 				],
-            ],
-            'innerHTML'    => '<blockquote class="wp-block-quote">' . $cite . '</blockquote>',
-            'innerContent' => [
+			],
+			'innerHTML'    => '<blockquote class="wp-block-quote">' . $cite . '</blockquote>',
+			'innerContent' => [
 				'<blockquote class="wp-block-quote">',
 				null,
 				$cite . '</blockquote>',
-            ],
+			],
 		];
-    }
+	}
 
-    /**
-     * Generate a HTML Block.
-     *
-     * @param string $html_content HTML content.
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_html( $html_content ) {
-        return [
-            'blockName'    => 'core/html',
-            'attrs'        => [],
-            'innerBlocks'  => [],
-            'innerHTML'    => $html_content,
-            'innerContent' => [ $html_content ],
+	/**
+	 * Generate a HTML Block.
+	 *
+	 * @param string $html_content HTML content.
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_html( $html_content ) {
+		return [
+			'blockName'    => 'core/html',
+			'attrs'        => [],
+			'innerBlocks'  => [],
+			'innerHTML'    => $html_content,
+			'innerContent' => [ $html_content ],
 		];
-    }
+	}
 
-    /**
-     * Generate a PDF Viewer Block (Gutenberg PDF Viewer Block plugin should be installed).
-     *
-     * @param int    $pdf_media_id PDF Media ID.
-     * @param string $pdf_url PDF URL if known.
-     * @param string $width PDF Block width, empty by default (which set it to 100%, plugin's default).
-     * @param string $height PDF Block height, empty by default (which set it to 700px, plugin's default).
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_pdf( $pdf_media_id, $pdf_url = '', $width = '', $height = '' ) {
-        $pdf_url = ! empty( $pdf_url ) ? $pdf_url : wp_get_attachment_url( $pdf_media_id );
-        $content = '<div class="wp-block-pdf-viewer-block-standard" style="text-align:left"><div class="uploaded-pdf"><a href="' . $pdf_url . '" data-width="' . $width . '" data-height="' . $height . '"></a></div></div>';
+	/**
+	 * Generate a PDF Viewer Block (Gutenberg PDF Viewer Block plugin should be installed).
+	 *
+	 * @param int    $pdf_media_id PDF Media ID.
+	 * @param string $pdf_url PDF URL if known.
+	 * @param string $width PDF Block width, empty by default (which set it to 100%, plugin's default).
+	 * @param string $height PDF Block height, empty by default (which set it to 700px, plugin's default).
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_pdf( $pdf_media_id, $pdf_url = '', $width = '', $height = '' ) {
+		$pdf_url = ! empty( $pdf_url ) ? $pdf_url : wp_get_attachment_url( $pdf_media_id );
+		$content = '<div class="wp-block-pdf-viewer-block-standard" style="text-align:left"><div class="uploaded-pdf"><a href="' . $pdf_url . '" data-width="' . $width . '" data-height="' . $height . '"></a></div></div>';
 
-        return [
-            'blockName'    => 'pdf-viewer-block/standard',
-            'attrs'        => [
+		return [
+			'blockName'    => 'pdf-viewer-block/standard',
+			'attrs'        => [
 				'mediaID' => $pdf_media_id,
-            ],
-            'innerBlocks'  => [],
-            'innerHTML'    => $content,
-            'innerContent' => [ $content ],
+			],
+			'innerBlocks'  => [],
+			'innerHTML'    => $content,
+			'innerContent' => [ $content ],
 		];
-    }
+	}
 
-    /**
-     * Generate a Featured Image Block.
-     *
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_featured_image() {
-        return [
-            'blockName'    => 'core/post-featured-image',
-            'attrs'        => [],
-            'innerBlocks'  => [],
-            'innerHTML'    => '',
-            'innerContent' => [],
+	/**
+	 * Generate a Featured Image Block.
+	 *
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_featured_image() {
+		return [
+			'blockName'    => 'core/post-featured-image',
+			'attrs'        => [],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
 		];
-    }
+	}
 
-    /**
-     * Generate a Site Logo Block.
-     *
-     * @param int $width Logo width (in pixels).
-     *
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_site_logo( $width = 0 ) {
-        $attrs = [];
-        if ( 0 !== $width ) {
-            $attrs['width'] = $width;
-        }
-        return [
-            'blockName'    => 'core/site-logo',
-            'attrs'        => $attrs,
-            'innerBlocks'  => [],
-            'innerHTML'    => '',
-            'innerContent' => [],
+	/**
+	 * Generate a Site Logo Block.
+	 *
+	 * @param int $width Logo width (in pixels).
+	 *
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_site_logo( $width = 0 ) {
+		$attrs = [];
+		if ( 0 !== $width ) {
+			$attrs['width'] = $width;
+		}
+		return [
+			'blockName'    => 'core/site-logo',
+			'attrs'        => $attrs,
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
 		];
-    }
+	}
 
-    /**
-     * Generate a Separator Block.
-     *
-     * @param string $style Separator style (is-style-default, is-style-dots, is-style-wide), empty is by default.
-     *
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_separator( $style = '' ) {
-        $attrs      = [];
-        $classnames = [ 'wp-block-separator', 'has-alpha-channel-opacity' ];
+	/**
+	 * Generate a Separator Block.
+	 *
+	 * @param string $style Separator style (is-style-default, is-style-dots, is-style-wide), empty is by default.
+	 *
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_separator( $style = '' ) {
+		$attrs      = [];
+		$classnames = [ 'wp-block-separator', 'has-alpha-channel-opacity' ];
 
-        if ( ! empty( $style ) ) {
-            $attrs['className'] = $style;
-            $classnames[]       = $style;
-        }
+		if ( ! empty( $style ) ) {
+			$attrs['className'] = $style;
+			$classnames[]       = $style;
+		}
 
-        $content = '<hr class="' . join( ' ', $classnames ) . '"/>';
+		$content = '<hr class="' . join( ' ', $classnames ) . '"/>';
 
-        return [
-            'blockName'    => 'core/separator',
-            'attrs'        => $attrs,
-            'innerBlocks'  => [],
-            'innerHTML'    => $content,
-            'innerContent' => [ $content ],
+		return [
+			'blockName'    => 'core/separator',
+			'attrs'        => $attrs,
+			'innerBlocks'  => [],
+			'innerHTML'    => $content,
+			'innerContent' => [ $content ],
 		];
-    }
+	}
 
-    /**
-     * Generate Newspack Author Profile Block.
-     *
-     * @param int     $author_id Author ID.
-     * @param boolean $show_email Show author email.
-     * @param boolean $show_avatar Show author avatar.
-     * @param boolean $show_newspack_job_title Show author job title.
-     * @param boolean $is_guest_author If the author is a guest author.
-     * @param boolean $show_bio Show author bio.
-     * @param boolean $show_social Show author bio.
-     * @param boolean $show_archive_link Show author link.
-     * @param boolean $show_newspack_employer Show author employer.
-     * @param boolean $show_newspack_phone_number Show author phone number.
-     * @param boolean $show_newspack_role Show author role.
-     * @return array
-     */
-    public function get_author_profile( $author_id, $show_email = false, $show_avatar = false, $show_newspack_job_title = false, $is_guest_author = false, $show_bio = false, $show_social = false, $show_archive_link = false, $show_newspack_employer = false, $show_newspack_phone_number = false, $show_newspack_role = false ) {
-        return [
-            'blockName'    => 'newspack-blocks/author-profile',
-            'attrs'        => [
+	/**
+	 * Generate Newspack Author Profile Block.
+	 *
+	 * @param int     $author_id Author ID.
+	 * @param boolean $show_email Show author email.
+	 * @param boolean $show_avatar Show author avatar.
+	 * @param boolean $show_newspack_job_title Show author job title.
+	 * @param boolean $is_guest_author If the author is a guest author.
+	 * @param boolean $show_bio Show author bio.
+	 * @param boolean $show_social Show author bio.
+	 * @param boolean $show_archive_link Show author link.
+	 * @param boolean $show_newspack_employer Show author employer.
+	 * @param boolean $show_newspack_phone_number Show author phone number.
+	 * @param boolean $show_newspack_role Show author role.
+	 * @return array
+	 */
+	public function get_author_profile( $author_id, $show_email = false, $show_avatar = false, $show_newspack_job_title = false, $is_guest_author = false, $show_bio = false, $show_social = false, $show_archive_link = false, $show_newspack_employer = false, $show_newspack_phone_number = false, $show_newspack_role = false ) {
+		return [
+			'blockName'    => 'newspack-blocks/author-profile',
+			'attrs'        => [
 				'authorId'                  => $author_id,
 				'isGuestAuthor'             => $is_guest_author,
 				'showBio'                   => $show_bio,
@@ -452,150 +452,150 @@ class GutenbergBlockGenerator {
 				'shownewspack_job_title'    => $show_newspack_job_title,
 				'shownewspack_employer'     => $show_newspack_employer,
 				'shownewspack_phone_number' => $show_newspack_phone_number,
-            ],
-            'innerBlocks'  => [],
-            'innerHTML'    => '',
-            'innerContent' => [],
+			],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
 		];
-    }
+	}
 
-    /**
-     * Generate a Columns Block.
-     *
-     * @param array  $columns Columns list.
-     * @param string $style Columns style (is-style-default, is-style-borders, is-style-first-col-to-second, is-style-first-col-to-third).
-     * @param string $is_stacked_on_mobile If the columns should be stacked on mobile, true by default.
-     *
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_columns( $columns, $style = '', $is_stacked_on_mobile = true ) {
-        $attrs      = [];
-        $classnames = [ 'wp-block-columns' ];
+	/**
+	 * Generate a Columns Block.
+	 *
+	 * @param array  $columns Columns list.
+	 * @param string $style Columns style (is-style-default, is-style-borders, is-style-first-col-to-second, is-style-first-col-to-third).
+	 * @param string $is_stacked_on_mobile If the columns should be stacked on mobile, true by default.
+	 *
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_columns( $columns, $style = '', $is_stacked_on_mobile = true ) {
+		$attrs      = [];
+		$classnames = [ 'wp-block-columns' ];
 
-        if ( ! $is_stacked_on_mobile ) {
-            $attrs['isStackedOnMobile'] = false;
-            $classnames[]               = 'is-not-stacked-on-mobile';
-        }
+		if ( ! $is_stacked_on_mobile ) {
+			$attrs['isStackedOnMobile'] = false;
+			$classnames[]               = 'is-not-stacked-on-mobile';
+		}
 
-        if ( ! empty( $style ) ) {
-            $attrs['className'] = $style;
-            $classnames[]       = $style;
-        }
+		if ( ! empty( $style ) ) {
+			$attrs['className'] = $style;
+			$classnames[]       = $style;
+		}
 
-        // Inner content.
+		// Inner content.
 		$inner_content = array_fill( 1, count( $columns ), null );
 		array_unshift( $inner_content, '<div class="wp-block-columns">' );
 		array_push( $inner_content, '</div>' );
 
-        return [
-            'blockName'    => 'core/columns',
-            'attrs'        => $attrs,
-            'innerBlocks'  => $columns,
-            'innerHTML'    => '<div class="' . join( ' ', $classnames ) . '"></div>',
-            'innerContent' => $inner_content,
+		return [
+			'blockName'    => 'core/columns',
+			'attrs'        => $attrs,
+			'innerBlocks'  => $columns,
+			'innerHTML'    => '<div class="' . join( ' ', $classnames ) . '"></div>',
+			'innerContent' => $inner_content,
 		];
-    }
+	}
 
-    /**
-     * Generate a Column Block.
-     *
-     * @param array  $blocks Blocks list.
-     * @param string $width Column width (e.g. 100px, 50%, 100em, 50rem, 50vw). If empty the columns sizes will be even.
-     *
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_column( $blocks, $width = '' ) {
-        $attrs  = [];
-        $styles = [];
+	/**
+	 * Generate a Column Block.
+	 *
+	 * @param array  $blocks Blocks list.
+	 * @param string $width Column width (e.g. 100px, 50%, 100em, 50rem, 50vw). If empty the columns sizes will be even.
+	 *
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_column( $blocks, $width = '' ) {
+		$attrs  = [];
+		$styles = [];
 
-        if ( ! empty( $width ) ) {
-            $attrs['width'] = $width;
-            $styles[]       = "flex-basis:$width";
-        }
+		if ( ! empty( $width ) ) {
+			$attrs['width'] = $width;
+			$styles[]       = "flex-basis:$width";
+		}
 
-        $styles_attribute = ! empty( $styles ) ? ' style="' . implode( ' ', $styles ) . '"' : '';
+		$styles_attribute = ! empty( $styles ) ? ' style="' . implode( ' ', $styles ) . '"' : '';
 
-        // Inner content.
+		// Inner content.
 		$inner_content = array_fill( 1, count( $blocks ), null );
 		array_unshift( $inner_content, '<div class="wp-block-column"' . $styles_attribute . '>' );
 		array_push( $inner_content, '</div>' );
 
-        return [
-            'blockName'    => 'core/column',
+		return [
+			'blockName'    => 'core/column',
 			'attrs'        => $attrs,
 			'innerBlocks'  => $blocks,
 			'innerHTML'    => '<div class="wp-block-column"' . $styles_attribute . '></div>',
 			'innerContent' => $inner_content,
-        ];
-    }
+		];
+	}
 
-    /**
-     * Generate a List Block.
-     *
-     * @param array   $elements List elements.
-     * @param boolean $ordered If the list is ordered. False by default.
-     *
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_list( $elements, $ordered = false ) {
-        $attrs = [];
+	/**
+	 * Generate a List Block.
+	 *
+	 * @param array   $elements List elements.
+	 * @param boolean $ordered If the list is ordered. False by default.
+	 *
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_list( $elements, $ordered = false ) {
+		$attrs = [];
 
-        if ( $ordered ) {
-            $attrs['ordered'] = true;
-        }
+		if ( $ordered ) {
+			$attrs['ordered'] = true;
+		}
 
-        // Inner content.
+		// Inner content.
 		$inner_content = array_fill( 1, count( $elements ), null );
 		array_unshift( $inner_content, '<ol>' );
 		array_push( $inner_content, '</ol>' );
 
-        return [
-            'blockName'    => 'core/list',
-            'attrs'        => $attrs,
-            'innerBlocks'  => array_map( [ $this, 'get_list_item' ], $elements ),
-            'innerHTML'    => '<ol></ol>',
-            'innerContent' => $inner_content,
-        ];
-    }
+		return [
+			'blockName'    => 'core/list',
+			'attrs'        => $attrs,
+			'innerBlocks'  => array_map( [ $this, 'get_list_item' ], $elements ),
+			'innerHTML'    => '<ol></ol>',
+			'innerContent' => $inner_content,
+		];
+	}
 
-    /**
-     * Generate a List Block item.
-     *
-     * @param string $content Item content.
-     *
-     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-     */
-    public function get_list_item( $content ) {
-        $item = '<li>' . $content . '</li>';
+	/**
+	 * Generate a List Block item.
+	 *
+	 * @param string $content Item content.
+	 *
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_list_item( $content ) {
+		$item = '<li>' . $content . '</li>';
 
-        return [
+		return [
 			'blockName'    => 'core/list-item',
 			'attrs'        => [],
 			'innerBlocks'  => [],
 			'innerHTML'    => $item,
 			'innerContent' => [ $item ],
 		];
-    }
+	}
 
-    /**
-     * Generate tile size based on its index.
-     *
-     * @param int      $index Tile size.
-     * @param string[] $tile_sizes_list Tile sizes list in percentage (e.g. [ '66.79014', '33.20986', '33.33333', '33.33333', '33.33333', '50.00000', '50.00000' ]).
-     * @return string
-     */
+	/**
+	 * Generate tile size based on its index.
+	 *
+	 * @param int      $index Tile size.
+	 * @param string[] $tile_sizes_list Tile sizes list in percentage (e.g. [ '66.79014', '33.20986', '33.33333', '33.33333', '33.33333', '50.00000', '50.00000' ]).
+	 * @return string
+	 */
 	private function get_tile_image_size_by_index( $index, $tile_sizes_list ) {
 		return $tile_sizes_list[ $index % count( $tile_sizes_list ) ];
-    }
+	}
 
-    /**
-     * Helper function used for getting the PHP array needed to generate a block.
-     * To be used the first time we're adding a new method to generate a block, to get the right array attributes.
-     *
-     * @param string $content content of one Gutenberg Block.
-     * @return string a JSON encoded array of the Gutenberg Block.
-     */
-    public function get_block_json_array_from_content( $content ) {
-        return json_encode( current( parse_blocks( $content ) ) ); // phpcs:disable WordPress.WP.AlternativeFunctions.json_encode_json_encode
-    }
+	/**
+	 * Helper function used for getting the PHP array needed to generate a block.
+	 * To be used the first time we're adding a new method to generate a block, to get the right array attributes.
+	 *
+	 * @param string $content content of one Gutenberg Block.
+	 * @return string a JSON encoded array of the Gutenberg Block.
+	 */
+	public function get_block_json_array_from_content( $content ) {
+		return json_encode( current( parse_blocks( $content ) ) ); // phpcs:disable WordPress.WP.AlternativeFunctions.json_encode_json_encode
+	}
 }

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -16,6 +16,7 @@
 namespace NewspackCustomContentMigrator\Logic;
 
 use \NewspackCustomContentMigrator\Utils\Logger;
+use WP_Post;
 
 /**
  * Class ContentDiffMigrator and main logic.
@@ -291,6 +292,27 @@ class GutenbergBlockGenerator {
 		return [
 			'blockName'    => 'core/image',
 			'attrs'        => $attrs,
+			'innerBlocks'  => [],
+			'innerHTML'    => $content,
+			'innerContent' => [ $content ],
+		];
+	}
+
+	/**
+	 * Get a video block.
+	 *
+	 * @param WP_Post $attachment_post
+	 *
+	 * @return array
+	 */
+	public function get_video( WP_Post $attachment_post ): array {
+		$video_url   = wp_get_attachment_url( $attachment_post->ID);
+		$content = <<<VIDEO
+<figure class="wp-block-video"><video controls src="$video_url"></video></figure>
+VIDEO;
+		return [
+			'blockName'    => 'core/video',
+			'attrs'        => [],
 			'innerBlocks'  => [],
 			'innerHTML'    => $content,
 			'innerContent' => [ $content ],
@@ -655,7 +677,7 @@ class GutenbergBlockGenerator {
 	 *
 	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
 	 */
-	public function get_group_constrained( $inner_blocks, $custom_classes = [] ) {
+	public function get_group_constrained( $inner_blocks, $custom_classes = [], $attrs = [] ) {
 
 		$class_append_custom = ! empty( $custom_classes ) ? implode( ' ', $custom_classes ) : '';
 
@@ -664,7 +686,6 @@ class GutenbergBlockGenerator {
 		$inner_content   = array_merge( $inner_content, array_fill( 1, count( $inner_blocks ), null ) );
 		$inner_content[] = '</div> ';
 
-		$attrs = [];
 		if ( ! empty( $custom_classes ) ) {
 			$attrs['className'] = implode( ' ', $custom_classes );
 		}
@@ -928,7 +949,7 @@ class GutenbergBlockGenerator {
 	}
 
 	/**
-	 * Generate a Newspack Homepage Articles Block.
+	 * Generate a Newspack Homepage Articles Block for categories.
 	 *
 	 * @param array $category_ids array of category IDs.
 	 * @param array $args args to pass to the block.
@@ -940,6 +961,34 @@ class GutenbergBlockGenerator {
 			return [];
 		}
 		$args['categories'] = $category_ids;
+
+		if ( empty( $args['postsToShow'] ) ) {
+			// Enforce a sane default if the value is not passed.
+			$args['postsToShow'] = 16;
+		}
+
+		return [
+			'blockName'    => 'newspack-blocks/homepage-articles',
+			'attrs'        => $args,
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+	}
+
+	/**
+	 * Generate a Newspack Homepage Articles Block with specific posts.
+	 *
+	 * @param array $category_ids array of post IDs.
+	 * @param array $args args to pass to the block.
+	 *
+	 * @return array
+	 */
+	public function get_homepage_articles_for_specific_posts( array $post_ids, array $args ): array {
+		if ( empty( $post_ids ) ) {
+			return [];
+		}
+		$args['specificPosts'] = $post_ids;
 
 		if ( empty( $args['postsToShow'] ) ) {
 			// Enforce a sane default if the value is not passed.

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -564,6 +564,7 @@ class GutenbergBlockGenerator {
 
 	/**
 	 * Generate a Group Block with the constrained layout.
+	 * Since Group block can have three different layouts with different markup and behavior, splitting these into separate methods.
 	 *
 	 * @param array $inner_blocks   Inner blocks.
 	 * @param array $custom_classes Custom classes to be added to the group block.

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -795,15 +795,23 @@ VIDEO;
 		return $this->get_core_embed( $src, $caption );
 	}
 
-	/**
-	 * Generate a Vimeo block -- uses core/embed.
-	 *
-	 * @param string $src     Vimeo src.
-	 * @param string $caption Optional.
-	 *
-	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
-	 */
-	public function get_twitter( $src, $caption = '' ) {
+	public function get_twitter( string $src, string $caption = '' ): array {
+		$class_names   = implode(
+			' ',
+			[
+				'wp-block-embed',
+				'is-type-rich',
+				'is-provider-twitter',
+				'wp-block-embed-twitter',
+				'nccm-twitter-embed',
+			]
+		);
+		$block_content = <<<HTML
+<figure class="$class_names"><div class="wp-block-embed__wrapper">
+$src
+</div></figure>
+HTML;
+
 		return [
 			'blockName'    => 'core/embed',
 			'attrs'        => [
@@ -811,12 +819,11 @@ VIDEO;
 				'type'             => 'rich',
 				'providerNameSlug' => 'twitter',
 				'responsive'       => true,
+				'className'        => $class_names
 			],
 			'innerBlocks'  => [],
-			'innerHTML'    => ' <figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper"> ' . $src . ' </div></figure> ',
-			'innerContent' => [
-				0 => ' <figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter"><div class="wp-block-embed__wrapper"> ' . $src . ' </div></figure> ',
-			],
+			'innerHTML'    => $block_content,
+			'innerContent' => [ $block_content ],
 		];
 	}
 

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -176,10 +176,11 @@ class GutenbergBlockGenerator {
     /**
      * Generate a Jetpack Slideshow Block.
      *
-     * @param int[]  $attachment_ids Attachments IDs to be used in the tiled gallery.
-     * @param int    $images_per_row Images per row.
-     * @param string $image_size Image size (thumbnail, medium, large, full), full by default.
-     * @param string $image_link_to Link images to `none`, `media`, or to `attachment`.
+     * @param int[]   $attachment_ids Attachments IDs to be used in the tiled gallery.
+     * @param int     $images_per_row Images per row.
+     * @param string  $image_size Image size (thumbnail, medium, large, full), full by default.
+     * @param string  $image_link_to Link images to `none`, `media`, or to `attachment`.
+     * @param boolean $crop_images To crop the gallery images or not.
      * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
      */
     public function get_gallery( $attachment_ids, $images_per_row = 3, $image_size = 'full', $image_link_to = 'none', $crop_images = false ) {

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -560,13 +560,42 @@ class GutenbergBlockGenerator {
 	}
 
 	/**
+	 * Generate a Genesis Accordion Block.
+	 *
+	 * WARNING: To use this block we need to install Genesis Blocks: https://wordpress.org/plugins/genesis-blocks/.
+	 *
+	 * @param string  $title Accordion title.
+	 * @param string  $body Accordion body content.
+	 * @param boolean $use_html_block If the content shoulb have a html block as parent, if not it defaults to paragraph.
+	 * @param boolean $open If the accordion is open by default, defaults to false.
+	 *
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_accordion( $title, $body, $use_html_block = false, $open = false ) {
+		$inner_block = $use_html_block ? $this->get_html( $body ) : $this->get_paragraph( $body );
+
+		$attrs = $open ? [ 'accordionOpen' => $open ] : [];
+		return [
+			'blockName'    => 'genesis-blocks/gb-accordion',
+			'attrs'        => $attrs,
+			'innerBlocks'  => [ $inner_block ],
+			'innerHTML'    => '<div class="wp-block-genesis-blocks-gb-accordion gb-block-accordion"><details><summary class="gb-accordion-title">' . $title . '</summary><div class="gb-accordion-text"></div></details></div>',
+			'innerContent' => [
+				'<div class="wp-block-genesis-blocks-gb-accordion gb-block-accordion"><details><summary class="gb-accordion-title">' . $title . '</summary><div class="gb-accordion-text">',
+				null,
+				'</div></details></div>',
+			],
+		];
+	}
+
+	/**
 	 * Generate a List Block item.
 	 *
 	 * @param string $content Item content.
 	 *
 	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
 	 */
-	public function get_list_item( $content ) {
+	private function get_list_item( $content ) {
 		$item = '<li>' . $content . '</li>';
 
 		return [

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -174,6 +174,409 @@ class GutenbergBlockGenerator {
     }
 
     /**
+     * Generate a Jetpack Slideshow Block.
+     *
+     * @param int[]  $attachment_ids Attachments IDs to be used in the tiled gallery.
+     * @param int    $images_per_row Images per row.
+     * @param string $image_size Image size (thumbnail, medium, large, full), full by default.
+     * @param string $image_link_to Link images to `none`, `media`, or to `attachment`.
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_gallery( $attachment_ids, $images_per_row = 3, $image_size = 'full', $image_link_to = 'none', $crop_images = false ) {
+        $attachment_posts = [];
+        $image_blocks     = [];
+		foreach ( $attachment_ids as $attachment_id ) {
+            $attachment_post = get_post( $attachment_id );
+            if ( ! $attachment_post ) {
+                $this->logger->log( 'gallery_migrator.log', sprintf( "Attachment %d doesn't exist!", $attachment_id ), Logger::WARNING );
+                continue;
+            }
+
+			$attachment_posts[] = $attachment_post;
+		}
+
+        foreach ( $attachment_posts as $attachment_post ) {
+            $image_blocks[] = $this->get_image( $attachment_post );
+        }
+
+        // Inner content.
+		$inner_content = array_fill( 1, count( $attachment_posts ), null );
+		array_unshift( $inner_content, '<figure class="wp-block-gallery has-nested-images columns-' . $images_per_row . '">' );
+		array_push( $inner_content, '</figure>' );
+
+        return [
+            'blockName'    => 'core/gallery',
+            'attrs'        => [
+				'columns'   => $images_per_row,
+				'imageCrop' => $crop_images,
+				'linkTo'    => $image_link_to,
+				'sizeSlug'  => $image_size,
+            ],
+            'innerBlocks'  => $image_blocks,
+            'innerHTML'    => '<figure class="wp-block-gallery has-nested-images columns-' . $images_per_row . '"></figure>',
+            'innerContent' => $inner_content,
+		];
+    }
+
+    /**
+     * Generate a List Block item.
+     *
+     * @param \WP_Post $attachment_post Image Post.
+     * @param string   $size Image size, full by default.
+     *
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_image( $attachment_post, $size = 'full' ) {
+        $caption_tag = ! empty( $attachment_post->post_excerpt ) ? '<figcaption class="wp-element-caption">' . $attachment_post->post_excerpt . '</figcaption>' : '';
+        $image_alt   = get_post_meta( $attachment_post->ID, '_wp_attachment_image_alt', true );
+
+        $attrs = [
+            'sizeSlug' => $size,
+        ];
+
+        $content = '<figure class="wp-block-image size-' . $size . '"><img src="' . wp_get_attachment_url( $attachment_post->ID ) . '" alt="' . $image_alt . '"/>' . $caption_tag . '</figure>';
+
+        return [
+			'blockName'    => 'core/image',
+			'attrs'        => $attrs,
+			'innerBlocks'  => [],
+			'innerHTML'    => $content,
+			'innerContent' => [ $content ],
+		];
+    }
+
+    /**
+     * Generate a Header Block.
+     *
+     * @param string $heading_content Paragraph content.
+     * @param string $heading_level Heading level (h1, h2, h3, h4, h5, h6), defaults to h2.
+     * @param string $anchor Paragraph anchor.
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_heading( $heading_content, $heading_level = 'h2', $anchor = '' ) {
+        $anchor_attribute = ! empty( $anchor ) ? ' id="' . $anchor . '"' : '';
+        $content          = "<$heading_level" . $anchor_attribute . '>' . $heading_content . "</$heading_level>";
+        return [
+            'blockName'    => 'core/heading',
+			'attrs'        => [],
+			'innerBlocks'  => [],
+			'innerHTML'    => $content,
+			'innerContent' => [ $content ],
+		];
+    }
+
+    /**
+     * Generate a Paragraph Block.
+     *
+     * @param string $paragraph_content Paragraph content.
+     * @param string $anchor Paragraph anchor.
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_paragraph( $paragraph_content, $anchor = '' ) {
+        $anchor_attribute = ! empty( $anchor ) ? ' id="' . $anchor . '"' : '';
+        $content          = '<p' . $anchor_attribute . '>' . $paragraph_content . '</p>';
+
+        return [
+            'blockName'    => 'core/paragraph',
+            'attrs'        => [],
+            'innerBlocks'  => [],
+            'innerHTML'    => $content,
+            'innerContent' => [ $content ],
+		];
+    }
+
+    /**
+     * Generate a Quote Block.
+     *
+     * @param string $quote_content Quote content.
+     * @param string $cite_content Quote cite.
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_quote( $quote_content, $cite_content = '' ) {
+        $content = '<p>' . $quote_content . '</p>';
+        $cite    = ! empty( $cite_content ) ? "<cite>$cite_content</cite>" : '';
+
+        return [
+            'blockName'    => 'core/quote',
+            'attrs'        => [],
+            'innerBlocks'  => [
+				[
+					'blockName'    => 'core/paragraph',
+					'attrs'        => [],
+					'innerBlocks'  => [],
+					'innerHTML'    => $content,
+					'innerContent' => [ $content ],
+				],
+            ],
+            'innerHTML'    => '<blockquote class="wp-block-quote">' . $cite . '</blockquote>',
+            'innerContent' => [
+				'<blockquote class="wp-block-quote">',
+				null,
+				$cite . '</blockquote>',
+            ],
+		];
+    }
+
+    /**
+     * Generate a HTML Block.
+     *
+     * @param string $html_content HTML content.
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_html( $html_content ) {
+        return [
+            'blockName'    => 'core/html',
+            'attrs'        => [],
+            'innerBlocks'  => [],
+            'innerHTML'    => $html_content,
+            'innerContent' => [ $html_content ],
+		];
+    }
+
+    /**
+     * Generate a PDF Viewer Block (Gutenberg PDF Viewer Block plugin should be installed).
+     *
+     * @param int    $pdf_media_id PDF Media ID.
+     * @param string $pdf_url PDF URL if known.
+     * @param string $width PDF Block width, empty by default (which set it to 100%, plugin's default).
+     * @param string $height PDF Block height, empty by default (which set it to 700px, plugin's default).
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_pdf( $pdf_media_id, $pdf_url = '', $width = '', $height = '' ) {
+        $pdf_url = ! empty( $pdf_url ) ? $pdf_url : wp_get_attachment_url( $pdf_media_id );
+        $content = '<div class="wp-block-pdf-viewer-block-standard" style="text-align:left"><div class="uploaded-pdf"><a href="' . $pdf_url . '" data-width="' . $width . '" data-height="' . $height . '"></a></div></div>';
+
+        return [
+            'blockName'    => 'pdf-viewer-block/standard',
+            'attrs'        => [
+				'mediaID' => $pdf_media_id,
+            ],
+            'innerBlocks'  => [],
+            'innerHTML'    => $content,
+            'innerContent' => [ $content ],
+		];
+    }
+
+    /**
+     * Generate a Featured Image Block.
+     *
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_featured_image() {
+        return [
+            'blockName'    => 'core/post-featured-image',
+            'attrs'        => [],
+            'innerBlocks'  => [],
+            'innerHTML'    => '',
+            'innerContent' => [],
+		];
+    }
+
+    /**
+     * Generate a Site Logo Block.
+     *
+     * @param int $width Logo width (in pixels).
+     *
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_site_logo( $width = 0 ) {
+        $attrs = [];
+        if ( 0 !== $width ) {
+            $attrs['width'] = $width;
+        }
+        return [
+            'blockName'    => 'core/site-logo',
+            'attrs'        => $attrs,
+            'innerBlocks'  => [],
+            'innerHTML'    => '',
+            'innerContent' => [],
+		];
+    }
+
+    /**
+     * Generate a Separator Block.
+     *
+     * @param string $style Separator style (is-style-default, is-style-dots, is-style-wide), empty is by default.
+     *
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_separator( $style = '' ) {
+        $attrs      = [];
+        $classnames = [ 'wp-block-separator', 'has-alpha-channel-opacity' ];
+
+        if ( ! empty( $style ) ) {
+            $attrs['className'] = $style;
+            $classnames[]       = $style;
+        }
+
+        $content = '<hr class="' . join( ' ', $classnames ) . '"/>';
+
+        return [
+            'blockName'    => 'core/separator',
+            'attrs'        => $attrs,
+            'innerBlocks'  => [],
+            'innerHTML'    => $content,
+            'innerContent' => [ $content ],
+		];
+    }
+
+    /**
+     * Generate Newspack Author Profile Block.
+     *
+     * @param int     $author_id Author ID.
+     * @param boolean $show_email Show author email.
+     * @param boolean $show_avatar Show author avatar.
+     * @param boolean $show_newspack_job_title Show author job title.
+     * @param boolean $is_guest_author If the author is a guest author.
+     * @param boolean $show_bio Show author bio.
+     * @param boolean $show_social Show author bio.
+     * @param boolean $show_archive_link Show author link.
+     * @param boolean $show_newspack_employer Show author employer.
+     * @param boolean $show_newspack_phone_number Show author phone number.
+     * @param boolean $show_newspack_role Show author role.
+     * @return array
+     */
+    public function get_author_profile( $author_id, $show_email = false, $show_avatar = false, $show_newspack_job_title = false, $is_guest_author = false, $show_bio = false, $show_social = false, $show_archive_link = false, $show_newspack_employer = false, $show_newspack_phone_number = false, $show_newspack_role = false ) {
+        return [
+            'blockName'    => 'newspack-blocks/author-profile',
+            'attrs'        => [
+				'authorId'                  => $author_id,
+				'isGuestAuthor'             => $is_guest_author,
+				'showBio'                   => $show_bio,
+				'showEmail'                 => $show_email,
+				'showAvatar'                => $show_avatar,
+				'showSocial'                => $show_social,
+				'showArchiveLink'           => $show_archive_link,
+				'shownewspack_role'         => $show_newspack_role,
+				'shownewspack_job_title'    => $show_newspack_job_title,
+				'shownewspack_employer'     => $show_newspack_employer,
+				'shownewspack_phone_number' => $show_newspack_phone_number,
+            ],
+            'innerBlocks'  => [],
+            'innerHTML'    => '',
+            'innerContent' => [],
+		];
+    }
+
+    /**
+     * Generate a Columns Block.
+     *
+     * @param array  $columns Columns list.
+     * @param string $style Columns style (is-style-default, is-style-borders, is-style-first-col-to-second, is-style-first-col-to-third).
+     * @param string $is_stacked_on_mobile If the columns should be stacked on mobile, true by default.
+     *
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_columns( $columns, $style = '', $is_stacked_on_mobile = true ) {
+        $attrs      = [];
+        $classnames = [ 'wp-block-columns' ];
+
+        if ( ! $is_stacked_on_mobile ) {
+            $attrs['isStackedOnMobile'] = false;
+            $classnames[]               = 'is-not-stacked-on-mobile';
+        }
+
+        if ( ! empty( $style ) ) {
+            $attrs['className'] = $style;
+            $classnames[]       = $style;
+        }
+
+        // Inner content.
+		$inner_content = array_fill( 1, count( $columns ), null );
+		array_unshift( $inner_content, '<div class="wp-block-columns">' );
+		array_push( $inner_content, '</div>' );
+
+        return [
+            'blockName'    => 'core/columns',
+            'attrs'        => $attrs,
+            'innerBlocks'  => $columns,
+            'innerHTML'    => '<div class="' . join( ' ', $classnames ) . '"></div>',
+            'innerContent' => $inner_content,
+		];
+    }
+
+    /**
+     * Generate a Column Block.
+     *
+     * @param array  $blocks Blocks list.
+     * @param string $width Column width (e.g. 100px, 50%, 100em, 50rem, 50vw). If empty the columns sizes will be even.
+     *
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_column( $blocks, $width = '' ) {
+        $attrs  = [];
+        $styles = [];
+
+        if ( ! empty( $width ) ) {
+            $attrs['width'] = $width;
+            $styles[]       = "flex-basis:$width";
+        }
+
+        $styles_attribute = ! empty( $styles ) ? ' style="' . implode( ' ', $styles ) . '"' : '';
+
+        // Inner content.
+		$inner_content = array_fill( 1, count( $blocks ), null );
+		array_unshift( $inner_content, '<div class="wp-block-column"' . $styles_attribute . '>' );
+		array_push( $inner_content, '</div>' );
+
+        return [
+            'blockName'    => 'core/column',
+			'attrs'        => $attrs,
+			'innerBlocks'  => $blocks,
+			'innerHTML'    => '<div class="wp-block-column"' . $styles_attribute . '></div>',
+			'innerContent' => $inner_content,
+        ];
+    }
+
+    /**
+     * Generate a List Block.
+     *
+     * @param array   $elements List elements.
+     * @param boolean $ordered If the list is ordered. False by default.
+     *
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_list( $elements, $ordered = false ) {
+        $attrs = [];
+
+        if ( $ordered ) {
+            $attrs['ordered'] = true;
+        }
+
+        // Inner content.
+		$inner_content = array_fill( 1, count( $elements ), null );
+		array_unshift( $inner_content, '<ol>' );
+		array_push( $inner_content, '</ol>' );
+
+        return [
+            'blockName'    => 'core/list',
+            'attrs'        => $attrs,
+            'innerBlocks'  => array_map( [ $this, 'get_list_item' ], $elements ),
+            'innerHTML'    => '<ol></ol>',
+            'innerContent' => $inner_content,
+        ];
+    }
+
+    /**
+     * Generate a List Block item.
+     *
+     * @param string $content Item content.
+     *
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_list_item( $content ) {
+        $item = '<li>' . $content . '</li>';
+
+        return [
+			'blockName'    => 'core/list-item',
+			'attrs'        => [],
+			'innerBlocks'  => [],
+			'innerHTML'    => $item,
+			'innerContent' => [ $item ],
+		];
+    }
+
+    /**
      * Generate tile size based on its index.
      *
      * @param int      $index Tile size.

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -16,7 +16,6 @@
 namespace NewspackCustomContentMigrator\Logic;
 
 use \NewspackCustomContentMigrator\Utils\Logger;
-use \WP_CLI;
 
 /**
  * Class ContentDiffMigrator and main logic.
@@ -25,6 +24,8 @@ use \WP_CLI;
  */
 class GutenbergBlockGenerator {
 	/**
+	 * Logger class.
+	 *
 	 * @var Logger.
 	 */
 	private $logger;

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -991,6 +991,9 @@ VIDEO;
 			return [];
 		}
 		$args['specificPosts'] = $post_ids;
+		if ( is_array( $args['className'] ?? false ) ) {
+			$args['className'] = implode( ' ', $args['className'] );
+		}
 
 		if ( empty( $args['postsToShow'] ) ) {
 			// Enforce a sane default if the value is not passed.

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -743,17 +743,44 @@ VIDEO;
 	/**
 	 * Generate a Youtube block -- uses core/embed.
 	 *
-	 * @param string $src     YT src.
-	 * @param string $caption Optional.
+	 * @param string $src     YT src or YT ID.
 	 *
 	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
 	 */
-	public function get_youtube( $src, $caption = '' ) {
-		// Remove GET params from $src, otherwise the embed might not work.
-		$src_parsed  = wp_parse_url( $src );
-		$src_cleaned = $src_parsed['scheme'] . '://' . $src_parsed['host'] . $src_parsed['path'];
+	public function get_youtube( $src ) {
+		// Check if the $src is a URL.
+		if ( filter_var( $src, FILTER_VALIDATE_URL ) ) {
+			return $this->youtube_block_from_src( $src );
+		}
 
-		return $this->get_core_embed( $src_cleaned, $caption );
+		// If the $src is not a URL, it's probably a YT ID.
+		return $this->youtube_block_from_src( 'https://www.youtube.com/watch?v=' . $src );
+	}
+
+	/**
+	 * Generate a Youtube block from a YouTube URL.
+	 *
+	 * @param string $youtube_video_url YT youtube_video_url.
+	 *
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	private function youtube_block_from_src( $youtube_video_url ) {
+		$inner_html = '<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+		' . $youtube_video_url . '
+		</div></figure>';
+		return [
+			'blockName'    => 'core/embed',
+			'attrs'        => [
+				'url'              => $youtube_video_url,
+				'type'             => 'video',
+				'providerNameSlug' => 'youtube',
+				'responsive'       => true,
+				'className'        => 'wp-embed-aspect-16-9 wp-has-aspect-ratio',
+			],
+			'innerBlocks'  => [],
+			'innerHTML'    => $inner_html,
+			'innerContent' => [ $inner_html ],
+		];
 	}
 
 	/**

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -563,6 +563,45 @@ class GutenbergBlockGenerator {
 	}
 
 	/**
+	 * Generate a Group Block with the constrained layout.
+	 *
+	 * @param array $inner_blocks   Inner blocks.
+	 * @param array $custom_classes Custom classes to be added to the group block.
+	 *
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_group_constrained( $inner_blocks, $custom_classes = [] ) {
+
+		$class_append_custom = ! empty( $custom_classes ) ? implode( ' ', $custom_classes ) : '';
+
+		$inner_content   = [];
+		$inner_content[] = ' <div class="wp-block-group' . ( ! empty( $class_append_custom ) ? ' ' . implode( ' ', $custom_classes ) : '' ) . '">';
+		$inner_content   = array_merge( $inner_content, array_fill( 1, count( $inner_blocks ), null ) );
+		$inner_content[] = '</div> ';
+
+		$attrs = [];
+		if ( ! empty( $custom_classes ) ) {
+			$attrs['className'] = implode( ' ', $custom_classes );
+		}
+		$attrs = array_merge(
+			$attrs,
+			[
+				'layout' => [
+					'type' => 'constrained',
+				],
+			]
+		);
+
+		return [
+			'blockName'    => 'core/group',
+			'attrs'        => $attrs,
+			'innerBlocks'  => $inner_blocks,
+			'innerHTML'    => ' <div class="wp-block-group' . ( ! empty( $class_append_custom ) ? ' ' . implode( ' ', $custom_classes ) : '' ) . '">  </div> ',
+			'innerContent' => $inner_content,
+		];
+	}
+
+	/**
 	 * Generate a List Block.
 	 *
 	 * @param array   $elements List elements.

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -366,24 +366,33 @@ class GutenbergBlockGenerator {
 	 * @param string $anchor Paragraph anchor.
 	 * @param string $text_color Paragraph text color (black, blue, green, red, yellow, gray, dark-gray, medium-gray, light-gray, white).
 	 * @param string $font_size Paragraph font size (small, normal, medium, large, huge).
+	 * @param array  $additional_css_classes Additional paragraph classes.
 	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
 	 */
-	public function get_paragraph( $paragraph_content, $anchor = '', $text_color = '', $font_size = '' ) {
-		$classes = [];
-		$attrs   = [];
+	public function get_paragraph( $paragraph_content, $anchor = '', $text_color = '', $font_size = '', array $additional_css_classes = [] ) {
+
+		// Paragraph can have both <p class=""> classes, and <!-- wp:paragraph {"className":""} --> className attributes (called "Additional CSS classes" in Gutenberg).
+		$paragraph_element_classes = [];
+		$attrs                     = [];
 		if ( ! empty( $text_color ) ) {
-			$classes[]         = 'has-' . $text_color . '-color has-text-color';
-			$attrs['fontSize'] = $text_color;
+			$paragraph_element_classes[] = 'has-' . $text_color . '-color has-text-color';
+			$attrs['fontSize']           = $text_color;
 		}
 		if ( ! empty( $font_size ) ) {
-			$classes[]         = 'has-' . $font_size . '-font-size';
-			$attrs['fontSize'] = $font_size;
+			$paragraph_element_classes[] = 'has-' . $font_size . '-font-size';
+			$attrs['fontSize']           = $font_size;
 		}
 
-		$class = ! empty( $classes ) ? ' class="' . implode( ' ', $classes ) . '"' : '';
+		// Add additional CSS classes to <p> and Block.
+		if ( ! empty( $additional_css_classes ) ) {
+			$paragraph_element_classes = array_merge( $paragraph_element_classes, $additional_css_classes );
+			$attrs['className']        = implode( ' ', $additional_css_classes );
+		}
+
+		$paragraph_element_class_string = ! empty( $paragraph_element_classes ) ? ' class="' . implode( ' ', $paragraph_element_classes ) . '"' : '';
 
 		$anchor_attribute = ! empty( $anchor ) ? ' id="' . $anchor . '"' : '';
-		$content          = '<p' . $anchor_attribute . $class . '>' . $paragraph_content . '</p>';
+		$content          = '<p' . $anchor_attribute . $paragraph_element_class_string . '>' . $paragraph_content . '</p>';
 
 		return [
 			'blockName'    => 'core/paragraph',

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Generator for Gutenberg Blocks content.
+ *
+ * To add a new method to this class that generates a Gutenberg Block, please follow these instructions:
+ *     - Create a draft post in Gutenberg and add the desired block.
+ *     - Copy the source HTML of your block (from the code editor) and pass it to the `get_block_json_array_from_content` method.
+ *     - Transform the JSON result to a PHP array using a tool like https://wtools.io/convert-json-to-php-array
+ *     - The newly created method should return this PHP array.
+ *     - Add method parameters as necessary to customize the resulting array.
+ *     - The idea is to use the output of your method as an input to the serialize_block(s) to get the HTML content of the block.
+ *
+ * @package GutenbergBlockGenerator
+ */
+
+namespace NewspackCustomContentMigrator\Logic;
+
+use \NewspackCustomContentMigrator\Utils\Logger;
+use \WP_CLI;
+
+/**
+ * Class ContentDiffMigrator and main logic.
+ *
+ * @package NewspackCustomContentMigrator\Logic
+ */
+class GutenbergBlockGenerator {
+    /**
+	 * @var Logger.
+	 */
+	private $logger;
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		$this->logger = new Logger();
+	}
+
+    /**
+     * Generate a Jetpack Tiled Gallery Block.
+     *
+     * @param int[]    $attachment_ids Attachments IDs to be used in the tiled gallery.
+     * @param string[] $tile_sizes_list List of tiles sizes in percentages (e.g. ['50', '50']).
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_jetpack_tiled_gallery( $attachment_ids, $tile_sizes_list = [ '66.79014', '33.20986', '33.33333', '33.33333', '33.33333', '50.00000', '50.00000' ] ) {
+        $gallery_content = '
+        <div class="wp-block-jetpack-tiled-gallery aligncenter is-style-rectangular">
+            <div class="tiled-gallery__gallery">
+                <div class="tiled-gallery__row">
+        ';
+
+        $tile_sizes                      = [];
+        $non_existing_attachment_indexes = [];
+
+		$gallery_content .= join(
+            ' ',
+            array_filter(
+                array_map(
+                    function( $index, $attachment_id ) use ( &$tile_sizes, &$non_existing_attachment_indexes, $tile_sizes_list ) {
+                        $attachment_url = wp_get_attachment_url( $attachment_id );
+
+                        if ( ! $attachment_url ) {
+                            $non_existing_attachment_indexes[] = $index;
+                            $this->logger->log( 'jetpack_tiled_gallery_migrator.log', sprintf( "Attachment %d doesn't exist!", $attachment_id ), Logger::WARNING );
+                            return null;
+                        }
+
+                        $tile_size    = $this->get_tile_image_size_by_index( $index, $tile_sizes_list );
+                        $tile_sizes[] = $tile_size;
+                        return '
+                            <div class="tiled-gallery__col" style="flex-basis: ' . $tile_size . '%">
+                            <figure class="tiled-gallery__item">
+                                <img
+                                        alt="' . get_the_title( $attachment_id ) . '"
+                                        data-id="' . $attachment_id . '"
+                                        data-link="' . $attachment_url . '"
+                                        data-url="' . $attachment_url . '"
+                                        src="' . $attachment_url . '"
+                                    data-amp-layout="responsive"
+                                />
+                            </figure>
+                            </div>';
+                    },
+                    array_keys( $attachment_ids ),
+                    $attachment_ids
+                )
+            )
+		);
+
+		$gallery_content .= '
+                </div>
+            </div>
+        </div>
+        ';
+
+        // delete unexisting attachments.
+        foreach ( $non_existing_attachment_indexes as $non_existing_attachment_index ) {
+            unset( $attachment_ids[ $non_existing_attachment_index ] );
+        }
+
+		return [
+			'blockName'    => 'jetpack/tiled-gallery',
+			'attrs'        => [
+				'columnWidths' => [], // It will be filled after fixing the block manually from the backend.
+				'ids'          => $attachment_ids,
+			],
+			'innerBlocks'  => [],
+			'innerHTML'    => $gallery_content,
+			'innerContent' => [ $gallery_content ],
+        ];
+    }
+
+    /**
+     * Generate a Jetpack Slideshow Block.
+     *
+     * @param int[]     $attachment_ids Attachments IDs to be used in the tiled gallery.
+     * @param string    $transition Slideshow transition (slide or fade).
+     * @param int|false $autoplay False de disable, on the delay in seconds.
+     * @param string    $image_size Image size (thumbnail, medium, large, full).
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_jetpack_slideshow( $attachment_ids, $transition = 'slide', $autoplay = false, $image_size = 'large' ) {
+        $data_autoplay = is_numeric( $autoplay ) ? 'data-autoplay="true" data-delay="' . $autoplay . '"' : '';
+        $data_effect   = 'data-effect="' . $transition . '"';
+
+        $attachment_posts = [];
+		foreach ( $attachment_ids as $attachment_id ) {
+            $attachment_post = get_post( $attachment_id );
+            if ( ! $attachment_post ) {
+                $this->logger->log( 'jetpack_slideshow_migrator.log', sprintf( "Attachment %d doesn't exist!", $attachment_id ), Logger::WARNING );
+                continue;
+            }
+
+			$attachment_posts[] = $attachment_post;
+		}
+
+        $slideshow_content = '
+            <div class="wp-block-jetpack-slideshow aligncenter" ' . $data_autoplay . ' ' . $data_effect . '>
+                <div class="wp-block-jetpack-slideshow_container swiper-container">
+                    <ul class="wp-block-jetpack-slideshow_swiper-wrapper swiper-wrapper">
+        ';
+
+        foreach ( $attachment_posts as $attachment_post ) {
+            $caption = ! empty( $attachment_post->post_excerpt ) ? $attachment_post->post_excerpt : $attachment_post->post_title;
+
+            $slideshow_content .= '<li class="wp-block-jetpack-slideshow_slide swiper-slide">
+            <figure>
+            <img alt="' . $attachment_post->post_title . '" class="wp-block-jetpack-slideshow_image wp-image-' . $attachment_post->ID . '" data-id="' . $attachment_post->ID . '" src="' . wp_get_attachment_url( $attachment_post->ID ) . '"/>
+            <figcaption class="wp-block-jetpack-slideshow_caption gallery-caption">' . $caption . '</figcaption>
+            </figure>
+            </li>';
+        }
+
+        $slideshow_content .= '</ul>
+                    <a class="wp-block-jetpack-slideshow_button-prev swiper-button-prev swiper-button-white" role="button"></a>
+                    <a class="wp-block-jetpack-slideshow_button-next swiper-button-next swiper-button-white" role="button"></a>
+                    <a aria-label="Pause Slideshow" class="wp-block-jetpack-slideshow_button-pause" role="button"></a>
+                    <div class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-white"></div>
+                </div>
+            </div>';
+        return [
+            'blockName'    => 'jetpack/slideshow',
+            'attrs'        => [
+                'ids'      => $attachment_ids,
+                'sizeSlug' => $image_size,
+                'effect'   => $transition,
+                'autoplay' => $autoplay,
+            ],
+            'innerBlocks'  => [],
+            'innerHTML'    => $slideshow_content,
+            'innerContent' => [ $slideshow_content ],
+        ];
+    }
+
+    /**
+     * Generate tile size based on its index.
+     *
+     * @param int      $index Tile size.
+     * @param string[] $tile_sizes_list Tile sizes list in percentage (e.g. [ '66.79014', '33.20986', '33.33333', '33.33333', '33.33333', '50.00000', '50.00000' ]).
+     * @return string
+     */
+	private function get_tile_image_size_by_index( $index, $tile_sizes_list ) {
+		return $tile_sizes_list[ $index % count( $tile_sizes_list ) ];
+    }
+
+    /**
+     * Helper function used for getting the PHP array needed to generate a block.
+     * To be used the first time we're adding a new method to generate a block, to get the right array attributes.
+     *
+     * @param string $content content of one Gutenberg Block.
+     * @return string a JSON encoded array of the Gutenberg Block.
+     */
+    public function get_block_json_array_from_content( $content ) {
+        return json_encode( current( parse_blocks( $content ) ) ); // phpcs:disable WordPress.WP.AlternativeFunctions.json_encode_json_encode
+    }
+}

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -15,7 +15,7 @@
 
 namespace NewspackCustomContentMigrator\Logic;
 
-use \NewspackCustomContentMigrator\Utils\Logger;
+use NewspackCustomContentMigrator\Utils\Logger;
 use WP_Post;
 
 /**
@@ -71,7 +71,7 @@ class GutenbergBlockGenerator {
 			' ',
 			array_filter(
 				array_map(
-					function( $index, $attachment_id ) use ( &$tile_sizes, &$non_existing_attachment_indexes, $tile_sizes_list ) {
+					function ( $index, $attachment_id ) use ( &$tile_sizes, &$non_existing_attachment_indexes, $tile_sizes_list ) {
 						$attachment_url = wp_get_attachment_url( $attachment_id );
 
 						if ( ! $attachment_url ) {
@@ -336,11 +336,11 @@ VIDEO;
 		$title          = empty( $title ) ? $attachment_post->post_title : $title;
 
 		$attrs = [
-			'id'             => $attachment_post->ID,
-			'href'           => $attachment_url,
-			'displayPreview' => true,
-			'previewHeight'  => $height,
-			'showDownloadButton'   => $show_download_button,
+			'id'                 => $attachment_post->ID,
+			'href'               => $attachment_url,
+			'displayPreview'     => true,
+			'previewHeight'      => $height,
+			'showDownloadButton' => $show_download_button,
 		];
 
 		$download_button = $show_download_button ? '<a href="' . $attachment_url . '" class="wp-block-file__button wp-element-button" download aria-describedby="wp-block-file--media-' . $uuid . '">Download</a>' : '';
@@ -766,6 +766,9 @@ VIDEO;
 	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
 	 */
 	private function youtube_block_from_src( $youtube_video_url ) {
+		// Clean the URL from query params as they break the block.
+		$youtube_video_url = strtok( $youtube_video_url, '?' );
+
 		$inner_html = '<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
 		' . $youtube_video_url . '
 		</div></figure>';
@@ -820,7 +823,7 @@ HTML;
 				'type'             => 'rich',
 				'providerNameSlug' => 'twitter',
 				'responsive'       => true,
-				'className'        => $class_names
+				'className'        => $class_names,
 			],
 			'innerBlocks'  => [],
 			'innerHTML'    => $block_content,
@@ -1043,5 +1046,4 @@ HTML;
 			'innerContent' => [],
 		];
 	}
-
 }

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -248,13 +248,14 @@ class GutenbergBlockGenerator {
 	 *
 	 * @param \WP_Post $attachment_post        Image Post.
 	 * @param string   $size                   Image size, full by default.
-	 * @param bool     $link_to_attachment_url Whether to link to the attachment URL or not.
-	 * @param string   $classname              Media HTML class.
-	 * @param string   $align                  Image alignment (left, right).
+	 * @param ?bool    $link_to_attachment_url Whether to link to the attachment URL or not. Defaults to true.
+	 * @param ?string  $classname              Media HTML class.
+	 * @param ?string  $align                  Image alignment (left, right).
+	 * @param ?string  $custom_link            If provided, will set custom link. Overrides $link_to_attachment_url.
 	 *
 	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
 	 */
-	public function get_image( $attachment_post, $size = 'full', $link_to_attachment_url = true, $classname = null, $align = null ) {
+	public function get_image( $attachment_post, $size = 'full', $link_to_attachment_url = true, $classname = null, $align = null, $custom_link = null ) {
 		// Validate size.
 		if ( ! in_array( $size, [ 'thumbnail', 'medium', 'large', 'full' ] ) ) {
 			$size = 'full';
@@ -273,8 +274,14 @@ class GutenbergBlockGenerator {
 		// Add <a> link to attachment URL.
 		$a_opening_tag = '';
 		$a_closing_tag = '';
-		if ( $link_to_attachment_url ) {
-			$a_opening_tag = sprintf( '<a href="%s">', $image_url );
+		if ( $custom_link || $link_to_attachment_url ) {
+			if ( $custom_link ) {
+				$link = $custom_link;
+			} elseif ( $link_to_attachment_url ) {
+				$link = $image_url;
+			}
+
+			$a_opening_tag = sprintf( '<a href="%s">', $link );
 			$a_closing_tag = '</a>';
 		}
 

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -917,4 +917,33 @@ class GutenbergBlockGenerator {
 	public function get_block_json_array_from_content( $content ) {
 		return json_encode( current( parse_blocks( $content ) ) ); // phpcs:disable WordPress.WP.AlternativeFunctions.json_encode_json_encode
 	}
+
+	/**
+	 * Generate a Newspack Homepage Articles Block.
+	 *
+	 * @param array $category_ids array of category IDs.
+	 * @param array $args args to pass to the block.
+	 *
+	 * @return array
+	 */
+	public function get_homepage_articles_for_category( array $category_ids, array $args ): array {
+		if ( empty( $category_ids ) ) {
+			return [];
+		}
+		$args['categories'] = $category_ids;
+
+		if ( empty( $args['postsToShow'] ) ) {
+			// Enforce a sane default if the value is not passed.
+			$args['postsToShow'] = 16;
+		}
+
+		return [
+			'blockName'    => 'newspack-blocks/homepage-articles',
+			'attrs'        => $args,
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+	}
+
 }

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -32,7 +32,7 @@ class GutenbergBlockGenerator {
 	/**
 	 * Constructor.
 	 */
-	private function __construct() {
+	public function __construct() {
 		$this->logger = new Logger();
 	}
 

--- a/tests/AttachmentUnitTestTrait.php
+++ b/tests/AttachmentUnitTestTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Newspack\MigrationTools\Tests;
+
+use Newspack\MigrationTools\Logic\AttachmentHelper;
+use WP_Error;
+
+trait AttachmentUnitTestTrait {
+
+	/**
+	 * @var array Attachment IDs to clean up on tearDown().
+	 */
+	private array $attachment_ids = [];
+
+	public string $dummy_image = 'https://dummyimage.com/600x400.jpg/000/fff&text=Iz+test';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function tearDown(): void { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		$this->clean_up_attachments();
+		parent::tearDown();
+	}
+
+	/**
+	 * This just wraps AttachmentHelper::import_attachment_for_post() and keeps track of the attachment IDs so we can delete them on tearDown().
+	 *
+	 * @param int    $post_id The post ID to attach the image to.
+	 * @param string $path The path to the image.
+	 * @param string $alt_text The (optional) alt text for the image.
+	 * @param array  $attachment_args Additional (optional) arguments for wp_insert_attachment().
+	 * @param string $desired_filename The (optional) desired filename for the attachment.
+	 *
+	 * @return int|WP_Error
+	 */
+	public function wrap_import_attachments_for_post( int $post_id, string $path, string $alt_text = '', array $attachment_args = [], string $desired_filename = '' ): int|WP_Error {
+		$attachment_id          = AttachmentHelper::import_attachment_for_post( $post_id, $path, $alt_text, $attachment_args, $desired_filename );
+		$this->attachment_ids[] = $attachment_id;
+		return $attachment_id;
+	}
+
+	/**
+	 * Delete the files created during the test.
+	 *
+	 * @return void
+	 */
+	public function clean_up_attachments(): void {
+		foreach ( $this->attachment_ids as $attachment_id ) {
+			wp_delete_attachment( $attachment_id, true );
+		}
+	}
+}

--- a/tests/Logic/GutenbergBlockGeneratorTest.php
+++ b/tests/Logic/GutenbergBlockGeneratorTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Newspack\MigrationTools\Tests\Logic;
+
+use DOMDocument;
+use DOMXPath;
+use Newspack\MigrationTools\Logic\AttachmentHelper;
+use Newspack\MigrationTools\Logic\GutenbergBlockGenerator;
+use Newspack\MigrationTools\Tests\AttachmentUnitTestTrait;
+use WP_UnitTestCase;
+
+class GutenbergBlockGeneratorTest extends WP_UnitTestCase {
+
+	use AttachmentUnitTestTrait;
+
+	private GutenbergBlockGenerator $block_generator;
+	private int $category_id;
+	private int $test_post_1_id;
+
+	protected function setUp(): void {
+		parent::setUp();
+		add_filter( 'newspack_migration_tools_log_clilog_disable', '__return_true' );
+		$this->block_generator = new GutenbergBlockGenerator();
+		$this->category_id     = self::factory()->category->create( [ 'name' => 'My Little Category' ] );
+		$this->test_post_1_id  = self::factory()->post->create(
+			[
+				'post_title'   => 'Test Post 1',
+				'post_content' => 'This is the content for Test Post 1.',
+			] 
+		);
+	}
+
+	private function get_dom( string $html ): DOMDocument {
+		$dom = new DOMDocument();
+		// Suppress errors to handle invalid HTML (common with HTML snippets)
+		libxml_use_internal_errors( true );
+		$dom->loadHtml( $html );
+		// Clear any potential parsing errors
+		libxml_clear_errors();
+
+		return $dom;
+	}
+
+	private function assert_xpath_node_exists( string $html, string $xpath_expression ): void {
+		$dom   = $this->get_dom( $html );
+		$xpath = new DOMXPath( $dom );
+		$this->assertNotEmpty( $xpath->query( $xpath_expression ), sprintf( 'XPath expression "%s" not found in: "%s"', $xpath_expression, $html ) );
+	}
+
+	public function test_get_core_embed() {
+		$rickroll_url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+		$block        = $this->block_generator->get_core_embed( $rickroll_url );
+		$html         = serialize_block( $block );
+		$this->assertStringStartsWith( '<!-- wp:embed', $html );
+		$this->assert_xpath_node_exists( $html, '//figure/div[contains(text(), "' . $rickroll_url . '")]' );
+	}
+
+	public function test_get_heading() {
+		$heading_text = 'Iz heading';
+
+		// Test default heading.
+		$block = $this->block_generator->get_heading( $heading_text );
+		$html  = serialize_block( $block );
+		$this->assertStringStartsWith( '<!-- wp:heading', $html );
+		$this->assert_xpath_node_exists( $html, '//h2[contains(text(), "' . $heading_text . '")]' );
+
+		// Test h5 with an anchor.
+		$block = $this->block_generator->get_heading( $heading_text, 'h5', 'fancy-link' );
+		$html  = serialize_block( $block );
+		$this->assert_xpath_node_exists( $html, '//h5[contains(text(), "' . $heading_text . '")]' );
+		$this->assert_xpath_node_exists( $html, '//h5[@id="fancy-link"]' );
+	}
+
+	public function test_get_homepage_articles_for_specific_posts() {
+		$block = $this->block_generator->get_homepage_articles_for_specific_posts( [ $this->test_post_1_id ], [ 'className' => [ 'one', 'two' ] ] );
+		$this->assertStringContainsString( 'one two', $block['attrs']['className'] );
+
+		$block = $this->block_generator->get_homepage_articles_for_specific_posts( [ $this->test_post_1_id ], [ 'className' => 'one two' ] );
+		$this->assertStringContainsString( 'one two', $block['attrs']['className'] );
+	}
+
+	public function test_get_homepage_articles_for_category() {
+		// Category exists.
+		$block = $this->block_generator->get_homepage_articles_for_category( [ $this->category_id ], [] );
+		$this->assertEquals( $block['attrs']['categories'], [ $this->category_id ] );
+
+		// No posts in category - should return empty block.
+		$block = $this->block_generator->get_homepage_articles_for_category( [], [] );
+		$this->assertEmpty( $block );
+
+		// Categor(ies) does not exist - should throw an exception.
+		$this->expectException( \Exception::class );
+		$this->block_generator->get_homepage_articles_for_category( [ 999999, 1929283 ], [] );
+	}
+
+
+	public function test_get_gallery() {
+		$attachment_id          = AttachmentHelper::import_attachment_for_post(
+			$this->test_post_1_id,
+			$this->dummy_image
+		);
+		$this->attachment_ids[] = $attachment_id;
+		$block                  = $this->block_generator->get_gallery( [ $attachment_id ] );
+		$this->assertEquals( 'core/image', $block['innerBlocks'][0]['blockName'] );
+	}
+
+
+	public function test_get_file_pdf() {
+		$attachment_id          = AttachmentHelper::import_attachment_for_post(
+			$this->test_post_1_id,
+			'tests/fixtures/test.pdf'
+		);
+		$this->attachment_ids[] = $attachment_id;
+		$no_download_link_block = $this->block_generator->get_file_pdf( get_post( $attachment_id ), 'My PDF', false );
+		$this->assertEquals( 'core/file', $no_download_link_block['blockName'] );
+		$this->assertStringNotContainsString( 'download', $no_download_link_block['innerHTML'] );
+
+		$with_download_link_block = $this->block_generator->get_file_pdf( get_post( $attachment_id ) );
+		$this->assertStringContainsString( 'download', $with_download_link_block['innerHTML'] );
+	}
+}

--- a/tests/Logic/TestAttachmentHelper.php
+++ b/tests/Logic/TestAttachmentHelper.php
@@ -3,15 +3,14 @@
 namespace Newspack\MigrationTools\Tests\Logic;
 
 use Newspack\MigrationTools\Logic\AttachmentHelper;
+use Newspack\MigrationTools\Tests\AttachmentUnitTestTrait;
 use WP_UnitTestCase;
 
 class TestAttachmentHelper extends WP_UnitTestCase {
 
+	use AttachmentUnitTestTrait;
+
 	private int $post_id;
-
-	private array $attachment_ids = [];
-
-	private $dummy_image = 'https://dummyimage.com/600x400.jpg/000/fff&text=Iz+test';
 
 	/**
 	 * {@inheritDoc}
@@ -19,16 +18,7 @@ class TestAttachmentHelper extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		$this->post_id = self::factory()->post->create();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function tearDown(): void {
-		foreach ( $this->attachment_ids as $attachment_id ) {
-			wp_delete_attachment( $attachment_id, true );
-		}
-		parent::tearDown();
+		add_filter( 'newspack_migration_tools_log_clilog_disable', '__return_true' );
 	}
 
 	/**
@@ -38,7 +28,7 @@ class TestAttachmentHelper extends WP_UnitTestCase {
 	 */
 	public function test_get_attachment_id_by_filename(): void {
 		$desired_file_name = uniqid() . '.jpeg';
-		$attachment_id     = AttachmentHelper::import_attachment_for_post(
+		$attachment_id     = $this->wrap_import_attachments_for_post(
 			self::factory()->post->create(),
 			$this->dummy_image,
 			'Test image',
@@ -63,7 +53,7 @@ class TestAttachmentHelper extends WP_UnitTestCase {
 		$post_excerpt = 'Some text about the image.';
 		$post_content = 'Some more lengthy text about the image.';
 
-		$attachment_id = AttachmentHelper::import_attachment_for_post(
+		$attachment_id = $this->wrap_import_attachments_for_post(
 			$this->post_id,
 			$this->dummy_image,
 			'Test image',
@@ -93,7 +83,7 @@ class TestAttachmentHelper extends WP_UnitTestCase {
 
 		$desired_file_name = uniqid() . '.jpeg';
 
-		$attachment_id          = AttachmentHelper::import_attachment_for_post(
+		$attachment_id          = $this->wrap_import_attachments_for_post(
 			$this->post_id,
 			$this->dummy_image,
 			'Named test image',


### PR DESCRIPTION
This moves `src/Logic/GutenbergBlockGenerator.php` from NCCM to here. 

There are a ton of commits because I moved over the file history over as well.

I added some tests for select blocks.