### PR TITLE
Fix: Attachments Sideload Error: return if error

### DIFF
--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -116,9 +116,8 @@ class Attachments {
 		if ( is_wp_error( $att_id ) ) {
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			@unlink( $file_array['tmp_name'] );
-			CliLog::get_logger( 'attachments' )->warning( $att_id->get_error_message() );
+			return new WP_Error( sprintf( 'File %s was not sideloaded: %s', $file_array['name'], $att_id->get_error_message() ) );
 		}
-
 
 		if ( $alt ) {
 			update_post_meta( $att_id, '_wp_attachment_image_alt', $alt );


### PR DESCRIPTION
## Changes

Since `is_wp_error( $att_id )` is `true`, we should do a `return` so that the function doesn't keep running.  The function already returns `WP_Error` in other places, so returning `WP_Error` here is not a problem.

## History

Looking at the history this bug has been here for a long time.  I assume it never happens because the only way I could cause it was to run the code in "debugger" and stop right before `media_handle_sideload` and delete the `/tmp/` file so that sideload would fail.

## How to test:

Run in "debugger" and stop right before `media_handle_sideload` and delete the `/tmp/` file so that sideload will fail.
