### PR TITLE
feat(MultiLog): add method to retrieve logger for both CLI and file

### DIFF
--- a/src/Util/Log/MultiLog.php
+++ b/src/Util/Log/MultiLog.php
@@ -63,6 +63,17 @@ class MultiLog implements LoggerInterface {
 	}
 
 	/**
+	 * Get a logger that logs to both the CLI and the file.
+	 *
+	 * @param string $name    The name of the logger.
+	 *
+	 * @throws InvalidArgumentException If any of the loggers do not implement the LoggerInterface.
+	 */
+	public static function get_cli_and_file_logger( string $name ): LoggerInterface {
+		return self::get_logger( $name, [ CliLog::get_logger( $name ), FileLog::get_logger( $name ) ] );
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function log( $level, Stringable|string $message, array $context = [] ): void {


### PR DESCRIPTION
This PR adds a helper to get CLI and File Loggers with the same name.

```php
$log = MultiLog::get_cli_and_file_logger( 'my-logger' );

// instead of
$log = MultiLog::get_logger( 'my-logger', [ CliLog::get_logger( 'my-logger'), FileLog::get_logger( 'my-logger') ] );
```

Another way to do it would be to instantiate the MultiLog loggers inside its get_logger method.

```php
// In MultiLog
/**
 * Get a logger that logs to multiple loggers.
 *
 * @param string         $name    The name of the logger.
 * @param class-string[] $loggers_classes Array of logger classnames - each will log when this logger logs.
 *
 * @throws InvalidArgumentException If any of the loggers do not implement the LoggerInterface.
 */
public static function get_logger( string $name, array $loggers_classes ): LoggerInterface {
	$loggers_classes = array_values( array_filter( $loggers_classes, fn( $logger_class ) => is_subclass_of( $logger_class, LoggerInterface::class ) ) );
	$loggers         = array_map( fn( $logger_class ) => $logger_class::get_logger( $name ), $loggers_classes );
	$name            = self::get_name_from_name_and_loggers( $name, $loggers );
	$logger          = self::get_existing_logger( $name );
	if ( $logger ) {
		return $logger;
	}

	return new self( $name, $loggers );
}

// When you want to use it
$log = MultiLog::get_logger( 'my-logger', [ CliLog::class, FileLog::class ] );
```