### PR TITLE
feat(GutenbergBlockGenerator): add details block

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,39 +1,39 @@
 name: Run Unit Tests
 
-on: [ pull_request ]
+on: [pull_request]
 
 jobs:
-  unit-tests:
-    runs-on: ubuntu-latest
+    unit-tests:
+        runs-on: ubuntu-22.04
 
-    env:
-      DB_DATABASE: wordpress_test
-      DB_USER: root
-      DB_PASSWORD: root
+        env:
+            DB_DATABASE: wordpress_test
+            DB_USER: root
+            DB_PASSWORD: root
 
-    steps:
-      - name: Set up MySQL
-        run: |
-          sudo /etc/init.d/mysql start
-          mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}
+        steps:
+            - name: Set up MySQL
+              run: |
+                  sudo /etc/init.d/mysql start
+                  mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}
 
-      - name: Checkout code
-        uses: actions/checkout@v2
+            - name: Checkout code
+              uses: actions/checkout@v2
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.1'
-          extensions: mbstring, mysqli
-          ini-values: |
-            memory_limit=2G
-          coverage: none
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: "8.1"
+                  extensions: mbstring, mysqli
+                  ini-values: |
+                      memory_limit=2G
+                  coverage: none
 
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest --no-interaction
+            - name: Install dependencies
+              run: composer install --prefer-dist --no-progress --no-suggest --no-interaction
 
-      - name: Download WordPress for unit tests
-        run: bash bin/install-wp-tests.sh ${{ env.DB_DATABASE }} ${{ env.DB_USER }} ${{ env.DB_USER }} 127.0.0.1:3306 latest true
+            - name: Download WordPress for unit tests
+              run: bash bin/install-wp-tests.sh ${{ env.DB_DATABASE }} ${{ env.DB_USER }} ${{ env.DB_USER }} 127.0.0.1:3306 latest true
 
-      - name: Run phpunit
-        run: composer run phpunit
+            - name: Run phpunit
+              run: composer run phpunit

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -933,8 +933,8 @@ HTML;
 	 * Generate a Newspack Iframe block.
 	 *
 	 * @param string $src    URL.
-	 * @param int $width Width.
-	 * @param int $height Height.
+	 * @param int    $width Width.
+	 * @param int    $height Height.
 	 *
 	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
 	 */
@@ -1120,6 +1120,37 @@ HTML;
 			'innerBlocks'  => [],
 			'innerHTML'    => '',
 			'innerContent' => [],
+		];
+	}
+
+	/**
+	 * Generate a Details Block.
+	 *
+	 * @param string $summary      The summary/title text for the details block.
+	 * @param array  $blocks       Inner blocks to be displayed in the details content.
+	 * @param bool   $show_content Whether the details should be open by default.
+	 *
+	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+	 */
+	public function get_details( $summary, array $blocks, bool $show_content = false ): array {
+		$attrs = [];
+		if ( $show_content ) {
+			$attrs['show_content'] = true;
+		}
+
+		$open_attr = $show_content ? ' open' : '';
+
+		// Inner content
+		$inner_content = array_fill( 1, count( $blocks ), null );
+		array_unshift( $inner_content, '<details class="wp-block-details"' . $open_attr . '><summary>' . $summary . '</summary>' );
+		array_push( $inner_content, '</details>' );
+
+		return [
+			'blockName'    => 'core/details',
+			'attrs'        => $attrs,
+			'innerBlocks'  => $blocks,
+			'innerHTML'    => '<details class="wp-block-details"' . $open_attr . '><summary>' . $summary . '</summary></details>',
+			'innerContent' => $inner_content,
 		];
 	}
 }


### PR DESCRIPTION
Adds [Details Block](https://wordpress.org/documentation/article/details-block/) generator.

It can be used like the below:

Check the [test file](https://github.com/Automattic/newspack-migration-tools/compare/feat/add-gutenberg-details-block?expand=1#diff-dc318c0766ec8c595b8b3ae7e2d8bbb356ec60b3159f9d2d14e55f9d9c555decR194-R217) to see how to use it.