### PR TITLE
Improve Attachment Handling and Duplicate Detection

### DIFF
--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -195,7 +195,8 @@ class Attachments {
 			"SELECT post_id
 			FROM {$wpdb->postmeta}
 			WHERE meta_key = '_wp_attached_file'
-			AND meta_value REGEXP %s;",
+			AND (meta_value LIKE %s OR meta_value REGEXP %s);",
+			$like,
 			$regex_pattern
 		);
 

--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -206,6 +206,8 @@ class Attachments {
 		foreach ( $attachment_ids as $attachment_id ) {
 
 			$candidate_path = get_attached_file( $attachment_id );
+			// Remove the "-scaled" suffix from the candidate path to check the original file size.
+			$candidate_path = str_replace( '-scaled', '', $candidate_path );
 			// Check the file sizes first. It's a fast operation and will save us from having to do the md5 check.
 			if ( ! file_exists( $candidate_path ) || ( filesize( $candidate_path ) !== filesize( $filepath ) ) ) {
 				continue;

--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -207,7 +207,7 @@ class Attachments {
 
 			$candidate_path = get_attached_file( $attachment_id );
 			// Remove the "-scaled" suffix from the candidate path to check the original file size.
-			$candidate_path = str_replace( '-scaled', '', $candidate_path );
+			$candidate_path = self::remove_scaled_suffix_from_image_url( $candidate_path ) ?? $candidate_path;
 			// Check the file sizes first. It's a fast operation and will save us from having to do the md5 check.
 			if ( ! file_exists( $candidate_path ) || ( filesize( $candidate_path ) !== filesize( $filepath ) ) ) {
 				continue;
@@ -218,6 +218,45 @@ class Attachments {
 			}
 		}
 
+		return null;
+	}
+
+	/**
+	 * Remove the '-scaled' suffix from the image URL, or return null if the URL is not a scaled image.
+	 * 
+	 * @param string $url  The image URL.
+	 * @return string|null The image URL without the '-scaled' suffix, or null if $url does not contain a scaled image.
+	 */
+	public static function remove_scaled_suffix_from_image_url( string $url ): string|null {
+		
+		// Supported WordPress image extensions.
+		$wp_supported_extensions = [ 'jpg', 'jpeg', 'png', 'gif', 'webp' ];
+	
+		// Extract filename and extension from URL.
+		$parsed_url = wp_parse_url( $url );
+		if ( ! isset( $parsed_url['path'] ) ) {
+			return null;
+		}
+		$path     = $parsed_url['path'];
+		$filename = basename( $path );
+	
+		// Match WP-supported image filenames that end in -scaled.
+		if ( preg_match( '/^(.*)-scaled\.(' . implode( '|', $wp_supported_extensions ) . ')$/i', $filename, $matches ) ) {
+			// $new_filename = {str_before_scaled} + {str_extension}. phpignore: Squiz.PHP.CommentedOutCode.Found.
+			$new_filename = $matches[1] . '.' . $matches[2];
+	
+			// Replace the filename in the path.
+			$new_path = str_replace( $filename, $new_filename, $path );
+	
+			// Rebuild URL with the modified path and original query string
+			$rebuilt_url = ( isset( $parsed_url['scheme'] ) ? "{$parsed_url['scheme']}://" : '' ) .
+							( isset( $parsed_url['host'] ) ? "{$parsed_url['host']}" : '' ) .
+							$new_path .
+							( isset( $parsed_url['query'] ) ? "?{$parsed_url['query']}" : '' );
+	
+			return $rebuilt_url;
+		}
+	
 		return null;
 	}
 

--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -206,8 +206,6 @@ class Attachments {
 		foreach ( $attachment_ids as $attachment_id ) {
 
 			$candidate_path = get_attached_file( $attachment_id );
-			// Remove the "-scaled" suffix from the candidate path to check the original file size.
-			$candidate_path = str_replace( '-scaled', '', $candidate_path );
 			// Check the file sizes first. It's a fast operation and will save us from having to do the md5 check.
 			if ( ! file_exists( $candidate_path ) || ( filesize( $candidate_path ) !== filesize( $filepath ) ) ) {
 				continue;

--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -120,7 +120,7 @@ class Attachments {
 		if ( is_wp_error( $att_id ) ) {
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			@unlink( $file_array['tmp_name'] );
-			CliLog::get_logger( 'attachments' )->warning( $att_id->get_error_message() );
+			return new WP_Error( sprintf( 'File %s was not sideloaded: %s', $file_array['name'], $att_id->get_error_message() ) );
 		}
 
 		if ( $alt ) {
@@ -147,12 +147,10 @@ class Attachments {
 			$filename = basename( $filepath );
 		}
 
-		$filename = sanitize_file_name( $filename );
-
 		global $wpdb;
 
 		// Check if the file with same name exists in the DB.
-		$like = '%' . $wpdb->esc_like( $filename );
+		$like = '%' . $wpdb->esc_like( sanitize_file_name( $filename ) );
 
 		/*
 		 * Check if files with numeric suffix like `filename-1.jpg` exist in DB.
@@ -164,7 +162,7 @@ class Attachments {
 		 */
 		$filename_path_parts    = pathinfo( $filename );
 		$filename_before_suffix = $filename_path_parts['filename'];
-		$filename_after_suffix  = isset( $filename_path_parts['extension'] ) ? '.' . $filename_path_parts['extension'] : '';
+		$filename_after_suffix  = '.' . $filename_path_parts['extension'];
 		/**
 		 * Constructs a regular expression to find attachments that could be duplicates.
 		 * The regex matches filenames with optional numeric and "-scaled" suffixes,
@@ -192,21 +190,21 @@ class Attachments {
 		);
 
 		// The $regex_pattern is used with $wpdb->prepare, which will handle SQL escaping.
-		$sql            = $wpdb->prepare(
+		// phpcs:disable -- Direct SQL query is OK here and the filename is escaped.
+		$sql = $wpdb->prepare(
 			"SELECT post_id
 			FROM {$wpdb->postmeta}
 			WHERE meta_key = '_wp_attached_file'
 			AND meta_value REGEXP %s;",
 			$regex_pattern
 		);
+
 		$attachment_ids = $wpdb->get_col( $sql );
 		// phpcs:enable
 
 		foreach ( $attachment_ids as $attachment_id ) {
 
 			$candidate_path = get_attached_file( $attachment_id );
-			// remove the -scaled from the candidate path.
-			$candidate_path = str_replace( '-scaled', '', $candidate_path );
 			// Check the file sizes first. It's a fast operation and will save us from having to do the md5 check.
 			if ( ! file_exists( $candidate_path ) || ( filesize( $candidate_path ) !== filesize( $filepath ) ) ) {
 				continue;

--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -207,7 +207,7 @@ class Attachments {
 
 			$candidate_path = get_attached_file( $attachment_id );
 			// Remove the "-scaled" suffix from the candidate path to check the original file size.
-			$candidate_path = str_replace( '-scaled', '', $candidate_path );
+			$candidate_path = str_replace( '-scaled.', '.', $candidate_path );
 			// Check the file sizes first. It's a fast operation and will save us from having to do the md5 check.
 			if ( ! file_exists( $candidate_path ) || ( filesize( $candidate_path ) !== filesize( $filepath ) ) ) {
 				continue;

--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -207,7 +207,7 @@ class Attachments {
 
 			$candidate_path = get_attached_file( $attachment_id );
 			// Remove the "-scaled" suffix from the candidate path to check the original file size.
-			$candidate_path = self::remove_scaled_suffix_from_image_url( $candidate_path ) ?? $candidate_path;
+			$candidate_path = str_replace( '-scaled', '', $candidate_path );
 			// Check the file sizes first. It's a fast operation and will save us from having to do the md5 check.
 			if ( ! file_exists( $candidate_path ) || ( filesize( $candidate_path ) !== filesize( $filepath ) ) ) {
 				continue;
@@ -218,45 +218,6 @@ class Attachments {
 			}
 		}
 
-		return null;
-	}
-
-	/**
-	 * Remove the '-scaled' suffix from the image URL, or return null if the URL is not a scaled image.
-	 * 
-	 * @param string $url  The image URL.
-	 * @return string|null The image URL without the '-scaled' suffix, or null if $url does not contain a scaled image.
-	 */
-	public static function remove_scaled_suffix_from_image_url( string $url ): string|null {
-		
-		// Supported WordPress image extensions.
-		$wp_supported_extensions = [ 'jpg', 'jpeg', 'png', 'gif', 'webp' ];
-	
-		// Extract filename and extension from URL.
-		$parsed_url = wp_parse_url( $url );
-		if ( ! isset( $parsed_url['path'] ) ) {
-			return null;
-		}
-		$path     = $parsed_url['path'];
-		$filename = basename( $path );
-	
-		// Match WP-supported image filenames that end in -scaled.
-		if ( preg_match( '/^(.*)-scaled\.(' . implode( '|', $wp_supported_extensions ) . ')$/i', $filename, $matches ) ) {
-			// $new_filename = {str_before_scaled} + {str_extension}. phpignore: Squiz.PHP.CommentedOutCode.Found.
-			$new_filename = $matches[1] . '.' . $matches[2];
-	
-			// Replace the filename in the path.
-			$new_path = str_replace( $filename, $new_filename, $path );
-	
-			// Rebuild URL with the modified path and original query string
-			$rebuilt_url = ( isset( $parsed_url['scheme'] ) ? "{$parsed_url['scheme']}://" : '' ) .
-							( isset( $parsed_url['host'] ) ? "{$parsed_url['host']}" : '' ) .
-							$new_path .
-							( isset( $parsed_url['query'] ) ? "?{$parsed_url['query']}" : '' );
-	
-			return $rebuilt_url;
-		}
-	
 		return null;
 	}
 

--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -50,7 +50,7 @@ class Attachments {
 	 *                             Set this to false to skip the existing lookup if, for example, you are uploading two images that have the
 	 *                             same filename and binary data, but you need them to be unique attachments in the db, so they can have different
 	 *                             alt/captions and also different postmeta.
-	 * 
+	 *
 	 * @return int|WP_Error Attachment ID.
 	 */
 	public static function import_external_file( $path, $title = null, $caption = null, $description = null, $alt = null, $post_id = 0, $args = [], $desired_filename = '', $try_existing = true ) {
@@ -120,7 +120,7 @@ class Attachments {
 		if ( is_wp_error( $att_id ) ) {
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			@unlink( $file_array['tmp_name'] );
-			return new WP_Error( sprintf( 'File %s was not sideloaded: %s', $file_array['name'], $att_id->get_error_message() ) );
+			CliLog::get_logger( 'attachments' )->warning( $att_id->get_error_message() );
 		}
 
 		if ( $alt ) {
@@ -147,10 +147,12 @@ class Attachments {
 			$filename = basename( $filepath );
 		}
 
+		$filename = sanitize_file_name( $filename );
+
 		global $wpdb;
 
 		// Check if the file with same name exists in the DB.
-		$like = '%' . $wpdb->esc_like( sanitize_file_name( $filename ) );
+		$like = '%' . $wpdb->esc_like( $filename );
 
 		/*
 		 * Check if files with numeric suffix like `filename-1.jpg` exist in DB.
@@ -162,32 +164,40 @@ class Attachments {
 		 */
 		$filename_path_parts    = pathinfo( $filename );
 		$filename_before_suffix = $filename_path_parts['filename'];
-		$filename_after_suffix  = '.' . $filename_path_parts['extension'];
+		$filename_after_suffix  = isset( $filename_path_parts['extension'] ) ? '.' . $filename_path_parts['extension'] : '';
 		/**
-		 * Here's the regex explained:
-		 *  - .+ -- anything first
-		 *  - %s -- is for filename before suffix
-		 *  - -[0-9]+ -- dash and one or more numbers
-		 *  - \%s -- is for filename after suffix
+		 * Constructs a regular expression to find attachments that could be duplicates.
+		 * The regex matches filenames with optional numeric and "-scaled" suffixes,
+		 * where the "-scaled" suffix appears after any numeric suffix if both are present.
+		 * For a base filename like "myimage.jpg", it will match:
+		 * - myimage.jpg
+		 * - myimage-scaled.jpg
+		 * - myimage-1.jpg
+		 * - myimage-1-scaled.jpg
+		 * It also handles paths, e.g., "2023/10/myimage.jpg".
+		 *
+		 * Regex breakdown:
+		 *  - (?:^|.*\/) : Matches the beginning of the string or any characters followed by a slash.
+		 *                 This handles cases where the meta_value is just "filename.ext" or "path/to/filename.ext".
+		 *  - %s         : The base filename (e.g., "myimage"), after being escaped by preg_quote.
+		 *  - (-[0-9]+)? : Optionally matches a numeric suffix (e.g., "-1", "-123").
+		 *  - (-scaled)? : Optionally matches a "-scaled" suffix. This comes after the numeric suffix if present.
+		 *  - %s         : The file extension (e.g., "\.jpg"), after being escaped by preg_quote. The dot is escaped.
+		 *  - $          : Matches the end of the string.
 		 */
-		$regex_duplicates = esc_sql(
-			sprintf(
-				'.+%s-[0-9]+\\%s',
-				$filename_before_suffix,
-				$filename_after_suffix
-			)
+		$regex_pattern = sprintf(
+			'(?:^|.*/)%s(-[0-9]+)?(-scaled)?%s$',
+			preg_quote( $filename_before_suffix, '/' ),
+			preg_quote( $filename_after_suffix, '/' )
 		);
 
-		// phpcs:disable -- $regex_duplicates is properly sanitized.
-		$sql  = $wpdb->prepare(
+		// The $regex_pattern is used with $wpdb->prepare, which will handle SQL escaping.
+		$sql            = $wpdb->prepare(
 			"SELECT post_id
 			FROM {$wpdb->postmeta}
 			WHERE meta_key = '_wp_attached_file'
-			AND (
-			    meta_value LIKE '%s'
-				OR meta_value REGEXP '$regex_duplicates'
-			) ;",
-			$like
+			AND meta_value REGEXP %s;",
+			$regex_pattern
 		);
 		$attachment_ids = $wpdb->get_col( $sql );
 		// phpcs:enable
@@ -195,6 +205,8 @@ class Attachments {
 		foreach ( $attachment_ids as $attachment_id ) {
 
 			$candidate_path = get_attached_file( $attachment_id );
+			// remove the -scaled from the candidate path.
+			$candidate_path = str_replace( '-scaled', '', $candidate_path );
 			// Check the file sizes first. It's a fast operation and will save us from having to do the md5 check.
 			if ( ! file_exists( $candidate_path ) || ( filesize( $candidate_path ) !== filesize( $filepath ) ) ) {
 				continue;


### PR DESCRIPTION
## Changes
- Enhanced duplicate attachment detection with improved filename pattern matching
- Added support for detecting scaled image variants (e.g., `-scaled` suffix)
- Improved handling of numeric suffixes in filenames (e.g., `image-1.jpg`)
- Added better logging for broken attachment detection
- Added support for S3-hosted attachments in broken URL detection
- Added helper methods for attachment retrieval and image source handling

## Technical Details
- Implemented a more robust regex pattern for matching attachment filenames that handles:
  - Base filenames with optional numeric suffixes (e.g., `image-1.jpg`)
  - Scaled image variants (e.g., `image-scaled.jpg`, `image-1-scaled.jpg`)
  - Path-based filenames (e.g., `2023/10/image.jpg`)
- Added `get_attachment_image_src()` helper to bypass Jetpack's Photon CDN
- Improved error handling and logging for broken attachment detection
- Added support for S3-hosted attachments in the broken URL checker

## Testing Scenarios

### 1. Duplicate Attachment Detection

#### Normal Files (1-5MB)
1. **Basic Duplicate Detection**
   - Upload an image (e.g., `test-image.jpg`, ~2MB)
   - Try to upload the same image again
   - Expected: Should return the existing attachment ID instead of creating a duplicate
   - Verify in Media Library that only one copy exists

2. **Scaled Image Variants**
   - Upload a large image that triggers WordPress scaling (e.g., `large-image.jpg`, > 2560px)
   - Check that both original and `-scaled` versions are handled correctly
   - Try to upload the same image again
   - Expected: Should detect and return the  existing attachment ID
   - Verify both original and scaled versions are preserved

3. **Numeric Suffix Handling**
   - Upload `test-image-1.jpg` (~2MB)
   - Upload the same file again, this time renamed to `test-image.jpg`
   - Expected: Should return the existing attachment ID instead of creating a duplicate

#### Large Files (5MB+)
1. **Large File Duplicate Detection**
   - Upload a large image (e.g., `large-photo.jpg`, ~8MB)
   - Try to upload the same file again
   - Expected: Should return the existing attachment ID
   - Verify file integrity is maintained

2. **Large Scaled Images**
   - Upload a very large image (e.g., `huge-photo.jpg`, ~10MB)
   - Let WordPress create scaled versions
   - Try to upload the same file again
   - Expected: Should detect and return the existing attachment ID
   - Verify all scaled versions are properly handled
