### PR TITLE
Feat: Allow skip of binary image matching when sideloading

### DIFF
--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -44,12 +44,16 @@ class Attachments {
 	 * @param array  $args        Optional. Attachment creation argument to override used by the \media_handle_sideload(), used
 	 *                            internally by the \wp_insert_attachment(), and even more internally by the \wp_insert_post().
 	 * @param string $desired_filename Optional. If the file you are importing has a different (or no) file extension than the one
-	 * you want the resulting attachment to have, you can specify it here. Make sure that it
-	 * actually matches the file mime type.
+	 *                                 you want the resulting attachment to have, you can specify it here. Make sure that it
+	 *                                 actually matches the file mime type.
+	 * @param bool   $try_existing Optional. Default true. Try to match an existing file using self::maybe_get_existing_attachment_id().
+	 *                             Set this to false to skip the existing lookup if, for example, you are uploading two images that have the
+	 *                             same filename and binary data, but you need them to be unique attachments in the db, so they can have different
+	 *                             alt/captions and also different postmeta. 
 	 *
 	 * @return int|WP_Error Attachment ID.
 	 */
-	public static function import_external_file( $path, $title = null, $caption = null, $description = null, $alt = null, $post_id = 0, $args = [], $desired_filename = '' ) {
+	public static function import_external_file( $path, $title = null, $caption = null, $description = null, $alt = null, $post_id = 0, $args = [], $desired_filename = '', $try_existing = true ) {
 		// Fetch remote or local file.
 		$is_http = 'http' == substr( $path, 0, 4 );
 		if ( $is_http ) {
@@ -94,7 +98,7 @@ class Attachments {
 			}
 		}
 
-		$maybe_exising_attachment_id = self::maybe_get_existing_attachment_id( $file_array['tmp_name'], $file_array['name'] );
+		$maybe_exising_attachment_id = ( $try_existing ) ? self::maybe_get_existing_attachment_id( $file_array['tmp_name'], $file_array['name'] ) : null;
 		if ( null !== $maybe_exising_attachment_id ) {
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			@unlink( $file_array['tmp_name'] );

--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -49,8 +49,8 @@ class Attachments {
 	 * @param bool   $try_existing Optional. Default true. Try to match an existing file using self::maybe_get_existing_attachment_id().
 	 *                             Set this to false to skip the existing lookup if, for example, you are uploading two images that have the
 	 *                             same filename and binary data, but you need them to be unique attachments in the db, so they can have different
-	 *                             alt/captions and also different postmeta. 
-	 *
+	 *                             alt/captions and also different postmeta.
+	 * 
 	 * @return int|WP_Error Attachment ID.
 	 */
 	public static function import_external_file( $path, $title = null, $caption = null, $description = null, $alt = null, $post_id = 0, $args = [], $desired_filename = '', $try_existing = true ) {


### PR DESCRIPTION
This PR allows "skipping" of the `maybe_get_existing_attachment_id()` function when importing external files.

Sometimes we want to have two distinct attachments created even if the filename and binary data is the same.  Here is an example:

We're migrating a publisher website that has images at these two urls:

```
example.com/article-one/image.jpg
example.com/article-two/image.jpg
```

These two images have the same filename, and their binary data is the same, so only importing one attachment makes sense, unless the publisher has different alt/caption for each image.  We need two distinct attachments in order to have distinct alt/caption, etc.

Additionally, during migrations we save "old-slug" info into the attachment `post_meta` rows.  If we combine the two images into one, then we could lose our "source of truth" old slug info since only one "old-slug" would be saved into postmeta.  (Yes, we could save "old-slug" as a post meta array with all sources of truths that point to this one attachment, but this can become cumbersome, and still doesn't solve the multiple alt/caption issue).
