### PR TITLE
fix: use of `strtok` was stripping url of youtube video code.

### DIFF
--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -779,7 +779,16 @@ VIDEO;
 	 */
 	private function youtube_block_from_src( $youtube_video_url ) {
 		// Clean the URL from query params as they break the block.
-		$youtube_video_url = strtok( $youtube_video_url, '?' );
+		$parsed_url        = wp_parse_url( $youtube_video_url );
+		$youtube_video_url = $parsed_url['scheme'] . '://' . $parsed_url['host'] . $parsed_url['path'];
+
+		if ( ! empty( $parsed_url['query'] ) ) {
+			$query_params = wp_parse_args( $parsed_url['query'] );
+
+			if ( array_key_exists( 'v', $query_params ) ) {
+				$youtube_video_url .= '?v=' . $query_params['v'];
+			}
+		}
 
 		$inner_html = '<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
 		' . $youtube_video_url . '

--- a/tests/Logic/GutenbergBlockGeneratorTest.php
+++ b/tests/Logic/GutenbergBlockGeneratorTest.php
@@ -118,4 +118,49 @@ class GutenbergBlockGeneratorTest extends WP_UnitTestCase {
 		$with_download_link_block = $this->block_generator->get_file_pdf( get_post( $attachment_id ) );
 		$this->assertStringContainsString( 'download', $with_download_link_block['innerHTML'] );
 	}
+
+	public function youtube_url_data_provider() {
+		return [
+			'with_v_param'                       => [
+				'url' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+			],
+			'with_v_param_and_additional_params' => [
+				'url' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ&param=value&another_param=should-be-removed',
+			],
+			'with_embed_version'                 => [
+				'url' => 'https://www.youtube.com/embed/N5HbZd9aqR4',
+			],
+			'with_youtube_code_only'             => [
+				'url' => 'N5HbZd9aqR4',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider youtube_url_data_provider
+	 * @return void
+	 */
+	public function test_get_youtube( $url ) {
+		$internal_url = $url;
+		if ( filter_var( $url, FILTER_VALIDATE_URL ) ) {
+			$parsed_url = wp_parse_url( $url );
+
+			$internal_url = $parsed_url['scheme'] . '://' . $parsed_url['host'] . $parsed_url['path'];
+
+			if ( ! empty( $parsed_url['query'] ) ) {
+				$query_params = wp_parse_args( $parsed_url['query'] );
+
+				if ( array_key_exists( 'v', $query_params ) ) {
+					$internal_url .= '?v=' . $query_params['v'];
+				}
+			}
+		} else {
+			$internal_url = 'https://www.youtube.com/watch?v=' . $url;
+		}
+
+		$youtube_block = $this->block_generator->get_youtube( $url );
+		$this->assertEquals( 'core/embed', $youtube_block['blockName'] );
+		$this->assertEquals( $internal_url, $youtube_block['attrs']['url'] );
+		$this->assertStringContainsString( $internal_url, $youtube_block['innerHTML'] );
+	}
 }


### PR DESCRIPTION
This led to blank blocks with no definitive URL. Just `https://www.youtube.com/watch`.

To test this:

1. new up the Gutenberg generator class: `$g = new \Newspack\MigrationTools\Logic\GutenbergBlockGenerator();`
2. Run this: `$g->get_youtube('N5HbZd9aqR4');`
3. Notice that the URL is not correctly generated.
4. Checkout this branch.
5. Repeat steps 1 & 2.
6. This time, notice that the URL is correctly set: `https://www.youtube.com/watch?v=N5HbZd9aqR4`