### PR TITLE
Refactor shortcode functionality from NCCM to NMT. Reusable command to replace shortcodes.

### DIFF
--- a/newspack-migration-tools.php
+++ b/newspack-migration-tools.php
@@ -2,7 +2,7 @@
 /**
  * Newspack Migration Tools.
  *
- * Version: 0.1.2
+ * Version: 0.1.3
  *
  * This is a library to be included by plugins. See README.md for more information.
  *

--- a/src/Command/General/ContentFixerMigrator.php
+++ b/src/Command/General/ContentFixerMigrator.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace NewspackCustomContentMigrator\Command\General;
+
+use \NewspackCustomContentMigrator\Command\InterfaceCommand;
+use \NewspackCustomContentMigrator\Logic\Posts as PostsLogic;
+use \WP_CLI;
+
+/**
+ * Custom migration scripts for Posts' content.
+ */
+class ContentFixerMigrator implements InterfaceCommand {
+	const POST_CONTENT_SHORTCODES_MIGRATION_LOG = 'POST_CONTENT_SHORTCODES_MIGRATION.log';
+
+    /**
+	 * @var PostsLogic.
+	 */
+	private $posts_logic = null;
+
+	/**
+	 * @var null|InterfaceCommand Instance.
+	 */
+	private static $instance = null;
+
+    /**
+	 * Constructor.
+	 */
+	private function __construct() {
+		$this->posts_logic = new PostsLogic();
+	}
+
+	/**
+	 * Singleton get_instance().
+	 *
+	 * @return InterfaceCommand|null
+	 */
+	public static function get_instance() {
+		$class = get_called_class();
+		if ( null === self::$instance ) {
+			self::$instance = new $class();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * See InterfaceCommand::register_commands.
+	 */
+	public function register_commands() {
+		WP_CLI::add_command(
+			'newspack-content-migrator remove-first-image-from-post-body',
+			array( $this, 'remove_first_image_from_post_body' ),
+			array(
+				'shortdesc' => 'Remove the first image from the post body, usefull to normalize the posts content in case some contains the featured image in their body and others not.',
+				'synopsis'  => array(),
+			)
+		);
+
+        WP_CLI::add_command(
+			'newspack-content-migrator remove-shortcodes-from-post-body',
+			array( $this, 'remove_shortcodes_from_post_body' ),
+			array(
+				'shortdesc' => 'Remove shortcodes from post body.',
+				'synopsis'  => array(
+					array(
+						'type'        => 'flag',
+						'name'        => 'dry-run',
+						'description' => 'Do a dry run simulation and don\'t actually edit the posts content.',
+						'optional'    => true,
+						'repeating'   => false,
+					),
+					array(
+						'type'        => 'assoc',
+						'name'        => 'shortcodes',
+						'description' => 'List of shortcodes to delete from all the posts content separated by a comma (e.g. shortcode1,shortcode2)',
+						'optional'    => false,
+						'repeating'   => false,
+					),
+					array(
+						'type'        => 'assoc',
+						'name'        => 'post_ids',
+						'description' => 'IDs of posts and pages to remove shortcodes from their content separated by a comma (e.g. 123,456)',
+						'optional'    => true,
+						'repeating'   => false,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Callable for `newspack-content-migrator remove-first-image-from-post-body`.
+	 */
+	public function remove_first_image_from_post_body() {
+		WP_CLI::confirm( "This will remove the first image from the post body if it's on a shortcode format ([caption ...]<img src=...>[/caption]), do you want to continue?" );
+
+		$this->posts_logic->throttled_posts_loop(
+			array(
+				'post_type'   => 'post',
+				'post_status' => array( 'publish' ),
+			),
+			function( $post ) {
+				global $wpdb;
+
+				if ( substr( $post->post_content, 0, strlen( '[caption' ) ) === '[caption' ) {
+					$start_with_images[] = $post->ID;
+
+					$pattern = get_shortcode_regex();
+					if ( preg_match_all( '/' . $pattern . '/s', $post->post_content, $matches ) && array_key_exists( 2, $matches ) && in_array( 'caption', $matches[2] ) ) {
+						$index = 0;
+						$count = 0;
+						// Remove the first image shortcode from the content.
+						foreach ( $matches[2] as $match ) {
+							if ( 'caption' === $match ) {
+								// Found our first image.
+								$index = $count;
+								break; // We've done enough.
+							}
+							$count++;
+						};
+						// Remove first gallery from content.
+						$content = str_replace( $matches[0][ $index ], '', $post->post_content );
+
+						if ( $content !== $post->post_content ) {
+							// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+							$wpdb->update(
+								$wpdb->prefix . 'posts',
+								array( 'post_content' => $content ),
+								array( 'ID' => $post->ID )
+							);
+
+							WP_CLI::line( sprintf( 'Updated post: %d', $post->ID ) );
+						}
+					}
+				}
+			}
+		);
+	}
+
+    /**
+	 * Callable for `newspack-content-migrator remove-shortcodes-from-post-body`.
+	 */
+	public function remove_shortcodes_from_post_body( $args, $assoc_args ) {
+		$shortcodes = isset( $assoc_args['shortcodes'] ) ? explode( ',', $assoc_args['shortcodes'] ) : null;
+		$post_ids   = isset( $assoc_args['post_ids'] ) ? explode( ',', $assoc_args['post_ids'] ) : null;
+		$dry_run    = isset( $assoc_args['dry-run'] ) ? true : false;
+
+		if ( is_null( $shortcodes ) || empty( $shortcodes ) ) {
+			WP_CLI::error( 'Invalid shortcodes list.' );
+		}
+
+		if ( $dry_run ) {
+			WP_CLI::warning( 'Dry mode, no changes are going to affect the database' );
+		} else {
+			WP_CLI::confirm( 'This will remove all the shortcodes with their content from all the posts content, do you want to continue?' );
+		}
+
+		$this->posts_logic->throttled_posts_loop(
+			array(
+				'post_type'   => array( 'post', 'page' ),
+				'post_status' => array( 'publish' ),
+				'post__in'    => $post_ids,
+			),
+			function( $post ) use ( $shortcodes, $dry_run ) {
+				$post_content_blocks = array();
+
+				foreach ( parse_blocks( $post->post_content ) as $content_block ) {
+					// remove shortcodes from Core shortcode, Core HTML, Paragraph, and Classic blocks.
+					if (
+						'core/shortcode' === $content_block['blockName']
+						|| 'core/html' === $content_block['blockName']
+						|| ( 'core/paragraph' === $content_block['blockName'] )
+						|| ( ! $content_block['blockName'] )
+					) {
+						$pattern = get_shortcode_regex( $shortcodes );
+
+						if ( preg_match_all( '/' . $pattern . '/s', $content_block['innerHTML'], $matches )
+							&& array_key_exists( 2, $matches )
+						) {
+							$content_without_shortcodes = $this->strip_shortcodes( $shortcodes, $content_block['innerHTML'] );
+							// remove resulting empty paragraphs if any.
+							$cleaned_content = trim( preg_replace( '/<p[^>]*><\\/p[^>]*>/', '', $content_without_shortcodes ) );
+
+							if ( empty( $cleaned_content ) ) {
+								$content_block = null;
+								continue;
+							}
+
+							$content_block['innerHTML']    = $cleaned_content;
+							$content_block['innerContent'] = array_map(
+								function( $inner_content ) use ( $shortcodes ) {
+									return $this->strip_shortcodes( $shortcodes, $inner_content );
+								},
+								$content_block['innerContent']
+							);
+						}
+					}
+
+					$post_content_blocks[] = $content_block;
+				}
+
+				$post_content_without_shortcodes = serialize_blocks( $post_content_blocks );
+
+				if ( $post_content_without_shortcodes !== $post->post_content ) {
+					if ( ! $dry_run ) {
+						$update = wp_update_post(
+							array(
+								'ID'           => $post->ID,
+								'post_content' => $post_content_without_shortcodes,
+							)
+						);
+
+						if ( is_wp_error( $update ) ) {
+							$this->log( self::POST_CONTENT_SHORTCODES_MIGRATION_LOG, sprintf( 'Failed to update post %d because %s', $post->ID, $update->get_error_message() ) );
+						} else {
+							$this->log( self::POST_CONTENT_SHORTCODES_MIGRATION_LOG, sprintf( 'Post %d cleaned from shortcodes.', $post->ID ) );
+						}
+					} else {
+						WP_CLI::line( sprintf( 'Post %d cleaned from shortcodes.', $post->ID ) );
+						WP_CLI::line( $post_content_without_shortcodes );
+					}
+				}
+			}
+		);
+	}
+
+    /**
+	 * Strip shortcodes from content.
+	 *
+	 * @param string[] $shortcodes Shortcodes to strip.
+	 * @param string   $text Content to strip the shortcodes from.
+	 * @return string
+	 */
+	private function strip_shortcodes( $shortcodes, $text ) {
+		if ( ! ( empty( $shortcodes ) || ! is_array( $shortcodes ) ) ) {
+			$tagregexp = join( '|', array_map( 'preg_quote', $shortcodes ) );
+			$regex     = '\[(\[?)';
+			$regex    .= "($tagregexp)";
+			$regex    .= '\b([^\]\/]*(?:\/(?!\])[^\]\/]*)*?)(?:(\/)\]|\](?:([^\[]*+(?:\[(?!\/\2\])[^\[]*+)*+)\[\/\2\])?)(\]?)';
+
+			$text = preg_replace( "/$regex/s", '', $text );
+		}
+
+		return $text;
+	}
+
+    /**
+     * Simple file logging.
+     *
+     * @param string  $file    File name or path.
+     * @param string  $message Log message.
+     * @param boolean $to_cli Display the logged message in CLI.
+     */
+	private function log( $file, $message, $to_cli = true ) {
+		$message .= "\n";
+		if ( $to_cli ) {
+			WP_CLI::line( $message );
+		}
+		file_put_contents( $file, $message, FILE_APPEND );
+	}
+}

--- a/src/Command/General/ContentFixerMigrator.php
+++ b/src/Command/General/ContentFixerMigrator.php
@@ -2,25 +2,24 @@
 
 namespace NewspackCustomContentMigrator\Command\General;
 
-use \NewspackCustomContentMigrator\Command\InterfaceCommand;
+use Newspack\MigrationTools\Command\WpCliCommandTrait;
+use NewspackCustomContentMigrator\Command\RegisterCommandInterface;
 use \NewspackCustomContentMigrator\Logic\Posts as PostsLogic;
 use \WP_CLI;
 
 /**
  * Custom migration scripts for Posts' content.
  */
-class ContentFixerMigrator implements InterfaceCommand {
+class ContentFixerMigrator implements RegisterCommandInterface {
+
+	use WpCliCommandTrait;
+
 	const POST_CONTENT_SHORTCODES_MIGRATION_LOG = 'POST_CONTENT_SHORTCODES_MIGRATION.log';
 
 	/**
 	 * @var PostsLogic.
 	 */
-	private $posts_logic = null;
-
-	/**
-	 * @var null|InterfaceCommand Instance.
-	 */
-	private static $instance = null;
+	private $posts_logic;
 
 	/**
 	 * Constructor.
@@ -30,26 +29,12 @@ class ContentFixerMigrator implements InterfaceCommand {
 	}
 
 	/**
-	 * Singleton get_instance().
-	 *
-	 * @return InterfaceCommand|null
+	 * {@inheritDoc}
 	 */
-	public static function get_instance() {
-		$class = get_called_class();
-		if ( null === self::$instance ) {
-			self::$instance = new $class();
-		}
-
-		return self::$instance;
-	}
-
-	/**
-	 * See InterfaceCommand::register_commands.
-	 */
-	public function register_commands() {
+	public static function register_commands(): void {
 		WP_CLI::add_command(
 			'newspack-content-migrator remove-first-image-from-post-body',
-			array( $this, 'remove_first_image_from_post_body' ),
+			self::get_command_closure( 'remove_first_image_from_post_body' ),
 			array(
 				'shortdesc' => 'Remove the first image from the post body, usefull to normalize the posts content in case some contains the featured image in their body and others not.',
 				'synopsis'  => array(),
@@ -58,7 +43,7 @@ class ContentFixerMigrator implements InterfaceCommand {
 
 		WP_CLI::add_command(
 			'newspack-content-migrator remove-shortcodes-from-post-body',
-			array( $this, 'remove_shortcodes_from_post_body' ),
+			self::get_command_closure( 'remove_shortcodes_from_post_body' ),
 			array(
 				'shortdesc' => 'Remove shortcodes from post body.',
 				'synopsis'  => array(
@@ -91,7 +76,7 @@ class ContentFixerMigrator implements InterfaceCommand {
 	/**
 	 * Callable for `newspack-content-migrator remove-first-image-from-post-body`.
 	 */
-	public function remove_first_image_from_post_body() {
+	public function remove_first_image_from_post_body( array $pos_args, array $assoc_args ) {
 		WP_CLI::confirm( "This will remove the first image from the post body if it's on a shortcode format ([caption ...]<img src=...>[/caption]), do you want to continue?" );
 
 		$this->posts_logic->throttled_posts_loop(

--- a/src/Command/General/ContentFixerMigrator.php
+++ b/src/Command/General/ContentFixerMigrator.php
@@ -12,7 +12,7 @@ use \WP_CLI;
 class ContentFixerMigrator implements InterfaceCommand {
 	const POST_CONTENT_SHORTCODES_MIGRATION_LOG = 'POST_CONTENT_SHORTCODES_MIGRATION.log';
 
-    /**
+	/**
 	 * @var PostsLogic.
 	 */
 	private $posts_logic = null;
@@ -22,7 +22,7 @@ class ContentFixerMigrator implements InterfaceCommand {
 	 */
 	private static $instance = null;
 
-    /**
+	/**
 	 * Constructor.
 	 */
 	private function __construct() {
@@ -56,7 +56,7 @@ class ContentFixerMigrator implements InterfaceCommand {
 			)
 		);
 
-        WP_CLI::add_command(
+		WP_CLI::add_command(
 			'newspack-content-migrator remove-shortcodes-from-post-body',
 			array( $this, 'remove_shortcodes_from_post_body' ),
 			array(
@@ -137,7 +137,7 @@ class ContentFixerMigrator implements InterfaceCommand {
 		);
 	}
 
-    /**
+	/**
 	 * Callable for `newspack-content-migrator remove-shortcodes-from-post-body`.
 	 */
 	public function remove_shortcodes_from_post_body( $args, $assoc_args ) {
@@ -224,7 +224,7 @@ class ContentFixerMigrator implements InterfaceCommand {
 		);
 	}
 
-    /**
+	/**
 	 * Strip shortcodes from content.
 	 *
 	 * @param string[] $shortcodes Shortcodes to strip.
@@ -244,13 +244,13 @@ class ContentFixerMigrator implements InterfaceCommand {
 		return $text;
 	}
 
-    /**
-     * Simple file logging.
-     *
-     * @param string  $file    File name or path.
-     * @param string  $message Log message.
-     * @param boolean $to_cli Display the logged message in CLI.
-     */
+	/**
+	 * Simple file logging.
+	 *
+	 * @param string  $file    File name or path.
+	 * @param string  $message Log message.
+	 * @param boolean $to_cli Display the logged message in CLI.
+	 */
 	private function log( $file, $message, $to_cli = true ) {
 		$message .= "\n";
 		if ( $to_cli ) {

--- a/src/Command/General/ContentFixerMigrator.php
+++ b/src/Command/General/ContentFixerMigrator.php
@@ -3,9 +3,9 @@
 namespace NewspackCustomContentMigrator\Command\General;
 
 use Newspack\MigrationTools\Command\WpCliCommandTrait;
+use Newspack\MigrationTools\Logic\Posts as PostsLogic;
 use NewspackCustomContentMigrator\Command\RegisterCommandInterface;
-use \NewspackCustomContentMigrator\Logic\Posts as PostsLogic;
-use \WP_CLI;
+use WP_CLI;
 
 /**
  * Custom migration scripts for Posts' content.

--- a/src/Command/ShortcodeReplacementInterface.php
+++ b/src/Command/ShortcodeReplacementInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Newspack\MigrationTools\Command;
+
+/**
+ * Used by the ShortcodesMigrator, `replace-shortcodes-in-post-body` command's `replace-callback` argument.
+ * Create a class method by implementing this interface which will take a shortcode name and a post_id where
+ * the shortcode is located, and return a replacement for that shortcode.
+ */
+interface ShortcodeReplacementInterface {
+	/**
+	 * Callback which generates a replacement for a shortcode.
+	 *
+	 * @param string $shortcode_name Shortcode name.
+	 * @param int    $post_id        Post ID where the shortcode is being replaced. Use this if needed for more context,
+	 *                               e.g. if you wish to get the post author, title, or anything that might be required
+	 *                               to generate the replacement.
+	 * @return string HTML replacement for the shortcode.
+	 */
+	public function replace_shortcode( string $shortcode_name, int $post_id ): string;
+}

--- a/src/Command/ShortcodeReplacementInterface.php
+++ b/src/Command/ShortcodeReplacementInterface.php
@@ -4,18 +4,18 @@ namespace Newspack\MigrationTools\Command;
 
 /**
  * Used by the ShortcodesMigrator, `replace-shortcodes-in-post-body` command's `replace-callback` argument.
- * Create a class method by implementing this interface which will take a shortcode name and a post_id where
- * the shortcode is located, and return a replacement for that shortcode.
+ * Create a class method by implementing this interface which will take a shortcode string and the post ID where
+ * this shortcode is located, and return a replacement for the shortcode.
  */
 interface ShortcodeReplacementInterface {
 	/**
-	 * Callback which generates a replacement for a shortcode.
+	 * Return a replacement for a shortcode.
 	 *
-	 * @param string $shortcode_name Shortcode name.
-	 * @param int    $post_id        Post ID where the shortcode is being replaced. Use this if needed for more context,
-	 *                               e.g. if you wish to get the post author, title, or anything that might be required
-	 *                               to generate the replacement.
-	 * @return string HTML replacement for the shortcode.
+	 * @param string $shortcode Shortcode string.
+	 * @param int    $post_id   Post ID where the shortcode is being replaced. Use for more context if needed,
+	 *                          e.g. to get the post author, title, or anything that might be required
+	 *                          to generate the replacement.
+	 * @return string|false Any HTML replacement for the shortcode. False if no adequate replacement is generated.
 	 */
-	public function replace_shortcode( string $shortcode_name, int $post_id ): string;
+	public function replace_shortcode( string $shortcode, int $post_id ): string|false;
 }

--- a/src/Command/ShortcodeReplacementInterface.php
+++ b/src/Command/ShortcodeReplacementInterface.php
@@ -11,7 +11,7 @@ interface ShortcodeReplacementInterface {
 	/**
 	 * Return a replacement for a shortcode.
 	 *
-	 * @param string $shortcode Shortcode string.
+	 * @param string $shortcode The whole shortcode text string.
 	 * @param int    $post_id   Post ID where the shortcode is being replaced. Use for more context if needed,
 	 *                          e.g. to get the post author, title, or anything that might be required
 	 *                          to generate the replacement.

--- a/src/Command/ShortcodesMigrator.php
+++ b/src/Command/ShortcodesMigrator.php
@@ -128,6 +128,9 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 		$post_ids         = isset( $assoc_args['post-ids'] ) ? explode( ',', $assoc_args['post-ids'] ) : null;
 		$dry_run          = isset( $assoc_args['dry-run'] ) ? true : false;
 
+		$post_types    = [ 'post', 'page' ];
+		$post_statuses = [ 'publish' ];
+
 		// Get the replacement class method.
 		list( $class_name, $method_name ) = explode( '::', $replace_callback );
 		try {
@@ -146,7 +149,7 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 	
 		// Get posts.
 		if ( is_null( $post_ids ) ) {
-			$post_ids = $this->posts_logic->get_all_posts_ids( [ 'post', 'page' ], [ 'publish' ] );
+			$post_ids = $this->posts_logic->get_all_posts_ids( $post_types, $post_statuses );
 		}
 		WP_CLI::line( sprintf( 'Searching total %s posts for shortodes and replacing them...', count( $post_ids ) ) );
 
@@ -250,7 +253,37 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 		// For $wpdb->update() to sink in.
 		wp_cache_flush();
 
-		// TODO: Check total count after replacements, warn if some shortcodes were not replaced.
+		// Extra QA, check total count after replacements, warn if some shortcodes were not replaced.
+		$post_types_placeholders  = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
+		$post_status_placeholders = implode( ',', array_fill( 0, count( $post_statuses ), '%s' ) );
+		// phpcs:disable -- $wpdb->prepare is used and all params are prepared.
+		// Remember, double %% is used to escape % in LIKE query.
+		$post_ids_qa = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID
+				FROM $wpdb->posts
+				WHERE post_content LIKE '%%%s%%'
+				AND post_type IN ($post_types_placeholders)
+				AND post_status IN ($post_status_placeholders)",
+				array_merge(
+					[ '[' . $shortcode ],
+					$post_types,
+					$post_statuses
+				)
+			)
+		);
+		// phpcs:enable
+		if ( ! empty( $post_ids_qa ) ) {
+			WP_CLI::warning(
+				sprintf(
+					'Some shortcodes were not replaced in total %d posts of post_type `%s` and post_status `%s`. Example first 10 IDs to check: %s',
+					count( $post_ids_qa ),
+					implode( ',', $post_types ),
+					implode( ',', $post_statuses ),
+					implode( ',', array_slice( $post_ids_qa, 0, 10 ) )
+				) 
+			);
+		}
 	}
 
 	/**

--- a/src/Command/ShortcodesMigrator.php
+++ b/src/Command/ShortcodesMigrator.php
@@ -176,6 +176,11 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 
 					// Get replacement.
 					$replacement_for_shortcode = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
+					if ( false === $replacement_for_shortcode ) {
+						WP_CLI::warning( sprintf( 'No replacement generated for shortcode: %s', $found_shortcode ) );
+						$content_blocks_updated[] = $content_block;
+						continue;
+					}
 
 					// Replace the whole shortcode block with a new replacement block.
 					$replacement_block        = [
@@ -213,8 +218,15 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 						// Output message just once in innerHTML, no need to repeat same finds in innerContent.
 						WP_CLI::line( sprintf( 'ID %d, replacing shortcode: %s', $post_id, $found_shortcode ) );
 
-						// Get and do replacement.
-						$replacement_for_shortcode      = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
+						// Get replacement.
+						$replacement_for_shortcode = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
+						if ( false === $replacement_for_shortcode ) {
+							WP_CLI::warning( sprintf( 'No replacement generated for shortcode: %s', $found_shortcode ) );
+							$content_blocks_updated[] = $content_block;
+							continue;
+						}
+	
+						// Do replacement.
 						$replacement_block['innerHTML'] = str_replace( $found_shortcode, $replacement_for_shortcode, $replacement_block['innerHTML'] );
 					}
 
@@ -223,8 +235,15 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 						$found_shortcodes = $this->shortcodes->get_all_shortcodes_from_content( $shortcode, $inner_content );
 
 						foreach ( $found_shortcodes as $found_shortcode ) {
-							// Get and do replacement.
-							$replacement_for_shortcode                              = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
+							// Get replacement.
+							$replacement_for_shortcode = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
+							if ( false === $replacement_for_shortcode ) {
+								WP_CLI::warning( sprintf( 'No replacement generated for shortcode: %s', $found_shortcode ) );
+								$content_blocks_updated[] = $content_block;
+								continue;
+							}
+							
+							// Do replacement.
 							$replacement_block['innerContent'][ $key_iner_content ] = str_replace( $found_shortcode, $replacement_for_shortcode, $replacement_block['innerContent'][ $key_iner_content ] );
 						}
 					}
@@ -276,7 +295,7 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 		if ( ! empty( $post_ids_qa ) ) {
 			WP_CLI::warning(
 				sprintf(
-					'Some shortcodes were not replaced in total %d posts of post_type `%s` and post_status `%s`. Example first 10 IDs to check: %s',
+					'Some shortcodes were not replaced in total %d posts of post_type `%s` and post_status `%s`. Example first 10 post IDs: %s',
 					count( $post_ids_qa ),
 					implode( ',', $post_types ),
 					implode( ',', $post_statuses ),

--- a/src/Command/ShortcodesMigrator.php
+++ b/src/Command/ShortcodesMigrator.php
@@ -1,16 +1,14 @@
 <?php
 
-namespace NewspackCustomContentMigrator\Command\General;
+namespace Newspack\MigrationTools\Command;
 
-use Newspack\MigrationTools\Command\WpCliCommandTrait;
 use Newspack\MigrationTools\Logic\Posts as PostsLogic;
-use NewspackCustomContentMigrator\Command\RegisterCommandInterface;
 use WP_CLI;
 
 /**
  * Custom migration scripts for Posts' content.
  */
-class ContentFixerMigrator implements RegisterCommandInterface {
+class ShortcodesMigrator implements WpCliCommandInterface {
 
 	use WpCliCommandTrait;
 
@@ -31,95 +29,40 @@ class ContentFixerMigrator implements RegisterCommandInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function register_commands(): void {
-		WP_CLI::add_command(
-			'newspack-content-migrator remove-first-image-from-post-body',
-			self::get_command_closure( 'remove_first_image_from_post_body' ),
-			array(
-				'shortdesc' => 'Remove the first image from the post body, usefull to normalize the posts content in case some contains the featured image in their body and others not.',
-				'synopsis'  => array(),
-			)
-		);
+	public static function get_cli_commands(): array {
+		return [
+			[
+				'newspack-content-migrator remove-shortcodes-from-post-body',
+				self::get_command_closure( 'remove_shortcodes_from_post_body' ),
 
-		WP_CLI::add_command(
-			'newspack-content-migrator remove-shortcodes-from-post-body',
-			self::get_command_closure( 'remove_shortcodes_from_post_body' ),
-			array(
-				'shortdesc' => 'Remove shortcodes from post body.',
-				'synopsis'  => array(
-					array(
-						'type'        => 'flag',
-						'name'        => 'dry-run',
-						'description' => 'Do a dry run simulation and don\'t actually edit the posts content.',
-						'optional'    => true,
-						'repeating'   => false,
+				[
+					'shortdesc' => 'Remove shortcodes from post body.',
+					'synopsis'  => array(
+						array(
+							'type'        => 'flag',
+							'name'        => 'dry-run',
+							'description' => 'Do a dry run simulation and don\'t actually edit the posts content.',
+							'optional'    => true,
+							'repeating'   => false,
+						),
+						array(
+							'type'        => 'assoc',
+							'name'        => 'shortcodes',
+							'description' => 'List of shortcodes to delete from all the posts content separated by a comma (e.g. shortcode1,shortcode2)',
+							'optional'    => false,
+							'repeating'   => false,
+						),
+						array(
+							'type'        => 'assoc',
+							'name'        => 'post_ids',
+							'description' => 'IDs of posts and pages to remove shortcodes from their content separated by a comma (e.g. 123,456)',
+							'optional'    => true,
+							'repeating'   => false,
+						),
 					),
-					array(
-						'type'        => 'assoc',
-						'name'        => 'shortcodes',
-						'description' => 'List of shortcodes to delete from all the posts content separated by a comma (e.g. shortcode1,shortcode2)',
-						'optional'    => false,
-						'repeating'   => false,
-					),
-					array(
-						'type'        => 'assoc',
-						'name'        => 'post_ids',
-						'description' => 'IDs of posts and pages to remove shortcodes from their content separated by a comma (e.g. 123,456)',
-						'optional'    => true,
-						'repeating'   => false,
-					),
-				),
-			)
-		);
-	}
-
-	/**
-	 * Callable for `newspack-content-migrator remove-first-image-from-post-body`.
-	 */
-	public function remove_first_image_from_post_body( array $pos_args, array $assoc_args ) {
-		WP_CLI::confirm( "This will remove the first image from the post body if it's on a shortcode format ([caption ...]<img src=...>[/caption]), do you want to continue?" );
-
-		$this->posts_logic->throttled_posts_loop(
-			array(
-				'post_type'   => 'post',
-				'post_status' => array( 'publish' ),
-			),
-			function( $post ) {
-				global $wpdb;
-
-				if ( substr( $post->post_content, 0, strlen( '[caption' ) ) === '[caption' ) {
-					$start_with_images[] = $post->ID;
-
-					$pattern = get_shortcode_regex();
-					if ( preg_match_all( '/' . $pattern . '/s', $post->post_content, $matches ) && array_key_exists( 2, $matches ) && in_array( 'caption', $matches[2] ) ) {
-						$index = 0;
-						$count = 0;
-						// Remove the first image shortcode from the content.
-						foreach ( $matches[2] as $match ) {
-							if ( 'caption' === $match ) {
-								// Found our first image.
-								$index = $count;
-								break; // We've done enough.
-							}
-							$count++;
-						};
-						// Remove first gallery from content.
-						$content = str_replace( $matches[0][ $index ], '', $post->post_content );
-
-						if ( $content !== $post->post_content ) {
-							// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-							$wpdb->update(
-								$wpdb->prefix . 'posts',
-								array( 'post_content' => $content ),
-								array( 'ID' => $post->ID )
-							);
-
-							WP_CLI::line( sprintf( 'Updated post: %d', $post->ID ) );
-						}
-					}
-				}
-			}
-		);
+				],
+			],
+		];
 	}
 
 	/**

--- a/src/Command/ShortcodesMigrator.php
+++ b/src/Command/ShortcodesMigrator.php
@@ -116,7 +116,7 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 	/**
 	 * Callable for `newspack-content-migrator replace-shortcodes-in-post-body`.
 	 *
-	 * @param array $args_pos   Positional arguments.      
+	 * @param array $args_pos   Positional arguments.
 	 * @param array $assoc_args Associative arguments.
 	 * @return void
 	 */
@@ -134,28 +134,32 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 			$reflection_method = new ReflectionMethod( $class_name, $method_name );
 		} catch ( ReflectionException $e ) {
 			WP_CLI::error( sprintf( 'Invalid provided replacement callback `%s`. See comment description for example usage.', $replace_callback ) );
-			exit(1);
+			exit( 1 );
 		}
 		
 		// Check if $class_instance is instance of ShortcodeReplacementInterface.
 		$class_instance = new $class_name();
 		if ( ! $class_instance instanceof ShortcodeReplacementInterface ) {
 			WP_CLI::error( sprintf( 'The class `%s` with method `%s` does not implement ShortcodeReplacementInterface.', $class_name, $method_name ) );
-			exit(1);
+			exit( 1 );
 		}
 	
+		// Get posts.
+		if ( is_null( $post_ids ) ) {
+			$post_ids = $this->posts_logic->get_all_posts_ids( [ 'post', 'page' ], [ 'publish' ] );
+		}
+		WP_CLI::line( sprintf( 'Searching total %s posts for shortodes and replacing them...', count( $post_ids ) ) );
+
 		// Replace in all posts IDs.
-		$post_ids = $this->posts_logic->get_all_posts_ids( [ 'post', 'page' ], [ 'publish' ] );
 		foreach ( $post_ids as $key => $post_id ) {
-			WP_CLI::line( sprintf( "ID %d %d/%d", $post_id, $key + 1, count($post_ids) ) );
 			
-			$post_content = $wpdb->get_var( $wpdb->prepare( "SELECT post_content FROM $wpdb->posts WHERE ID = %d", $post_id ) );
+			$post_content = $wpdb->get_var( $wpdb->prepare( "SELECT post_content FROM $wpdb->posts WHERE ID = %d", $post_id ) ); // phpcs:ignore -- WordPress.DB.DirectDatabaseQuery.NoCaching
 			if ( empty( $post_content ) || ! $this->shortcodes->has_shortcode( $shortcode, $post_content ) ) {
 				continue;
 			}
 			
-			// Parse post content with parse_blocks() -- will handle both raw HTML and shortcode blocks.
-			$content_blocks = parse_blocks( $post_content );
+			// Look blocks, parse_blocks() handles both raw HTML and shortcode blocks.
+			$content_blocks         = parse_blocks( $post_content );
 			$content_blocks_updated = [];
 			foreach ( $content_blocks as $content_block ) {
 				
@@ -163,12 +167,25 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 				 * If it's a shortcode block, replace the entire block.
 				 */
 				if ( 'core/shortcode' === $content_block['blockName'] ) {
+
 					$found_shortcode = trim( $content_block['innerHTML'] );
+					
+					WP_CLI::line( sprintf( 'ID %d, replacing shortcode: %s', $post_id, $found_shortcode ) );
 
 					// Get replacement.
-					$replacement = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
+					$replacement_for_shortcode = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
 
-					// TODO: Replace the found shortcode block with the replacement.
+					// Replace the found shortcode block data with the replacement block.
+					$replacement_block        = [
+						'blockName'    => null,
+						'attrs'        => [],
+						'innerBlocks'  => [],
+						'innerHTML'    => $replacement_for_shortcode,
+						'innerContent' => [
+							$replacement_for_shortcode,
+						],
+					];
+					$content_blocks_updated[] = $replacement_block;
 
 				} elseif (
 					( 'core/html' === $content_block['blockName'] )
@@ -177,30 +194,61 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 				) {
 
 					/**
-					 * If it's inside one of these blocks (Core HTML, Paragraph, Classic blocks, and NULL 'blockName' is raw HTML),
-					 * replace inside that block.
-					 */
+					* If the shortcode is inside one of these blocks (Core HTML, Paragraph, Classic blocks, and NULL 'blockName' is raw HTML),
+					* do replacements inside those blocks.
+					*/
 
-					$found_shortcodes = $this->shortcodes->get_all_shortcodes_from_content( $shortcode, $content_block['innerHTML'] );
+					$replacement_block = $content_block;
+
+					// Get all shortcodes in block.
+					$found_shortcodes = $this->shortcodes->get_all_shortcodes_from_content( $shortcode, $replacement_block['innerHTML'] );
 					if ( ! $found_shortcodes ) {
-						$content_blocks_updated[] = $content_block;
+						$content_blocks_updated[] = $replacement_block;
 						continue;
 					}
 					
+					// Replace shortcodes in innerHTML.
 					foreach ( $found_shortcodes as $found_shortcode ) {
-						// Get replacement.
-						$replacement = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
+						// Output message just once in innerHTML, no need to repeat same finds in innerContent.
+						WP_CLI::line( sprintf( 'ID %d, replacing shortcode: %s', $post_id, $found_shortcode ) );
+
+						// Get and do replacement.
+						$replacement_for_shortcode      = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
+						$replacement_block['innerHTML'] = str_replace( $found_shortcode, $replacement_for_shortcode, $replacement_block['innerHTML'] );
 					}
 
-					// TODO: Replace the found shortcodes with the replacement.
-					
+					// Replace shortcodes in innerContent.
+					foreach ( $replacement_block['innerContent'] as $key_iner_content => $inner_content ) {
+						$found_shortcodes = $this->shortcodes->get_all_shortcodes_from_content( $shortcode, $inner_content );
+
+						foreach ( $found_shortcodes as $found_shortcode ) {
+							// Get and do replacement.
+							$replacement_for_shortcode                              = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
+							$replacement_block['innerContent'][ $key_iner_content ] = str_replace( $found_shortcode, $replacement_for_shortcode, $replacement_block['innerContent'][ $key_iner_content ] );
+						}
+					}
+
+					$content_blocks_updated[] = $replacement_block;
+				}
+			}
+
+			// Save.
+			if ( $content_blocks_updated !== $content_blocks ) {
+				if ( ! $dry_run ) {
+					$post_content_updated = serialize_blocks( $content_blocks_updated );
+					// phpcs:disable -- WordPress.DB.DirectDatabaseQuery.NoCaching
+					$wpdb->update(
+						$wpdb->prefix . 'posts',
+						[ 'post_content' => $post_content_updated ],
+						[ 'ID' => $post_id ]
+					);
+					// phpcs:enable
 				}
 			}
 		}
 
-		// TODO: Save.
-		if ( ! $dry_run ) {
-		}
+		// For $wpdb->update() to sink in.
+		wp_cache_flush();
 
 		// TODO: Check total count after replacements, warn if some shortcodes were not replaced.
 	}

--- a/src/Command/ShortcodesMigrator.php
+++ b/src/Command/ShortcodesMigrator.php
@@ -3,6 +3,8 @@
 namespace Newspack\MigrationTools\Command;
 
 use Newspack\MigrationTools\Logic\Posts as PostsLogic;
+use ShortcodeReplacementInterface;
+use ReflectionMethod;
 use WP_CLI;
 
 /**
@@ -34,7 +36,6 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 			[
 				'newspack-content-migrator remove-shortcodes-from-post-body',
 				self::get_command_closure( 'remove_shortcodes_from_post_body' ),
-
 				[
 					'shortdesc' => 'Remove shortcodes from post body.',
 					'synopsis'  => array(
@@ -62,7 +63,62 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 					),
 				],
 			],
+			[
+				'newspack-content-migrator replace-shortcodes-in-post-body',
+				self::get_command_closure( 'replace_shortcodes_in_posts' ),
+				[
+					'shortdesc' => 'Replaces shortcodes from post body of all published posts and pages.',
+					'synopsis'  => [
+						[
+							'type'        => 'assoc',
+							'name'        => 'shortcode',
+							'description' => 'Shortcode name to replace, e.g. --shortcode=shortcode1 .',
+							'optional'    => false,
+							'repeating'   => false,
+						],
+						[
+							'type'        => 'assoc',
+							'name'        => 'replace-callback',
+							'description' => 'Fully qualified path to a callback method which will be used to generate a replacement. E.g. --replace-callback="Vendor\Package\ClassA::myShortcodeReplacementMethod" . Must implement ShortcodeReplacementInterface.',
+							'optional'    => false,
+							'repeating'   => false,
+						],
+						[
+							'type'        => 'flag',
+							'name'        => 'dry-run',
+							'description' => 'Do a dry run simulation and don\'t actually edit the posts content.',
+							'optional'    => true,
+							'repeating'   => false,
+						],
+						[
+							'type'        => 'assoc',
+							'name'        => 'post-ids',
+							'description' => 'Optional, if not provided will replace for all posts and pages. IDs of posts and pages to remove shortcodes from their content separated by a comma (e.g. 123,456)',
+							'optional'    => true,
+							'repeating'   => false,
+						],
+					],
+				],
+			],
 		];
+	}
+	
+	public function replace_shortcodes_in_posts( $args, $assoc_args ) {
+		$shortcode        = $assoc_args['shortcode'];
+		$replace_callback = $assoc_args['replace-callback'];
+		$post_ids         = isset( $assoc_args['post-ids'] ) ? explode( ',', $assoc_args['post-ids'] ) : null;
+		$dry_run          = isset( $assoc_args['dry-run'] ) ? true : false;
+
+		WP_CLI::line( '> replace_shortcodes_in_posts' );
+		
+		$post_id = 123;
+		
+		// Invoke the replacement method with arguments (see inteface ShortcodeReplacementInterface for the arguments).
+		list( $class_name, $method_name ) = explode( '::', $replace_callback );
+		$reflection_method                = new ReflectionMethod( $class_name, $method_name );
+		$class_instance                   = new $class_name();		$result                           = $reflection_method->invoke( $class_instance, $shortcode, $post_id );
+
+		WP_CLI::line( 'end.' );
 	}
 
 	/**

--- a/src/Command/ShortcodesMigrator.php
+++ b/src/Command/ShortcodesMigrator.php
@@ -161,7 +161,7 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 				continue;
 			}
 			
-			// Look blocks, parse_blocks() handles both raw HTML and shortcode blocks.
+			// Replace in post_content, parse_blocks() handles both raw HTML and shortcode blocks.
 			$content_blocks         = parse_blocks( $post_content );
 			$content_blocks_updated = [];
 			foreach ( $content_blocks as $content_block ) {
@@ -172,13 +172,12 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 				if ( 'core/shortcode' === $content_block['blockName'] ) {
 
 					$found_shortcode = trim( $content_block['innerHTML'] );
-					
 					WP_CLI::line( sprintf( 'ID %d, replacing shortcode: %s', $post_id, $found_shortcode ) );
 
 					// Get replacement.
 					$replacement_for_shortcode = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
 
-					// Replace the found shortcode block data with the replacement block.
+					// Replace the whole shortcode block with a new replacement block.
 					$replacement_block        = [
 						'blockName'    => null,
 						'attrs'        => [],
@@ -197,13 +196,12 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 				) {
 
 					/**
-					* If the shortcode is inside one of these blocks (Core HTML, Paragraph, Classic blocks, and NULL 'blockName' is raw HTML),
-					* do replacements inside those blocks.
+					* If the shortcode is inside any of these blocks -- Core HTML, Paragraph, Classic blocks,
+					* and NULL 'blockName' which is raw HTML -- do replacements inside these blocks.
 					*/
-
 					$replacement_block = $content_block;
 
-					// Get all shortcodes in block.
+					// Get all shortcodes.
 					$found_shortcodes = $this->shortcodes->get_all_shortcodes_from_content( $shortcode, $replacement_block['innerHTML'] );
 					if ( ! $found_shortcodes ) {
 						$content_blocks_updated[] = $replacement_block;
@@ -220,7 +218,7 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 						$replacement_block['innerHTML'] = str_replace( $found_shortcode, $replacement_for_shortcode, $replacement_block['innerHTML'] );
 					}
 
-					// Replace shortcodes in innerContent.
+					// Also replace shortcodes in innerContent.
 					foreach ( $replacement_block['innerContent'] as $key_iner_content => $inner_content ) {
 						$found_shortcodes = $this->shortcodes->get_all_shortcodes_from_content( $shortcode, $inner_content );
 
@@ -253,10 +251,12 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 		// For $wpdb->update() to sink in.
 		wp_cache_flush();
 
-		// Do an extra QA and check if all shortcodes were replaced.
+		/**
+		 * Do an extra QA and check if all shortcodes were replaced.
+		 */
 		$post_types_placeholders  = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
 		$post_status_placeholders = implode( ',', array_fill( 0, count( $post_statuses ), '%s' ) );
-		// phpcs:disable -- $wpdb->prepare is used and all params are prepared.
+		// phpcs:disable -- $wpdb->prepare is used and all params are prepared and escaped.
 		// Remember, double %% is used to escape % in LIKE query.
 		$post_ids_qa = $wpdb->get_col(
 			$wpdb->prepare(

--- a/src/Command/ShortcodesMigrator.php
+++ b/src/Command/ShortcodesMigrator.php
@@ -3,8 +3,10 @@
 namespace Newspack\MigrationTools\Command;
 
 use Newspack\MigrationTools\Logic\Posts as PostsLogic;
-use ShortcodeReplacementInterface;
+use Newspack\MigrationTools\Logic\Shortcodes;
+use Newspack\MigrationTools\Command\ShortcodeReplacementInterface;
 use ReflectionMethod;
+use ReflectionException;
 use WP_CLI;
 
 /**
@@ -20,12 +22,20 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 	 * @var PostsLogic.
 	 */
 	private $posts_logic;
+	
+	/**
+	 * Shortcodes logic.
+	 * 
+	 * @var Shortcodes $shortcodes Shortcodes logic.
+	 */
+	private $shortcodes;
 
 	/**
 	 * Constructor.
 	 */
 	private function __construct() {
 		$this->posts_logic = new PostsLogic();
+		$this->shortcodes  = new Shortcodes();
 	}
 
 	/**
@@ -103,22 +113,96 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 		];
 	}
 	
-	public function replace_shortcodes_in_posts( $args, $assoc_args ) {
+	/**
+	 * Callable for `newspack-content-migrator replace-shortcodes-in-post-body`.
+	 *
+	 * @param array $args_pos   Positional arguments.      
+	 * @param array $assoc_args Associative arguments.
+	 * @return void
+	 */
+	public function replace_shortcodes_in_posts( array $args_pos, array $assoc_args ): void {
+		global $wpdb;
+		
 		$shortcode        = $assoc_args['shortcode'];
 		$replace_callback = $assoc_args['replace-callback'];
 		$post_ids         = isset( $assoc_args['post-ids'] ) ? explode( ',', $assoc_args['post-ids'] ) : null;
 		$dry_run          = isset( $assoc_args['dry-run'] ) ? true : false;
 
-		WP_CLI::line( '> replace_shortcodes_in_posts' );
-		
-		$post_id = 123;
-		
-		// Invoke the replacement method with arguments (see inteface ShortcodeReplacementInterface for the arguments).
+		// Get the replacement class method.
 		list( $class_name, $method_name ) = explode( '::', $replace_callback );
-		$reflection_method                = new ReflectionMethod( $class_name, $method_name );
-		$class_instance                   = new $class_name();		$result                           = $reflection_method->invoke( $class_instance, $shortcode, $post_id );
+		try {
+			$reflection_method = new ReflectionMethod( $class_name, $method_name );
+		} catch ( ReflectionException $e ) {
+			WP_CLI::error( sprintf( 'Invalid provided replacement callback `%s`. See comment description for example usage.', $replace_callback ) );
+			exit(1);
+		}
+		
+		// Check if $class_instance is instance of ShortcodeReplacementInterface.
+		$class_instance = new $class_name();
+		if ( ! $class_instance instanceof ShortcodeReplacementInterface ) {
+			WP_CLI::error( sprintf( 'The class `%s` with method `%s` does not implement ShortcodeReplacementInterface.', $class_name, $method_name ) );
+			exit(1);
+		}
+	
+		// Replace in all posts IDs.
+		$post_ids = $this->posts_logic->get_all_posts_ids( [ 'post', 'page' ], [ 'publish' ] );
+		foreach ( $post_ids as $key => $post_id ) {
+			WP_CLI::line( sprintf( "ID %d %d/%d", $post_id, $key + 1, count($post_ids) ) );
+			
+			$post_content = $wpdb->get_var( $wpdb->prepare( "SELECT post_content FROM $wpdb->posts WHERE ID = %d", $post_id ) );
+			if ( empty( $post_content ) || ! $this->shortcodes->has_shortcode( $shortcode, $post_content ) ) {
+				continue;
+			}
+			
+			// Parse post content with parse_blocks() -- will handle both raw HTML and shortcode blocks.
+			$content_blocks = parse_blocks( $post_content );
+			$content_blocks_updated = [];
+			foreach ( $content_blocks as $content_block ) {
+				
+				/**
+				 * If it's a shortcode block, replace the entire block.
+				 */
+				if ( 'core/shortcode' === $content_block['blockName'] ) {
+					$found_shortcode = trim( $content_block['innerHTML'] );
 
-		WP_CLI::line( 'end.' );
+					// Get replacement.
+					$replacement = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
+
+					// TODO: Replace the found shortcode block with the replacement.
+
+				} elseif (
+					( 'core/html' === $content_block['blockName'] )
+					|| ( 'core/paragraph' === $content_block['blockName'] )
+					|| ( ! $content_block['blockName'] )
+				) {
+
+					/**
+					 * If it's inside one of these blocks (Core HTML, Paragraph, Classic blocks, and NULL 'blockName' is raw HTML),
+					 * replace inside that block.
+					 */
+
+					$found_shortcodes = $this->shortcodes->get_all_shortcodes_from_content( $shortcode, $content_block['innerHTML'] );
+					if ( ! $found_shortcodes ) {
+						$content_blocks_updated[] = $content_block;
+						continue;
+					}
+					
+					foreach ( $found_shortcodes as $found_shortcode ) {
+						// Get replacement.
+						$replacement = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
+					}
+
+					// TODO: Replace the found shortcodes with the replacement.
+					
+				}
+			}
+		}
+
+		// TODO: Save.
+		if ( ! $dry_run ) {
+		}
+
+		// TODO: Check total count after replacements, warn if some shortcodes were not replaced.
 	}
 
 	/**

--- a/src/Command/ShortcodesMigrator.php
+++ b/src/Command/ShortcodesMigrator.php
@@ -253,7 +253,7 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 		// For $wpdb->update() to sink in.
 		wp_cache_flush();
 
-		// Extra QA, check total count after replacements, warn if some shortcodes were not replaced.
+		// Do an extra QA and check if all shortcodes were replaced.
 		$post_types_placeholders  = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
 		$post_status_placeholders = implode( ',', array_fill( 0, count( $post_statuses ), '%s' ) );
 		// phpcs:disable -- $wpdb->prepare is used and all params are prepared.

--- a/src/Command/WpCliCommands.php
+++ b/src/Command/WpCliCommands.php
@@ -24,6 +24,7 @@ class WpCliCommands {
 			PostsMigrator::class,
 			SettingsMigrator::class,
 			WooCommMigrator::class,
+			ShortcodesMigrator::class,
 		];
 
 		return apply_filters( 'newspack_migration_tools_command_classes', $classes_with_cli_commands );

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -830,9 +830,11 @@ AUDIO;
 			}
 		}
 
-		$inner_html = '<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
-		' . $youtube_video_url . '
-		</div></figure>';
+		$inner_html = <<<HTML
+<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+$youtube_video_url
+</div></figure>
+HTML;
 
 		return [
 			'blockName'    => 'core/embed',

--- a/src/Logic/Shortcodes.php
+++ b/src/Logic/Shortcodes.php
@@ -68,21 +68,40 @@ class Shortcodes {
 	 */
 	public function get_all_shortcode_attributes( string $shortcode ): array {
 
-		// Get the shortcode arguments list for shortcode_parse_atts().
-		$text = trim( $shortcode );
+		/**
+		 * Validate shortcode a bit.
+		 */
+		$shortcode_trimmed   = trim( $shortcode );
+		$starts_with_bracket = '[' === substr( $shortcode_trimmed, 0, 1 );
+		$ends_in_bracket     = ']' === substr( $shortcode_trimmed, -1 );
+		if ( ! $starts_with_bracket || ! $ends_in_bracket ) {
+			// Shouldn't happen, but better safe than sorry.
+			throw new UnexpectedValueException( sprintf( 'Invalid shortcode format `%s`', esc_html( $shortcode ) ) );
+		}
+
+		/**
+		 * If the shortcode has no attributes, return an empty array.
+		 */
+		if ( strpos( $shortcode_trimmed, ' ' ) === false ) {
+			return [];
+		}
+
+		/**
+		 * Get the shortcode arguments list needed for `shortcode_parse_atts( $text )`.
+		 */
+		$text = $shortcode_trimmed;
 		// Remove evertything before and including the first space.
 		$text = substr( $text, strpos( $text, ' ' ) + 1 );
-		// Remove ending `]`.
-		if ( ']' !== substr( $text, -1 ) ) {
-			// Shouldn't happen, but better safe than sorry.
-			throw new UnexpectedValueException( 'Invalid shortcode format. Ending `]` not found.' );
-		}
+		// Remove the ending `]`.
 		$text = substr( $text, 0, -1 );
-
 		// Parse.
+		$text       = trim( $text );
 		$attributes = shortcode_parse_atts( $text );
 
-		// For attributes without value, make the array key equal attribute name, and the array value equal null.
+		/**
+		 * For attributes without value, make the array key equal to the attribute name,
+		 * and the array value equal to null.
+		 */
 		foreach ( $attributes as $key => $value ) {
 			// If the key is integer, that's an attribute without value.
 			if ( is_int( $key ) ) {
@@ -90,6 +109,9 @@ class Shortcodes {
 				unset( $attributes[ $key ] );
 			}
 		}
+
+		// Sort by keys, keeping values.
+		ksort( $attributes );
 
 		return $attributes;
 	}

--- a/src/Logic/Shortcodes.php
+++ b/src/Logic/Shortcodes.php
@@ -46,14 +46,15 @@ class Shortcodes {
 	/**
 	 * Parse shortcode attributes using `shortcode_parse_atts`. A memo helper wrapper method.
 	 * 
-	 * @param string $shortcode
+	 * @param string $shortcode Shortcode string.
+	 * 
 	 * @return array Response from shortcode_parse_atts(). Here's how `shortcode_parse_atts` will parse
 	 *               attributes which do have and do not have values:
 	 *               e.g. for following shortcode:
 	 *               ```
 	 *               [customshort attr1="value1" attr2 attr3="value3" attr4 attr5]
 	 *               ```
-	 *               the resulting array will be:
+	 *               the resulting array will be --  ❗️  NOTE that the ending `]` is included in final argument's value:
 	 *               ```
 	 *               array(6) {
 	 *                   [0]     => "[customshort"

--- a/src/Logic/Shortcodes.php
+++ b/src/Logic/Shortcodes.php
@@ -44,30 +44,131 @@ class Shortcodes {
 	}
 
 	/**
-	 * Parse shortcode attributes using `shortcode_parse_atts`. A memo helper wrapper method.
+	 * Get all shortcode attributes.
 	 * 
 	 * @param string $shortcode Shortcode string.
 	 * 
-	 * @return array Response from shortcode_parse_atts(). Here's how `shortcode_parse_atts` will parse
-	 *               attributes which do have and do not have values:
-	 *               e.g. for following shortcode:
+	 * @return array Keys are shortcode attribute names.
+	 *               Values are null where a shortcode attribute has no value, e.g. [customshort myattribute]
+	 *               or strings if they do have values, e.g. [customshort myattribute="somevalue"].
+	 *               E.g. shortcode [customshort attr1="value1" attr2 attr3="value3" attr4 attr5] will return:
 	 *               ```
-	 *               [customshort attr1="value1" attr2 attr3="value3" attr4 attr5]
-	 *               ```
-	 *               the resulting array will be --  ❗️  NOTE that the ending `]` is included in final argument's value:
-	 *               ```
-	 *               array(6) {
-	 *                   [0]     => "[customshort"
+	 *               array(5) {
 	 *                   'attr1' => "value1"
-	 *                   [1]     => "attr2"
+	 *                   'attr2' => null
 	 *                   'attr3' => "value3"
-	 *                   [2]     => "attr4"
-	 *                   [3]     => "attr5]"
+	 *                   'attr4' => null
+	 *                   'attr5' => null
 	 *               }
 	 *               ```
 	 */
-	public function get_shortcode_attributes( string $shortcode ): array {
-		$attrs = shortcode_parse_atts( $shortcode );
-		return $attrs;
+	public function get_all_shortcode_attributes( string $shortcode ): array {
+		
+		/**
+		 * Uses the built in shortcode_parse_atts() function, however at the time of writing this
+		 * the shortcode_parse_atts() seems to return incorrect results for the final attribute with a value.
+		 * For example, `shortcode_parse_atts( '[customshort attr1="val1" attr2="val2" "attr3="val3"]' )` will return:
+		 * ```
+		 * array(4) {
+		 *   [0] => "[customshort"
+		 *   'attr1' => "val1"
+		 *   'attr2' => "val2"
+		 *   [1]     => "attr3="val3"]"
+		 * }
+		 * ```
+		 * Note that the attr3 is not parsed correctly.
+		 *
+		 * By adding a space just before the ending `]` character and then running shortcode_parse_atts(),
+		 * the final element can be returned correctly, however an empty parameter will be added at the end.
+		 * For example, and note the space before ending `]`, `shortcode_parse_atts( '[customshort attr1="val1" attr2="val2" attr3="val3" ]' )`
+		 * will return:
+		 * ```
+		 * array(5) {
+		 *   [0] => "[customshort"
+		 *   'attr1' => "val1"
+		 *   'attr2' => "val2"
+		 *   'attr3' => "val3"
+		 *   [1] => "]"
+		 * }
+		 * ```
+		 *
+		 * Conclusion -- we'll add a space before the ending `]` character, then run the parse method,
+		 * then remove both starting and the ending element from the resulting array, and we'll end up with the correct result.
+		 *
+		 * Also confirming that the same works for attributes with no values, e.g. `shortcode_parse_atts( '[customshort attr1 attr2]' )`:
+		 * ```
+		 * array(3) {
+		 *   [0] => "[customshort"
+		 *   [1] => "attr1"
+		 *   [2] => "attr2]"
+		 * }
+		 * ```
+		 * and with added space before ending `]`, e.g. `[customshort attr1 attr2 ]`, result is:
+		 * ```
+		 * array(4) {
+		 *   [0] => "[customshort"
+		 *   [1] => "attr1"
+		 *   [2] => "attr2"
+		 *   [3] => "]"
+		 * }
+		 * ```
+		 *
+		 * Therefore, adding a space before the ending `]`, and cleaning up the trailing element, will give
+		 * the correct list of parameters.
+		 */
+
+		// Add a space character just before the ending `]`.
+		if ( ' ' !== substr( $shortcode, -2, 1 ) ) {
+			$shortcode = substr( $shortcode, 0, -1 ) . ' ]'; 
+		}
+		
+		// Parse.
+		$attributes = shortcode_parse_atts( $shortcode );
+
+		// Remove 0th element, shortcode name.
+		unset( $attributes[0] );
+
+		// Remove the final element from array -- the trailing element from when we added the space.
+		$last_key = array_key_last( $attributes );
+		unset( $attributes[ $last_key ] );
+
+		// For attributes without value, make the key attribute name, and value null.
+		foreach ( $attributes as $key => $value ) {
+			// If the key is integer, that's an attribute without value.
+			if ( is_int( $key ) ) {
+				$attributes[ $value ] = null;
+				unset( $attributes[ $key ] );
+			}
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Get a specific shortcode attribute.
+	 * Uses the built in WP `shortcode_parse_atts` and automatically strips the ending `]` from the last key-value pair.
+	 *
+	 * @param string $attribute_name Name of the attribute.
+	 * @param string $shortcode Shortcode string.
+	 *
+	 * @return mixed The attribute value if it's a key-value pair, 
+	 *               true if it's a boolean attribute (no value), 
+	 *               false if the attribute is not found.
+	 */
+	public function get_shortcode_attribute( string $attribute_name, string $shortcode ): mixed {
+		$attributes = $this->get_all_shortcode_attributes( $shortcode );
+		
+		// Attribute not found.
+		if ( ! array_key_exists( $attribute_name, $attributes ) ) {
+			return false;
+		}
+
+		// If the value is null, that means it's an attribute without value, so return true.
+		if ( is_null( $attributes[ $attribute_name ] ) ) {
+			return true;
+		}
+
+		// Return the attribute value.
+		return $attributes[ $attribute_name ];
 	}
 }

--- a/src/Logic/Shortcodes.php
+++ b/src/Logic/Shortcodes.php
@@ -42,4 +42,31 @@ class Shortcodes {
 
 		return $shortcodes_found;
 	}
+
+	/**
+	 * Parse shortcode attributes using `shortcode_parse_atts`. A memo helper wrapper method.
+	 * 
+	 * @param string $shortcode
+	 * @return array Response from shortcode_parse_atts(). Here's how `shortcode_parse_atts` will parse
+	 *               attributes which do have and do not have values:
+	 *               e.g. for following shortcode:
+	 *               ```
+	 *               [customshort attr1="value1" attr2 attr3="value3" attr4 attr5]
+	 *               ```
+	 *               the resulting array will be:
+	 *               ```
+	 *               array(6) {
+	 *                   [0]     => "[customshort"
+	 *                   'attr1' => "value1"
+	 *                   [1]     => "attr2"
+	 *                   'attr3' => "value3"
+	 *                   [2]     => "attr4"
+	 *                   [3]     => "attr5]"
+	 *               }
+	 *               ```
+	 */
+	public function get_shortcode_attributes( string $shortcode ): array {
+		$attrs = shortcode_parse_atts( $shortcode );
+		return $attrs;
+	}
 }

--- a/src/Logic/Shortcodes.php
+++ b/src/Logic/Shortcodes.php
@@ -2,6 +2,8 @@
 
 namespace Newspack\MigrationTools\Logic;
 
+use UnexpectedValueException;
+
 /**
  * Shortcodes logic class.
  */
@@ -48,6 +50,8 @@ class Shortcodes {
 	 * 
 	 * @param string $shortcode Shortcode string.
 	 * 
+	 * @throws UnexpectedValueException If the shortcode format is invalid.
+	 * 
 	 * @return array Keys are shortcode attribute names.
 	 *               Values are null where a shortcode attribute has no value, e.g. [customshort myattribute]
 	 *               or strings if they do have values, e.g. [customshort myattribute="somevalue"].
@@ -63,76 +67,22 @@ class Shortcodes {
 	 *               ```
 	 */
 	public function get_all_shortcode_attributes( string $shortcode ): array {
-		
-		/**
-		 * Uses the built in shortcode_parse_atts() function, however at the time of writing this
-		 * the shortcode_parse_atts() seems to return incorrect results for the final attribute with a value.
-		 * For example, `shortcode_parse_atts( '[customshort attr1="val1" attr2="val2" "attr3="val3"]' )` will return:
-		 * ```
-		 * array(4) {
-		 *   [0] => "[customshort"
-		 *   'attr1' => "val1"
-		 *   'attr2' => "val2"
-		 *   [1]     => "attr3="val3"]"
-		 * }
-		 * ```
-		 * Note that the attr3 is not parsed correctly.
-		 *
-		 * By adding a space just before the ending `]` character and then running shortcode_parse_atts(),
-		 * the final element can be returned correctly, however an empty parameter will be added at the end.
-		 * For example, and note the space before ending `]`, `shortcode_parse_atts( '[customshort attr1="val1" attr2="val2" attr3="val3" ]' )`
-		 * will return:
-		 * ```
-		 * array(5) {
-		 *   [0] => "[customshort"
-		 *   'attr1' => "val1"
-		 *   'attr2' => "val2"
-		 *   'attr3' => "val3"
-		 *   [1] => "]"
-		 * }
-		 * ```
-		 *
-		 * Conclusion -- we'll add a space before the ending `]` character, then run the parse method,
-		 * then remove both starting and the ending element from the resulting array, and we'll end up with the correct result.
-		 *
-		 * Also confirming that the same works for attributes with no values, e.g. `shortcode_parse_atts( '[customshort attr1 attr2]' )`:
-		 * ```
-		 * array(3) {
-		 *   [0] => "[customshort"
-		 *   [1] => "attr1"
-		 *   [2] => "attr2]"
-		 * }
-		 * ```
-		 * and with added space before ending `]`, e.g. `[customshort attr1 attr2 ]`, result is:
-		 * ```
-		 * array(4) {
-		 *   [0] => "[customshort"
-		 *   [1] => "attr1"
-		 *   [2] => "attr2"
-		 *   [3] => "]"
-		 * }
-		 * ```
-		 *
-		 * Therefore, adding a space before the ending `]`, and cleaning up the trailing element, will give
-		 * the correct list of parameters.
-		 */
 
-		// Add a space character just before the ending `]`.
-		if ( ' ' !== substr( $shortcode, -2, 1 ) ) {
-			$shortcode = substr( $shortcode, 0, -1 ) . ' ]'; 
+		// Get the shortcode arguments list for shortcode_parse_atts().
+		$text = trim( $shortcode );
+		// Remove evertything before and including the first space.
+		$text = substr( $text, strpos( $text, ' ' ) + 1 );
+		// Remove ending `]`.
+		if ( ']' !== substr( $text, -1 ) ) {
+			// Shouldn't happen, but better safe than sorry.
+			throw new UnexpectedValueException( 'Invalid shortcode format. Ending `]` not found.' );
 		}
-		
+		$text = substr( $text, 0, -1 );
+
 		// Parse.
-		$attributes = shortcode_parse_atts( $shortcode );
+		$attributes = shortcode_parse_atts( $text );
 
-		// Remove 0th element, shortcode name.
-		unset( $attributes[0] );
-
-		// Remove the final element from array -- the trailing element from when we added the space.
-		$last_key = array_key_last( $attributes );
-		unset( $attributes[ $last_key ] );
-
-		// For attributes without value, make the key attribute name, and value null.
+		// For attributes without value, make the array key equal attribute name, and the array value equal null.
 		foreach ( $attributes as $key => $value ) {
 			// If the key is integer, that's an attribute without value.
 			if ( is_int( $key ) ) {
@@ -151,8 +101,8 @@ class Shortcodes {
 	 * @param string $attribute_name Name of the attribute.
 	 * @param string $shortcode Shortcode string.
 	 *
-	 * @return mixed The attribute value if it's a key-value pair, 
-	 *               true if it's a boolean attribute (no value), 
+	 * @return mixed string attribute value if it's a key-value pair.
+	 *               true if it's an attribute without a value.
 	 *               false if the attribute is not found.
 	 */
 	public function get_shortcode_attribute( string $attribute_name, string $shortcode ): mixed {

--- a/src/Logic/Shortcodes.php
+++ b/src/Logic/Shortcodes.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Newspack\MigrationTools\Logic;
+
+/**
+ * Shortcodes logic class.
+ */
+class Shortcodes {
+
+	/**
+	 * Checks if a post content has a specific shortcode, without the need for the shortcode to be registered.
+	 * 
+	 * @param string $shortcode_name Shortcode name.
+	 * @param string $post_content   HTML content.
+	 * @return bool                  True if the shortcode is found in the content, false otherwise.
+	 */
+	public function has_shortcode( string $shortcode_name, string $post_content ): bool {
+		$pattern       = get_shortcode_regex( [ $shortcode_name ] );
+		$res           = preg_match_all( '/' . $pattern . '/s', $post_content, $matches );
+		$has_shortcode = is_int( $res ) && $res > 0;
+		
+		return $has_shortcode;
+	}
+
+	/**
+	 * Gets all shortcodes from a post content.
+	 * 
+	 * @param string $shortcode_name Shortcode name.
+	 * @param string $post_content   HTML content.
+	 * 
+	 * @return array Array containing all found shortcodes.
+	 */
+	public function get_all_shortcodes_from_content( string $shortcode_name, string $post_content ): array {
+		$shortcodes_found = [];
+		
+		$pattern = get_shortcode_regex( [ $shortcode_name ] );
+		$matches = [];
+		$res     = preg_match_all( '/' . $pattern . '/s', $post_content, $matches );
+		if ( is_int( $res ) && $res > 0 ) {
+			$shortcodes_found = $matches[0];
+		}
+
+		return $shortcodes_found;
+	}
+}


### PR DESCRIPTION
## Main updates in this PR -- shortcode functionality
- refactored `ContentFixerMigrator` from NCCM ([NCCM PR 575](https://github.com/Automattic/newspack-custom-content-migrator/pull/575)) which had some shortcode functionality and moved those parts into this repo, and renamed this code to `ShortcodesMigrator` (kept existing code history and authors during the move)
- new command to replace shortcodes in content, `newspack-content-migrator replace-shortcodes-in-post-body`. Command takes `--shortcode` name of shortcode, and `--replace-callback` a custom callback which returns a custom replacement. Here's an example of a reusable command which replaces all `[arve ...]` shortcodes with response from a custom callback
```
wp newspack-content-migrator replace-shortcodes-in-post-body \
--shortcode=arve \
--replace-callback="NewspackCustomContentMigrator\Command\PublisherSpecific\SanDiegoVoiceAndViewpointMigrator::replace_shortcode"
```
The custom callback implements the new interface `ShortcodeReplacementInterface` and implements one method `replace_shortcode( string $shortcode, int $post_id ): string|false` -- takes the shortcode and the post ID (if more context is needed for replacement), and returns the replacement string. My example of a publisher specific replacement callback can be found in [NCCM PR](https://github.com/Automattic/newspack-custom-content-migrator/pull/575) `SanDiegoVoiceAndViewpointMigrator::replace_shortcode`.

## Minor updates in this PR
- a tiny update in `src/Logic/GutenbergBlockGenerator.php` to remove unnecessary spaces