### PR TITLE
Fix composer dev vs. non-dev and debug backtrace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require": {
         "php": ">=8.1",
         "monolog/monolog": "^3.7",
-        "bramus/monolog-colored-line-formatter": "^3.1"
+        "bramus/monolog-colored-line-formatter": "^3.1",
+        "halaxa/json-machine": "^1.1"
     },
     "require-dev": {
         "ext-libxml": "*",
@@ -25,8 +26,7 @@
         "phpcompatibility/phpcompatibility-wp": "*",
         "phpunit/phpunit": "^9.6",
         "yoast/phpunit-polyfills": "^2.0",
-        "php-coveralls/php-coveralls": "^2.7",
-        "halaxa/json-machine": "^1.1"
+        "php-coveralls/php-coveralls": "^2.7"
     },
     "scripts": {
         "phpcs": "./vendor/bin/phpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c77e8cb4789463bbe1c1f4dd2ce0b63a",
+    "content-hash": "6ab268fd639214ed0121cf1980a463f3",
     "packages": [
         {
             "name": "bramus/ansi-php",
@@ -101,6 +101,65 @@
                 }
             ],
             "time": "2023-08-18T13:44:29+00:00"
+        },
+        {
+            "name": "halaxa/json-machine",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/halaxa/json-machine.git",
+                "reference": "5147f38f74d7ab3e27733e3f3bdabbd2fd28e3fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/halaxa/json-machine/zipball/5147f38f74d7ab3e27733e3f3bdabbd2fd28e3fa",
+                "reference": "5147f38f74d7ab3e27733e3f3bdabbd2fd28e3fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": "7.0 - 8.3"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.0"
+            },
+            "suggest": {
+                "ext-json": "To run JSON Machine out of the box without custom decoders.",
+                "guzzlehttp/guzzle": "To run example with GuzzleHttp"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "JsonMachine\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/autoloader.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Filip Halaxa",
+                    "email": "filip@halaxa.cz"
+                }
+            ],
+            "description": "Efficient, easy-to-use and fast JSON pull parser",
+            "support": {
+                "issues": "https://github.com/halaxa/json-machine/issues",
+                "source": "https://github.com/halaxa/json-machine/tree/1.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://ko-fi.com/G2G57KTE4",
+                    "type": "other"
+                }
+            ],
+            "time": "2023-11-28T21:12:40+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -781,65 +840,6 @@
                 }
             ],
             "time": "2024-07-18T11:15:46+00:00"
-        },
-        {
-            "name": "halaxa/json-machine",
-            "version": "1.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/halaxa/json-machine.git",
-                "reference": "5147f38f74d7ab3e27733e3f3bdabbd2fd28e3fa"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/halaxa/json-machine/zipball/5147f38f74d7ab3e27733e3f3bdabbd2fd28e3fa",
-                "reference": "5147f38f74d7ab3e27733e3f3bdabbd2fd28e3fa",
-                "shasum": ""
-            },
-            "require": {
-                "php": "7.0 - 8.3"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "friendsofphp/php-cs-fixer": "^3.0",
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^8.0"
-            },
-            "suggest": {
-                "ext-json": "To run JSON Machine out of the box without custom decoders.",
-                "guzzlehttp/guzzle": "To run example with GuzzleHttp"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "JsonMachine\\": "src/"
-                },
-                "exclude-from-classmap": [
-                    "src/autoloader.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Filip Halaxa",
-                    "email": "filip@halaxa.cz"
-                }
-            ],
-            "description": "Efficient, easy-to-use and fast JSON pull parser",
-            "support": {
-                "issues": "https://github.com/halaxa/json-machine/issues",
-                "source": "https://github.com/halaxa/json-machine/tree/1.1.4"
-            },
-            "funding": [
-                {
-                    "url": "https://ko-fi.com/G2G57KTE4",
-                    "type": "other"
-                }
-            ],
-            "time": "2023-11-28T21:12:40+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/src/NMT.php
+++ b/src/NMT.php
@@ -80,12 +80,10 @@ class NMT {
 	public static function exit_with_message( string $message, array $loggers = [] ): void {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- we are about to shut down, so this is not a performance ding.
 		$backtrace = debug_backtrace();
-		if ( ! empty( $backtrace[1] ) ) {
-			for ( $i = 1; $i < 5; $i++ ) { // Closures do not have files, so try to find the first file in the backtrace (but cap at 5).
-				if ( ! empty( $backtrace[ $i ]['file'] ) ) {
-					$message .= ' --> ' . $backtrace[ $i ]['file'] . ':' . $backtrace[ $i ]['line'] ?? '';
-					break;
-				}
+		for ( $i = 0; $i < 5; $i++ ) { // Closures do not have files, so try to find the first file in the backtrace (but cap at 5).
+			if ( ! empty( $backtrace[ $i ]['file'] ) ) {
+				$message .= ' --> ' . $backtrace[ $i ]['file'] . ':' . $backtrace[ $i ]['line'] ?? '';
+				break;
 			}
 		}
 


### PR DESCRIPTION
Small fix I'm going to sneak under the review-radar.

* It moves `halaxa/json-machine` from require-dev to require
* It fixes the code that points to the line that throws an error to accommodate some cases where we pointed to the wrong file and line.