### PR TITLE
Envira gallery migrator

### DIFF
--- a/src/Command/EnviraGalleryMigrator.php
+++ b/src/Command/EnviraGalleryMigrator.php
@@ -133,15 +133,11 @@ class EnviraGalleryMigrator implements WpCliCommandInterface, ShortcodeReplaceme
 
 		// Get attachment IDs from postmeta meta_key = '_eg_in_gallery'.
 		// phpcs:disable -- WordPress.DB.DirectDatabaseQuery.NoCaching
-		$att_ids = maybe_unserialize(
-			$wpdb->get_var(
-				$wpdb->prepare(
-					"SELECT meta_value FROM $wpdb->postmeta WHERE post_id = %d AND meta_key = %s",
-					$id,
-					self::ENVIRA_POSTMETA_KEY_ATTACHED_IMAGES
-					) 
-					) 
-				);
+		$att_ids = maybe_unserialize( $wpdb->get_var( $wpdb->prepare(
+			"SELECT meta_value FROM $wpdb->postmeta WHERE post_id = %d AND meta_key = %s",
+			$id,
+			self::ENVIRA_POSTMETA_KEY_ATTACHED_IMAGES
+		) ) );
 		// phpcs:enable
 		if ( empty( $att_ids ) ) {
 			WP_CLI::warning( sprintf( 'Envira gallery `id` %d in post ID %d has no attached images.', $id, $post_id ) );

--- a/src/Command/EnviraGalleryMigrator.php
+++ b/src/Command/EnviraGalleryMigrator.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Custom migration scripts for Envira Gallery Lite.
+ * 
+ * @package NewspackCustomContentMigrator\Command\General
+ */
+
+namespace Newspack\MigrationTools\Command;
+
+use Newspack\MigrationTools\Command\ShortcodeReplacementInterface;
+use Newspack\MigrationTools\Logic\Shortcodes;
+use Newspack\MigrationTools\Logic\GutenbergBlockGenerator;
+use WP_CLI;
+
+/**
+ * Custom migration scripts for Envira Gallery Lite.
+ */
+class EnviraGalleryMigrator implements WpCliCommandInterface, ShortcodeReplacementInterface {
+
+	// Envira Gallery postmeta key containing images belonging to gallery.
+	const ENVIRA_POSTMETA_KEY_ATTACHED_IMAGES = '_eg_in_gallery';
+
+	/**
+	 * Shortcodes instance.
+	 * 
+	 * @var Shortcodes $shortcode Shortcodes instance.
+	 */
+	private $shortcode;
+
+	/**
+	 * GutenbergBlockGenerator instance.
+	 * 
+	 * @var GutenbergBlockGenerator
+	 */
+	private $gutenberg;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->shortcode = new Shortcodes();
+		$this->gutenberg = new GutenbergBlockGenerator();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_cli_commands(): array {
+		return [
+			[
+				'newspack-migration-tools envira-gallery-lite-to-gutenberg-gallery',
+				[ __CLASS__, 'cmd_migrate_envira_galleries' ],
+				[
+					'shortdesc' => 'Converts Envira Gallery Lite galleries to Gutenberg Gallery blocks throughout all Posts and Pages.',
+					'synopsis'  => [
+						[
+							'type'      => 'flag',
+							'name'      => 'dry-run',
+							'optional'  => true,
+							'repeating' => false,
+						],
+						[
+							'type'        => 'assoc',
+							'name'        => 'post-ids',
+							'description' => 'Optional, if not provided will replace for all posts and pages. IDs of posts and pages to remove shortcodes from their content separated by a comma (e.g. 123,456)',
+							'optional'    => true,
+							'repeating'   => false,
+						],
+						[
+							'type'        => 'assoc',
+							'name'        => 'post-types',
+							'description' => 'Optional CSV of post types to replace shortcodes from their content, if not provided will replace for all posts and pages. E.g. post,page',
+							'optional'    => true,
+							'repeating'   => false,
+							'default'     => 'post,page',
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Command handler for migrating Envira galleries.
+	 *
+	 * @param array $pos_args   Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function cmd_migrate_envira_galleries( $pos_args, $assoc_args ) {
+		$dry_run        = isset( $assoc_args['dry-run'] ) ?? false;
+		$post_ids_csv   = isset( $assoc_args['post-ids'] ) ? $assoc_args['post-ids'] : null;
+		$post_types_csv = isset( $assoc_args['post-types'] ) ? $assoc_args['post-types'] : 'post,page';
+				
+		// Leverage and use existing Shortcodes replacement command with a replacement for Envira shortcodes.
+		WP_CLI::runcommand(
+			sprintf(
+				'newspack-content-migrator replace-shortcodes-in-post-body --shortcode=envira-gallery --replace-callback=Newspack\MigrationTools\Command\EnviraGalleryMigrator::replace_shortcode %s %s %s',
+				$dry_run ? '--dry-run' : '',
+				$post_ids_csv ? '--post-ids=' . $post_ids_csv : '',
+				$post_types_csv ? '--post-types=' . $post_types_csv : ''
+			),
+			[
+				'return'     => false,
+				'launch'     => false,
+				'exit_error' => true,
+			]
+		);
+	}
+
+	/**
+	 * Replace Envira Gallery shortcode with Gutenberg gallery block.
+	 *
+	 * @param string $shortcode The shortcode to replace.
+	 * @param int    $post_id   The post ID where the shortcode is used.
+	 * 
+	 * @return string|false The replacement HTML or false if replacement failed.
+	 */
+	public function replace_shortcode( string $shortcode, int $post_id ): string|false {
+		global $wpdb;
+
+		// Clean up and decode shortcode text.
+		$decoded_shortcode = $this->shortcode->decode_shortcode( $shortcode );
+
+		// Get gallery ID.
+		$id = $this->shortcode->get_shortcode_attribute( 'id', $decoded_shortcode );
+
+		// Get the gallery post row, check if post_type is 'envira'.
+		$gallery_post = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE ID = %d", $id ) ); // phpcs:ignore -- WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( 'envira' !== $gallery_post->post_type ) {
+			WP_CLI::warning( sprintf( 'Envira gallery `id` %d used in post ID %d not found.', $id, $post_id ) );
+			return false;
+		}
+
+		// Get attachment IDs from postmeta meta_key = '_eg_in_gallery'.
+		// phpcs:disable -- WordPress.DB.DirectDatabaseQuery.NoCaching
+		$att_ids = maybe_unserialize(
+			$wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT meta_value FROM $wpdb->postmeta WHERE post_id = %d AND meta_key = %s",
+					$id,
+					self::ENVIRA_POSTMETA_KEY_ATTACHED_IMAGES
+					) 
+					) 
+				);
+		// phpcs:enable
+		if ( empty( $att_ids ) ) {
+			WP_CLI::warning( sprintf( 'Envira gallery `id` %d in post ID %d has no attached images.', $id, $post_id ) );
+			return false;
+		}
+
+		// Generate the tiled gallery block replacement.
+		$gutenberg_block            = $this->gutenberg->get_jetpack_tiled_gallery( $att_ids, 'media' );
+		$gutenberg_block_serialized = serialize_block( $gutenberg_block );
+
+		return $gutenberg_block_serialized;
+	}
+}

--- a/src/Command/ShortcodesMigrator.php
+++ b/src/Command/ShortcodesMigrator.php
@@ -107,6 +107,14 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 							'optional'    => true,
 							'repeating'   => false,
 						],
+						[
+							'type'        => 'assoc',
+							'name'        => 'post-types',
+							'description' => 'Optional CSV of post types to replace shortcodes from their content, if not provided will replace for all posts and pages. E.g. post,page',
+							'optional'    => true,
+							'repeating'   => false,
+							'default'     => 'post,page',
+						],
 					],
 				],
 			],
