### PR TITLE
Make cli log format more configurable

### DIFF
--- a/src/NMT.php
+++ b/src/NMT.php
@@ -27,7 +27,7 @@ class NMT {
 	 * Private on purpose
 	 */
 	private function __construct() {
-		$this->log_level = Level::fromName( LogLevel::DEBUG );
+		$this->log_level = Level::fromName( LogLevel::INFO );
 
 		if ( defined( 'NMT_LOG_LEVEL' ) && in_array( NMT_LOG_LEVEL, array_map( fn( $value ) => $value->name, Level::cases() ) ) ) {
 			$this->log_level = Level::fromName( NMT_LOG_LEVEL );

--- a/src/Util/Log/CliLog.php
+++ b/src/Util/Log/CliLog.php
@@ -4,6 +4,7 @@ namespace Newspack\MigrationTools\Util\Log;
 
 use Bramus\Monolog\Formatter\ColoredLineFormatter;
 use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
@@ -39,7 +40,15 @@ class CliLog {
 		} else {
 			$handler = new StreamHandler( 'php://stdout', NMT::get_log_level() );
 			if ( null === $formatter ) {
-				$formatter = new ColoredLineFormatter( null, null, 'Y-m-d H:i:s', true, true );
+				$format      = ( defined( 'NMT_CLI_LOG_FORMAT' ) ?? false ) ? NMT_CLI_LOG_FORMAT : LineFormatter::SIMPLE_FORMAT;
+				$date_format = ( defined( 'NMT_CLI_LOG_DATE_FORMAT' ) ?? false ) ? NMT_CLI_LOG_DATE_FORMAT : 'Y-m-d H:i:s';
+				$formatter   = new ColoredLineFormatter(
+					null,
+					apply_filters( 'nmt_cli_log_format', $format ),
+					apply_filters( 'nmt_cli_log_date_format', $date_format ),
+					true,
+					true
+				);
 			}
 			$handler->setFormatter( $formatter );
 			$logger->pushHandler( $handler );

--- a/src/Util/Log/CliLog.php
+++ b/src/Util/Log/CliLog.php
@@ -40,9 +40,15 @@ class CliLog {
 		} else {
 			$handler = new StreamHandler( 'php://stdout', NMT::get_log_level() );
 			if ( null === $formatter ) {
-				$format      = ( defined( 'NMT_CLI_LOG_FORMAT' ) ?? false ) ? NMT_CLI_LOG_FORMAT : LineFormatter::SIMPLE_FORMAT;
-				$date_format = ( defined( 'NMT_CLI_LOG_DATE_FORMAT' ) ?? false ) ? NMT_CLI_LOG_DATE_FORMAT : 'Y-m-d H:i:s';
-				$formatter   = new ColoredLineFormatter(
+				$format      = apply_filters( 'nmt_cli_log_format', LineFormatter::SIMPLE_FORMAT );
+				$date_format = apply_filters( 'nmt_cli_log_date_format', 'Y-m-d H:i:s' );
+				if ( defined( 'NMT_CLI_LOG_FORMAT' ) ) {
+					$format = NMT_CLI_LOG_FORMAT;
+				}
+				if ( defined( 'NMT_CLI_LOG_DATE_FORMAT' ) ) {
+					$date_format = NMT_CLI_LOG_DATE_FORMAT;
+				}
+				$formatter = new ColoredLineFormatter(
 					null,
 					apply_filters( 'nmt_cli_log_format', $format ),
 					apply_filters( 'nmt_cli_log_date_format', $date_format ),


### PR DESCRIPTION
This adds filters and constants for the format and date format of the CliLogger. 

## How to test
Try adding this in wp-config:
```
define( 'NMT_CLI_LOG_DATE_FORMAT', 'H:i:s' );
define( 'NMT_CLI_LOG_FORMAT', "[%datetime%] %level_name%: %message% %context% %extra%\n" );
```
Now do something that logs and check the timestamp matches above and that the logger name is not there. 

Try implementing filters that format different from above and check that is applied: `nmt_cli_log_format` and `nmt_cli_log_date_format`