### PR TITLE
Add PHPUnit Newspack Plugin

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -42,9 +42,9 @@ elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 	WP_TESTS_TAG="trunk"
 else
 	# http serves a single offer, whereas https serves multiple. we only want one
-	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
-	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
-	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	download http://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' $TMPDIR/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//')
 	if [[ -z "$LATEST_VERSION" ]]; then
 		echo "Latest WordPress version could not be found"
 		exit 1
@@ -98,8 +98,10 @@ install_wp() {
 # Install plugins needed for the test suite.
 install_contrib_plugins() {
   # Also see set_up_contrib_plugins() in ./bootstrap.php in this repo for how to activate plugins in the test suite.
-  wget -nv -O /tmp/co-authors-plus.zip https://downloads.wordpress.org/plugin/co-authors-plus.zip
-  unzip -q -o /tmp/co-authors-plus.zip -d $WP_CORE_DIR/wp-content/plugins/
+  wget -nv -O $TMPDIR/co-authors-plus.zip https://downloads.wordpress.org/plugin/co-authors-plus.zip
+  unzip -q -o $TMPDIR/co-authors-plus.zip -d $WP_CORE_DIR/wp-content/plugins/
+  wget -nv -O $TMPDIR/newspack-plugin.zip https://github.com/Automattic/newspack-plugin/releases/latest/download/newspack-plugin.zip
+  unzip -q -o $TMPDIR/newspack-plugin.zip -d $WP_CORE_DIR/wp-content/plugins/
 }
 
 install_test_suite() {
@@ -129,6 +131,8 @@ install_test_suite() {
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+		# allow CAP in Newspack Plugin otherwise CAP tests fail:
+		echo "define( 'NEWSPACK_ENABLE_CAP_GUEST_AUTHORS', true );" >> "$WP_TESTS_DIR"/wp-tests-config.php
 	fi
 
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,6 +36,8 @@ function set_up_contrib_plugins(): void {
 	$plugins_active_in_tests = [
 		// The CAP plugin is used so much in our code that it is hard to test without it.
 		'co-authors-plus' => 'co-authors-plus/co-authors-plus.php',
+		// The Newspack plugin is required for GuestContributorsHelper tests.
+		'newspack-plugin' => 'newspack-plugin/newspack.php',
 	];
 
 	$wordpress_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress';
@@ -70,6 +72,9 @@ tests_add_filter( 'muplugins_loaded', fn() => require dirname( __DIR__ ) . '/new
 
 // Include and "activate" plugins needed.
 set_up_contrib_plugins();
+
+// Force include of Newspack Plugin's autoloader since phpunit ignores it because the plugin doesn't use __DIR__ .
+require_once rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress/wp-content/plugins/newspack-plugin/vendor/autoload.php';
 
 // Start up the WP testing environment.
 require "{$_tests_dir}/includes/bootstrap.php";

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -73,7 +73,8 @@ tests_add_filter( 'muplugins_loaded', fn() => require dirname( __DIR__ ) . '/new
 // Include and "activate" plugins needed.
 set_up_contrib_plugins();
 
-// Force include of Newspack Plugin's autoloader since phpunit ignores it because the plugin doesn't use __DIR__ .
+// Bug: Force include of Newspack Plugin's autoloader since phpunit ignores it because the plugin doesn't use __DIR__ .
+// Remove this once the PR ( https://github.com/Automattic/newspack-plugin/pull/3808 ) is merged into the latest release zip.
 require_once rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress/wp-content/plugins/newspack-plugin/vendor/autoload.php';
 
 // Start up the WP testing environment.


### PR DESCRIPTION
## Description

Includes the Newspack Plugin as a dependency within the NMT phpunit tests.

## Changes

1. Adds the latest Newspack Plugin from github releases into the testing wordpress installation.
2. Fixes some `/tmp` paths to `$TMPDIR`.
3. Adds the CAP define for Newspack Plugin so we can still fully test our CAP functions.
4. Temporary composer include path until a path change is made in the Newspack Plugin.