@@ -127,8 +135,8 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 		$replace_callback = $assoc_args['replace-callback'];
 		$post_ids         = isset( $assoc_args['post-ids'] ) ? explode( ',', $assoc_args['post-ids'] ) : null;
 		$dry_run          = isset( $assoc_args['dry-run'] ) ? true : false;
+		$post_types       = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : [ 'post', 'page' ];
 
-		$post_types    = [ 'post', 'page' ];
 		$post_statuses = [ 'publish' ];
 
 		// Get the replacement class method.
@@ -172,7 +180,7 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 				if ( 'core/shortcode' === $content_block['blockName'] ) {
 
 					$found_shortcode = trim( $content_block['innerHTML'] );
-					WP_CLI::line( sprintf( 'ID %d, replacing shortcode: %s', $post_id, $found_shortcode ) );
+					WP_CLI::line( sprintf( 'Post ID %d, replacing shortcode: %s', $post_id, $found_shortcode ) );
 
 					// Get replacement.
 					$replacement_for_shortcode = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );
@@ -216,7 +224,7 @@ class ShortcodesMigrator implements WpCliCommandInterface {
 					// Replace shortcodes in innerHTML.
 					foreach ( $found_shortcodes as $found_shortcode ) {
 						// Output message just once in innerHTML, no need to repeat same finds in innerContent.
-						WP_CLI::line( sprintf( 'ID %d, replacing shortcode: %s', $post_id, $found_shortcode ) );
+						WP_CLI::line( sprintf( 'Post ID %d, replacing shortcode: %s', $post_id, $found_shortcode ) );
 
 						// Get replacement.
 						$replacement_for_shortcode = $reflection_method->invoke( $class_instance, $found_shortcode, $post_id );

--- a/src/Command/WpCliCommands.php
+++ b/src/Command/WpCliCommands.php
@@ -25,6 +25,7 @@ class WpCliCommands {
 			SettingsMigrator::class,
 			WooCommMigrator::class,
 			ShortcodesMigrator::class,
+			EnviraGalleryMigrator::class,
 		];
 
 		return apply_filters( 'newspack_migration_tools_command_classes', $classes_with_cli_commands );

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -38,13 +38,13 @@ class GutenbergBlockGenerator {
 	 *      - at the time of writing this, JP Tiled Gallery doesn't support captions
 	 *
 	 * @param int[]    $attachment_ids  Attachments IDs to be used in the tiled gallery.
-	 * @param string   $link_to         `linkTo` attribute of the Jetpack Tiled Gallery block. Can be "media", or "attachment".
+	 * @param ?string  $link_to         `linkTo` attribute of the Jetpack Tiled Gallery block. Can be "media", or "attachment", or null.
 	 * @param string[] $tile_sizes_list List of tiles sizes in percentages (e.g. ['50', '50']).
 	 *
 	 * @return array to be used in the serialize_block() or serialize_blocks() function to get the raw content of a Gutenberg Block.
 	 * @throws \UnexpectedValueException If $link_to param is invalid.
 	 */
-	public function get_jetpack_tiled_gallery( array $attachment_ids, string $link_to, array $tile_sizes_list = [
+	public function get_jetpack_tiled_gallery( array $attachment_ids, ?string $link_to, array $tile_sizes_list = [
 		'66.79014',
 		'33.20986',
 		'33.33333',
@@ -73,7 +73,7 @@ class GutenbergBlockGenerator {
 			' ',
 			array_filter(
 				array_map(
-					function ( $index, $attachment_id ) use ( &$tile_sizes, &$non_existing_attachment_indexes, $tile_sizes_list, $file_logger ) {
+					function ( $index, $attachment_id ) use ( &$tile_sizes, &$non_existing_attachment_indexes, $tile_sizes_list, $file_logger, $link_to ) {
 						$attachment_url = wp_get_attachment_url( $attachment_id );
 
 						if ( ! $attachment_url ) {
@@ -86,9 +86,20 @@ class GutenbergBlockGenerator {
 						$tile_size    = $this->get_tile_image_size_by_index( $index, $tile_sizes_list );
 						$tile_sizes[] = $tile_size;
 
+						// Add <a> link to attachment URL if linkTo is set to "attachment" or "media".
+						$a_opening_tag = '';
+						$a_closing_tag = '';
+						if ( 'attachment' == $link_to ) {
+							$a_opening_tag = sprintf( '<a href="%s">', get_permalink( $attachment_id ) );
+							$a_closing_tag = '</a>';
+						} elseif ( 'media' == $link_to ) {
+							$a_opening_tag = sprintf( '<a href="%s">', wp_get_attachment_url( $attachment_id ) );
+							$a_closing_tag = '</a>';
+						}
+
 						return '
                             <div class="tiled-gallery__col" style="flex-basis: ' . $tile_size . '%">
-                            <figure class="tiled-gallery__item">
+                            ' . $a_opening_tag . '<figure class="tiled-gallery__item">
                                 <img
                                         alt="' . get_the_title( $attachment_id ) . '"
                                         data-id="' . $attachment_id . '"
@@ -97,7 +108,7 @@ class GutenbergBlockGenerator {
                                         src="' . $attachment_url . '"
                                     data-amp-layout="responsive"
                                 />
-                            </figure>
+                            </figure>' . $a_closing_tag . '
                             </div>';
 					},
 					array_keys( $attachment_ids ),

--- a/src/Logic/Shortcodes.php
+++ b/src/Logic/Shortcodes.php
@@ -143,4 +143,24 @@ class Shortcodes {
 		// Return the attribute value.
 		return $attributes[ $attribute_name ];
 	}
+
+	/**
+	 * HTML-decodes shortcode text and replaces all known fancy quotes to regular double quote.
+	 * 
+	 * @param string $shortcode Full shortcode text content including brackets.
+	 * @return string The decoded shortcode content
+	 */
+	public function decode_shortcode( string $shortcode ): string {
+		// Decode HTML entities in shortcode (e.g. &quot; or &#8221; to ").
+		$decoded_shortcode = html_entity_decode( $shortcode );
+		
+		// Replace all known similar fancy quotes to regular double quote.
+		$decoded_shortcode = str_replace(
+			[ '“', '”', '‘', '’', '«', '»', '‹', '›', '„', '‚', '′', '″' ],
+			'"',
+			$decoded_shortcode
+		);
+
+		return $decoded_shortcode;
+	}
 }


### PR DESCRIPTION
## Change in this PR

- `src/Command/EnviraGalleryMigrator.php`

Added new reusable command `wp newspack-migration-tools envira-gallery-lite-to-gutenberg-gallery` which converts Envira galleries to tiled galleries (tiled gals layout is the most similar to Envira's layout).

Uses the existing shortcode replacement command, provides Envira specific replacement callback.

## Other small changes

- `src/Command/ShortcodesMigrator.php` just exposed post-type selection via argument
- `src/Logic/GutenbergBlockGenerator.php` added missing `<a>` tag surrounding images which use `linkTo` block parameter
- `src/Logic/GutenbergBlockGenerator.php` small helper method added to decode content which was jumbled and too much serialized