### PR TITLE
Add CSVWriter Util class

### DIFF
--- a/src/Util/CsvWriter.php
+++ b/src/Util/CsvWriter.php
@@ -26,11 +26,11 @@ class CsvWriter {
 	public function __construct(
 		private string $filename
 	) {
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 		$this->file_pointer = fopen( getcwd() . '/' . $this->filename, 'a+' );
 
 		if ( false === $this->file_pointer ) {
-            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new Exception( "Could not open file: {$this->filename}" );
 		}
 	}
@@ -58,9 +58,9 @@ class CsvWriter {
 	 * @throws Exception If the row cannot be written to the file.
 	 */
 	public function put( array $row ): void {
-        // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
 		if ( false === fputcsv( $this->file_pointer, $row ) ) {
-            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new Exception( "Could not write to file: {$this->filename}" );
 		}
 	}
@@ -73,7 +73,7 @@ class CsvWriter {
 	 */
 	public function close(): void {
 		if ( false === fclose( $this->file_pointer ) ) {
-            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new Exception( "Could not close file: {$this->filename}" );
 		}
 	}

--- a/src/Util/CsvWriter.php
+++ b/src/Util/CsvWriter.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Wrapper class for writing CSV files.
+ *
+ * @package Newspack\MigrationTools\Util
+ */
+
+namespace Newspack\MigrationTools\Util;
+
+use Exception;
+
+class CsvWriter {
+	/**
+	 * CSV file pointer.
+	 * 
+	 * @var resource
+	 */
+	private $file_pointer;
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param string $filename The name of the CSV file to write to.
+	 * @throws Exception If the file cannot be opened.
+	 */
+	public function __construct(
+		private string $filename
+	) {
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		$this->file_pointer = fopen( getcwd() . '/' . $this->filename, 'a+' );
+
+		if ( false === $this->file_pointer ) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new Exception( "Could not open file: {$this->filename}" );
+		}
+	}
+
+	/**
+	 * Sets the Header columns for the CSV file.
+	 * 
+	 * @param  array $header The header columns to write.
+	 * @return void
+	 */
+	public function set_header( array $header ): void {
+		// Check if the file is empty before writing the header.
+		if ( fstat( $this->file_pointer )['size'] > 0 ) {
+			return;
+		}
+
+		$this->put( $header );
+	}
+
+	/**
+	 * Writes a row to the CSV file.
+	 * 
+	 * @param  array $row The row data to write.
+	 * @return void
+	 * @throws Exception If the row cannot be written to the file.
+	 */
+	public function put( array $row ): void {
+        // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
+		if ( false === fputcsv( $this->file_pointer, $row ) ) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new Exception( "Could not write to file: {$this->filename}" );
+		}
+	}
+
+	/**
+	 * Closes the file pointer.
+	 * 
+	 * @return void
+	 * @throws Exception If the file cannot be closed.
+	 */
+	public function close(): void {
+		if ( false === fclose( $this->file_pointer ) ) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new Exception( "Could not close file: {$this->filename}" );
+		}
+	}
+}

--- a/tests/Util/CsvWriterTest.php
+++ b/tests/Util/CsvWriterTest.php
@@ -46,7 +46,7 @@ class CsvWriterTest extends TestCase {
 		$csv_writer->set_header( $header );
 		$csv_writer->close();
 
-        // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 		$content = file_get_contents( $this->test_file );
 		$this->assertStringContainsString( 'Column1,Column2,Column3', $content );
 	}
@@ -57,7 +57,7 @@ class CsvWriterTest extends TestCase {
 		$csv_writer->put( $row );
 		$csv_writer->close();
 
-        // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 		$content = file_get_contents( $this->test_file );
 		$this->assertStringContainsString( 'Data1,Data2,Data3', $content );
 	}
@@ -68,7 +68,7 @@ class CsvWriterTest extends TestCase {
 		$csv_writer->set_header( [ 'Header1', 'Header2' ] );
 		$csv_writer->close();
 
-        // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 		$content = file_get_contents( $this->test_file );
 		$this->assertStringNotContainsString( 'Header1,Header2', $content );
 	}

--- a/tests/Util/CsvWriterTest.php
+++ b/tests/Util/CsvWriterTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Newspack\MigrationTools\Util\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Newspack\MigrationTools\Util\CsvWriter;
+
+/**
+ * Class CsvWriterTest
+ * 
+ * @package newspack-migration-tools
+ */
+class CsvWriterTest extends TestCase {
+	private string $test_file;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$temp_dir = get_temp_dir();
+
+		$random_dir_name = wp_unique_filename( $temp_dir, uniqid( time() ) );
+
+		wp_mkdir_p( $random_dir_name );
+
+		$this->test_file = $random_dir_name . '/test.csv';
+		if ( file_exists( $this->test_file ) ) {
+			unlink( $this->test_file );
+		}
+	}
+
+	protected function tearDown(): void {
+		if ( file_exists( $this->test_file ) ) {
+			unlink( $this->test_file );
+		}
+	}
+
+	public function testConstructorCreatesFile(): void {
+		$csv_writer = new CsvWriter( $this->test_file );
+		$this->assertFileExists( $this->test_file );
+		$csv_writer->close();
+	}
+
+	public function testSetHeaderWritesHeader(): void {
+		$csv_writer = new CsvWriter( $this->test_file );
+		$header     = [ 'Column1', 'Column2', 'Column3' ];
+		$csv_writer->set_header( $header );
+		$csv_writer->close();
+
+        // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		$content = file_get_contents( $this->test_file );
+		$this->assertStringContainsString( 'Column1,Column2,Column3', $content );
+	}
+
+	public function testPutWritesRow(): void {
+		$csv_writer = new CsvWriter( $this->test_file );
+		$row        = [ 'Data1', 'Data2', 'Data3' ];
+		$csv_writer->put( $row );
+		$csv_writer->close();
+
+        // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		$content = file_get_contents( $this->test_file );
+		$this->assertStringContainsString( 'Data1,Data2,Data3', $content );
+	}
+
+	public function testSetHeaderDoesNotOverwriteExistingContent(): void {
+		$csv_writer = new CsvWriter( $this->test_file );
+		$csv_writer->put( [ 'ExistingData' ] );
+		$csv_writer->set_header( [ 'Header1', 'Header2' ] );
+		$csv_writer->close();
+
+        // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		$content = file_get_contents( $this->test_file );
+		$this->assertStringNotContainsString( 'Header1,Header2', $content );
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `CsvWriter` utility class for writing CSV files, with built-in support for setting headers, adding rows, and handling file operations safely.

## Purpose

The `CsvWriter` class makes it easy to write data to CSV files with minimal setup. It manages file creation, prevents header duplication, and throws exceptions if any file operation fails.

## Usage Example

```php

use Newspack\MigrationTools\Util\CsvWriter;

try {
    $csv = new CsvWriter( 'output.csv' ); // The file is created in the current working directory
    $csv->set_header( [ 'Name', 'Email', 'Age' ] );
    $csv->put( [ 'Alice', 'alice@example.com', 30 ] );
    $csv->put( [ 'Bob', 'bob@example.com', 28 ] );
    $csv->close();
} catch ( Exception $e ) {
    error_log( $e->getMessage() );
}
```

## Tests

Unit tests are included in `tests/Util/CsvWriterTest.php` to cover file creation, header handling, row writing, and error conditions.