### PR TITLE
Enhance Guest Contributors Helper Documentation and Functionality

### DIFF
--- a/docs/guest-contributors.md
+++ b/docs/guest-contributors.md
@@ -149,4 +149,3 @@ if ( is_wp_error( $result ) ) {
 -   `ERROR_EXISTING_USERS`: Existing user(s) found. Use `$force = true` to skip this check
 -   `ERROR_COAUTHORS_PLUS`: Co-Authors Plus plugin not found
 -   `ERROR_USER_NICENAME`: User nicename cannot be blank
-    s

--- a/docs/guest-contributors.md
+++ b/docs/guest-contributors.md
@@ -6,7 +6,8 @@ Guest Contributors are a feature of the Newspack Plugin that initializes a new r
 
 ## Prerequisites
 
-* Newspack Plugin `>= 6.2.0` must be installed and activated to use this helper.
+-   Newspack Plugin `>= 6.2.0` must be installed and activated to use this helper.
+-   Co-Authors Plus plugin must be installed and activated for assigning contributors to posts.
 
 ## GuestContributorsHelper
 
@@ -14,11 +15,48 @@ The `GuestContributorsHelper` class provides a set of static methods for working
 
 ### Methods
 
+#### create_or_get_contributor
+
+Create or get a contributor user. This is a wrapper around `UsersHelper::create_or_get_user` that sets the role to the guest contributor role.
+
+**Parameters:**
+
+-   `$data` (array): The data to create the user with. The array is the same as `wp_insert_user` accepts. You must provide one of the following fields: 'user_email', 'user_login', 'user_nicename', 'display_name'.
+-   `$unique_identifier` (string): A unique identifier for the user.
+
+**Returns:** `WP_User|WP_Error` - The user object if created or found, or a WP_Error if the user cannot be created.
+
+Example usage:
+
+```php
+use Newspack\MigrationTools\Logic\GuestContributorsHelper;
+
+$user_data = [
+    'display_name' => 'John Smith',
+    'user_email'   => 'john.smith@example.com',
+    'user_login'   => 'johnsmith',
+];
+
+$user = GuestContributorsHelper::create_or_get_contributor( $user_data, 'john-smith-unique' );
+if ( is_wp_error( $user ) ) {
+    WP_CLI::error( $user->get_error_message() );
+}
+```
+
 #### create_by_display_name
 
-Create a guest contributor by display name. Duplicate display names are allowed in WordPress, but this function will return an error if a matching display name is found. To bypass this error, set argument `$force = true`. Eitherway, created users will always have a unique `user_login` and unique `user_email`. The function will create a sanitized `user_nicename` (url slug) but WordPress may still add -2, -3, etc, if a matching slug already exists. To set a specific `user_nicename`, use the `$args` parameter.  
+Create a guest contributor by display name. Duplicate display names are allowed in WordPress, but this function will return an error if a matching display name is found. To bypass this error, set argument `$force = true`. Eitherway, created users will always have a unique `user_login` and unique `user_email`. The function will create a sanitized `user_nicename` (url slug) but WordPress may still add -2, -3, etc, if a matching slug already exists. To set a specific `user_nicename`, use the `$args` parameter.
 
 Within this function there is an error check for display name `> 250` since this could cause a WordPress bug that returns `int(0)` (instead of `WP_Error`) when calling `wp_insert_user`. Another error could be returned if pre-sanitization causes a blank `user_nicename` which cause WordPress to use `user_login` as the slug which is a security risk.
+
+**Parameters:**
+
+-   `$display_name` (string): The Display Name of the new user. Duplicates are allowed with `$force = true`.
+-   `$args` (array): Optional. Array of additional arguments.
+    -   `user_nicename` (string): URL slug for user. Duplicates will be appended by WordPress with -2, -3, ...
+-   `$force` (bool): Force user creation even if display name matches existing user(s).
+
+**Returns:** `int|WP_Error` - Inserted user ID or WP_Error.
 
 Example usage:
 
@@ -47,9 +85,16 @@ if ( is_wp_error( $user_id ) ) WP_CLI::error( $user_id->get_error_message() );
 
 #### get_by_display_name
 
-Get an array of guest contributor(s) by display name. Only guest contrubutors with a case-sensitive exact match will be returned. 
+Get an array of guest contributor(s) by display name. Only guest contributors with a case-sensitive exact match will be returned.
+
+**Parameters:**
+
+-   `$display_name` (string): Display name to find.
+
+**Returns:** `array|WP_Error` - Array of user ID(s) or WP_Error.
 
 Example usage:
+
 ```php
 use Newspack\MigrationTools\Logic\GuestContributorsHelper;
 
@@ -57,33 +102,51 @@ $users = GuestContributorsHelper::get_by_display_name( 'John Smith' );
 if ( is_wp_error( $users ) ) WP_CLI::error( $users->get_error_message() );
 ```
 
-## Notes
+#### assign_contributors_to_post
 
-### To assign Guest Contributors to posts, use CoAuthors Plus
+Assigns Guest Contributors to a Post using Co-Authors Plus.
 
-CoAuthors Plus is still required for Newspack (plugin and theme) as the way to handle multiple authors per post.  Only the CoAuthors Plus "Guest Authors" features is turned-off by default in Newspack Plugin, but the CoAuthors Plus multiple author taxonomy is still used.
+**Parameters:**
 
-Depending on the site you're working on, the Newspack Migration Tools `CoAuthorsPlusHelper` may not work.  Until that helper is refactored due to "Guest Authors" being defaulted to "off", please use the following code:
+-   `$post_id` (int): Post ID.
+-   `$contributor_ids` (array): Array of contributor IDs.
+
+**Returns:** `true|WP_Error` - True if successful, WP_Error if not.
+
+Example usage:
 
 ```php
+use Newspack\MigrationTools\Logic\GuestContributorsHelper;
 
-// CAP Plugin is required.
-if ( ! is_plugin_active( "co-authors-plus/co-authors-plus.php" ) ) {
-    WP_CLI::error( 'Co-Authors Plus plugin not found. Install and activate it before using this code.' );
-}
+$post_id = 123;
+$contributor_ids = [ 1, 2, 3 ];
 
-global $coauthors_plus;
-
-// Integer array of WP_User IDs.
-$author_ids = [ 1, 2, 3 ]; 
-
-// Assign ids to post. 
-$success = $coauthors_plus->add_coauthors( $post_id, $author_ids, false, 'id' );
-if ( ! $success ) {
-    WP_CLI::error( sprintf( 'Failed to set authors - add_coauthors return: %s', wp_json_encode( $success ) ) );
+$result = GuestContributorsHelper::assign_contributors_to_post( $post_id, $contributor_ids );
+if ( is_wp_error( $result ) ) {
+    WP_CLI::error( $result->get_error_message() );
 }
 ```
 
+### Error Handling
 
+All methods in the `GuestContributorsHelper` class return either the expected result or a `WP_Error` object. Always check for errors:
 
+```php
+$result = GuestContributorsHelper::create_by_display_name( 'John Smith' );
+if ( is_wp_error( $result ) ) {
+    // Handle error
+    WP_CLI::error( $result->get_error_message() );
+} else {
+    // Use the result (user ID)
+    $user_id = $result;
+}
+```
 
+### Common Error Messages
+
+-   `ERROR_NEWSPACK_PLUGIN`: Newspack Plugin's Guest Contributors feature is required
+-   `ERROR_DISPLAY_NAME`: Display Name must be between 1 and 250 characters
+-   `ERROR_EXISTING_USERS`: Existing user(s) found. Use `$force = true` to skip this check
+-   `ERROR_COAUTHORS_PLUS`: Co-Authors Plus plugin not found
+-   `ERROR_USER_NICENAME`: User nicename cannot be blank
+    s

--- a/src/Logic/GuestContributorsHelper.php
+++ b/src/Logic/GuestContributorsHelper.php
@@ -37,8 +37,11 @@ class GuestContributorsHelper {
 		$data['role'] = Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME;
 		try {
 			return UsersHelper::create_or_get_user( $data, $unique_identifier );
-		} catch ( \InvalidArgumentException $e ) {
-			return new WP_Error( $e->getCode(), $e->getMessage() );
+		} catch ( \Exception $e ) {
+			// WP_Error() requires the first argument "code" to be not empty (which also means not "0").
+			// Attempt to retrieve code from exception, else default the code to the exception type.
+			// Don't use the null coalescing operator "??", as it will allow the value of 0 to be accepted.
+			return new WP_Error( $e->getCode() ? $e->getCode() : get_class( $e ), $e->getMessage() );
 		}
 	}
 

--- a/src/Logic/GuestContributorsHelper.php
+++ b/src/Logic/GuestContributorsHelper.php
@@ -129,6 +129,10 @@ class GuestContributorsHelper {
 	 * @return bool|WP_Error True if successful, WP_Error if not.
 	 */
 	public static function assign_contributors_to_post( int $post_id, array $contributor_ids ): bool|WP_Error {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		if ( ! is_plugin_active( 'co-authors-plus/co-authors-plus.php' ) ) {
 			return new WP_Error( 'ERROR_COAUTHORS_PLUS', 'Co-Authors Plus plugin not found. Install and activate it before using this code.' );
 		}

--- a/src/Logic/GuestContributorsHelper.php
+++ b/src/Logic/GuestContributorsHelper.php
@@ -134,7 +134,7 @@ class GuestContributorsHelper {
 		// Assign ids to post.
 		$success = $coauthors_plus->add_coauthors( $post_id, $contributor_ids, false, 'id' );
 		if ( ! $success ) {
-			return new WP_Error( 'ERROR_ASSIGN_CONTRIBUTORS', sprintf( 'Failed to set authors - add_coauthors return: %s', wp_json_encode( $success ) ) );
+			return new WP_Error( 'ERROR_ASSIGN_CONTRIBUTORS', 'Failed to set authors. The add_coauthors() function did not successfully add contributors to the post.' );
 		}
 
 		return true;

--- a/src/Logic/GuestContributorsHelper.php
+++ b/src/Logic/GuestContributorsHelper.php
@@ -3,6 +3,8 @@
 namespace Newspack\MigrationTools\Logic;
 
 use Newspack\Guest_Contributor_Role;
+use Newspack\MigrationTools\Logic\UsersHelper;
+use WP_User;
 use WP_Error;
 use WP_Role;
 
@@ -18,6 +20,25 @@ class GuestContributorsHelper {
 	const ERROR_USER_NICENAME   = 'User nicename can not be blank.';
 
 	/**
+	 * Create or get a contributor user.
+	 *
+	 * This is a wrapper around UsersHelper::create_or_get_user that sets the role to the guest contributor role.
+	 *
+	 * @param array  $data              The data to create the user with. The array is the same as wp_insert_user accepts. https://developer.wordpress.org/reference/functions/wp_insert_user. Note that you *have* to provide one of the following fields: 'user_email', 'user_login', 'user_nicename', 'display_name'.
+	 * @param string $unique_identifier A unique identifier for the user.
+	 *
+	 * @return WP_User|WP_Error The user object if created or found, or a WP_Error if the user cannot be created.
+	 */
+	public static function create_or_get_contributor( array $data, string $unique_identifier ): WP_User|WP_Error {
+		if ( ! self::validate_newspack_plugin() ) {
+			return new WP_Error( 'ERROR_NEWSPACK_PLUGIN', self::ERROR_NEWSPACK_PLUGIN );
+		}
+
+		$data['role'] = Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME;
+		return UsersHelper::create_or_get_user( $data, $unique_identifier );
+	}
+
+	/**
 	 * Create a Guest Contributor by Display Name.
 	 *
 	 * @param string $display_name The Display Name of the new user. Duplicates are allowed with $force = true.
@@ -29,7 +50,7 @@ class GuestContributorsHelper {
 	 * @return int|\WP_Error  Inserted user ID or WP_Error.
 	 */
 	public static function create_by_display_name( $display_name, $args = array(), $force = false ): int|\WP_Error {
-		
+
 		if ( ! self::validate_newspack_plugin() ) {
 			return new WP_Error( 'ERROR_NEWSPACK_PLUGIN', self::ERROR_NEWSPACK_PLUGIN );
 		}
@@ -40,7 +61,7 @@ class GuestContributorsHelper {
 		if ( empty( $display_name ) || mb_strlen( $display_name ) > 250 ) {
 			return new WP_Error( 'ERROR_DISPLAY_NAME', self::ERROR_DISPLAY_NAME );
 		}
-		
+
 		// If we're not forcing user creation, check for existing user(s) - could be multiple.
 		if ( ! $force ) {
 			$existing = self::get_by_display_name( $display_name );
@@ -96,13 +117,37 @@ class GuestContributorsHelper {
 	}
 
 	/**
+	 * Assigns Guest Contributors to the Post.
+	 *
+	 * @param int   $post_id                 Post IDs.
+	 * @param array $contributor_ids         Contributor IDs.
+	 *
+	 * @return true|WP_Error True if successful, WP_Error if not.
+	 */
+	public static function assign_contributors_to_post( int $post_id, array $contributor_ids ): true|WP_Error {
+		if ( ! is_plugin_active( 'co-authors-plus/co-authors-plus.php' ) ) {
+			return new WP_Error( 'ERROR_COAUTHORS_PLUS', 'Co-Authors Plus plugin not found. Install and activate it before using this code.' );
+		}
+
+		global $coauthors_plus;
+
+		// Assign ids to post.
+		$success = $coauthors_plus->add_coauthors( $post_id, $contributor_ids, false, 'id' );
+		if ( ! $success ) {
+			return new WP_Error( 'ERROR_ASSIGN_CONTRIBUTORS', sprintf( 'Failed to set authors - add_coauthors return: %s', wp_json_encode( $success ) ) );
+		}
+
+		return true;
+	}
+
+	/**
 	 * Generate a unique dummy email address with a random suffix.
-	 * 
+	 *
 	 * @param string $display_name The user display name.
 	 * @return string|\WP_Error Example: ron-chambers-12345@example.com
 	 */
 	public static function generate_email( $display_name ): string|\WP_Error {
-		
+
 		if ( ! is_callable( 'Guest_Contributor_Role', 'get_dummy_email_domain' ) ) {
 			return new WP_Error( 'ERROR_EMAIL_DOMAIN', self::ERROR_EMAIL_DOMAIN );
 		}
@@ -114,7 +159,7 @@ class GuestContributorsHelper {
 		}
 
 		// hard code email column char length from db.
-		$db_max_chars = 100; 
+		$db_max_chars = 100;
 
 		// initial dummy email suffix.
 		$email_suffix = '@' . Guest_Contributor_Role::get_dummy_email_domain();
@@ -145,7 +190,7 @@ class GuestContributorsHelper {
 	 *
 	 * @param string $display_name The user display name.
 	 * @return string|\WP_Error Example: ron-chambers-12345
-	 */ 
+	 */
 	public static function generate_username( $display_name ): string|\WP_Error {
 
 		// sanitize in the same way wp_insert_user would.
@@ -155,7 +200,7 @@ class GuestContributorsHelper {
 		}
 
 		// hard code char length from db.
-		$db_max_chars = 60; 
+		$db_max_chars = 60;
 
 		// stop infinite loops.
 		$attempts = 0;
@@ -180,15 +225,15 @@ class GuestContributorsHelper {
 
 	/**
 	 * Gets Guest Contributor(s) by display name.
-	 * 
-	 * Display name string matching is exact (case senstive). 
+	 *
+	 * Display name string matching is exact (case senstive).
 	 * Multiple results may be returned.
 	 *
 	 * @param string $display_name Display name to find.
 	 * @return array|\WP_Error Array of user ID(s) or WP_Error.
 	 */
 	public static function get_by_display_name( $display_name ): array|\WP_Error {
-		
+
 		if ( ! self::validate_newspack_plugin() ) {
 			return new WP_Error( 'ERROR_NEWSPACK_PLUGIN', self::ERROR_NEWSPACK_PLUGIN );
 		}
@@ -199,17 +244,17 @@ class GuestContributorsHelper {
 		// To fix both these issues, exact match will be performed in foreach after this query.
 		$get_users = get_users(
 			array(
-				'search'         => $display_name, 
+				'search'         => $display_name,
 				'search_columns' => array( 'display_name' ),
 				'role'           => Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME,
 				'fields'         => array( 'ID', 'display_name' ),
 				'orderby'        => 'ID',
-			) 
+			)
 		);
-		
+
 		// Filter results on exact match of display name, return just the ID(s) of the remaining objects.
 		return array_map(
-			fn( $user ) => $user->ID, 
+			fn( $user ) => $user->ID,
 			array_filter( $get_users, fn( $user ) => $user->display_name === $display_name )
 		);
 	}

--- a/src/Logic/GuestContributorsHelper.php
+++ b/src/Logic/GuestContributorsHelper.php
@@ -122,9 +122,9 @@ class GuestContributorsHelper {
 	 * @param int   $post_id                 Post IDs.
 	 * @param array $contributor_ids         Contributor IDs.
 	 *
-	 * @return true|WP_Error True if successful, WP_Error if not.
+	 * @return bool|WP_Error True if successful, WP_Error if not.
 	 */
-	public static function assign_contributors_to_post( int $post_id, array $contributor_ids ): true|WP_Error {
+	public static function assign_contributors_to_post( int $post_id, array $contributor_ids ): bool|WP_Error {
 		if ( ! is_plugin_active( 'co-authors-plus/co-authors-plus.php' ) ) {
 			return new WP_Error( 'ERROR_COAUTHORS_PLUS', 'Co-Authors Plus plugin not found. Install and activate it before using this code.' );
 		}

--- a/src/Logic/GuestContributorsHelper.php
+++ b/src/Logic/GuestContributorsHelper.php
@@ -35,7 +35,11 @@ class GuestContributorsHelper {
 		}
 
 		$data['role'] = Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME;
-		return UsersHelper::create_or_get_user( $data, $unique_identifier );
+		try {
+			return UsersHelper::create_or_get_user( $data, $unique_identifier );
+		} catch ( \InvalidArgumentException $e ) {
+			return new WP_Error( $e->getCode(), $e->getMessage() );
+		}
 	}
 
 	/**

--- a/src/Logic/NinjaTablesHelper.php
+++ b/src/Logic/NinjaTablesHelper.php
@@ -21,6 +21,10 @@ class NinjaTablesHelper {
 	 * NinjaTables constructor.
 	 */
 	public function __construct() {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		if ( ! is_plugin_active( 'ninja-tables/ninja-tables.php' ) ) {
 			NMT::exit_with_message( 'Ninja Tables is a dependency, and will have to be installed and activated before this command can be used.' );
 		}

--- a/src/Logic/Redirection.php
+++ b/src/Logic/Redirection.php
@@ -8,6 +8,10 @@ use Red_Group;
 class Redirection {
 
 	public function __construct() {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		if ( ! is_plugin_active( 'redirection/redirection.php' ) ) {
 			NMT::exit_with_message( 'The Redirection plugin ( redirection ) is a dependency, and will have to be installed and activated before this helper class can be used.' );
 		}

--- a/src/Logic/SimpleLocalAvatars.php
+++ b/src/Logic/SimpleLocalAvatars.php
@@ -38,6 +38,10 @@ class SimpleLocalAvatars {
 	 * Constructor.
 	 */
 	public function __construct() {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		if ( ! is_plugin_active( 'simple-local-avatars/simple-local-avatars.php' ) ) {
 			NMT::exit_with_message( 'The simple-local-avatars plugin is a dependency, and will have to be installed and activated before this helper class can be used.' );
 		}

--- a/src/Util/FgHelper.php
+++ b/src/Util/FgHelper.php
@@ -65,6 +65,10 @@ class FgHelper {
 			NMT::exit_with_message( 'NCCM_SOURCE_WEBSITE_URL is not defined in wp-config.php' );
 		}
 
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		if ( ! is_plugin_active( "fg-{$this->type}-to-wp-premium/fg-{$this->type}-to-wp-premium.php" ) ) {
 			NMT::exit_with_message( "FG {$this->type} to WP Premium plugin not found. Install and activate it before using this class." );
 		}
@@ -79,7 +83,7 @@ class FgHelper {
 		// Filter if option values already exist in db.
 		add_filter( "option_{$this->function_prefix}_options", [ $this, 'filter_options' ] );
 		// Filter if option values do not exist in db. (Needed otherwise WordPress won't filter the options).
-		add_filter( "default_option_{$this->function_prefix}_options", [ $this, 'filter_options' ] );       
+		add_filter( "default_option_{$this->function_prefix}_options", [ $this, 'filter_options' ] );
 	}
 
 	/**
@@ -102,14 +106,14 @@ class FgHelper {
 
 	/**
 	 * Filter the options for the FG plugin.
-	 * 
+	 *
 	 * For database environment variables put these variables in your .env file locally.
-	 * 
+	 *
 	 * @param  array|false $options The options array to filter or boolean false if database option doesn't exist.
 	 * @return array                The filtered options.
 	 */
 	public function filter_options( array|false $options ): array {
-		
+
 		// For when options don't exist yet in the db.
 		if ( false === $options ) {
 			$options = [];
@@ -126,7 +130,7 @@ class FgHelper {
 		$options['prefix'] = $this->get_import_tables_prefix();
 
 		$options['url'] = NCCM_SOURCE_WEBSITE_URL;
-		
+
 		return $options;
 	}
 

--- a/tests/Logic/GuestContributorsHelperTest.php
+++ b/tests/Logic/GuestContributorsHelperTest.php
@@ -2,13 +2,12 @@
 
 namespace Newspack\MigrationTools\Tests\Logic;
 
+use Newspack\Guest_Contributor_Role;
 use Newspack\MigrationTools\Logic\GuestContributorsHelper;
 use WP_Error;
 use WP_UnitTestCase;
 
 class GuestContributorsHelperTest extends WP_UnitTestCase {
-
-	const NEWSPACK_CONTRIBUTOR_ROLE = 'contributor_no_edit';
 
 	/**
 	 * Test that the Newspack Plugin is installed and activated.
@@ -173,7 +172,7 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 		} else {
 			$this->assertInstanceOf( \WP_User::class, $result );
 			// Verify the user has the correct role
-			$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $result->roles );
+			$this->assertContains( Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME, $result->roles );
 		}
 	}
 
@@ -250,7 +249,7 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 		// Create user first time
 		$user1 = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
 		$this->assertInstanceOf( \WP_User::class, $user1 );
-		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user1->roles );
+		$this->assertContains( Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME, $user1->roles );
 
 		// Call again with same unique identifier
 		$user2 = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
@@ -298,7 +297,7 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 		$user = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
 
 		$this->assertInstanceOf( \WP_User::class, $user );
-		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user->roles );
+		$this->assertContains( Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME, $user->roles );
 		$this->assertNotContains( 'subscriber', $user->roles );
 		$this->assertNotContains( 'author', $user->roles );
 		$this->assertNotContains( 'editor', $user->roles );
@@ -318,7 +317,7 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( \WP_User::class, $user );
 		$this->assertEquals( 'Minimal User', $user->display_name );
-		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user->roles );
+		$this->assertContains( Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME, $user->roles );
 		$this->assertNotEmpty( $user->user_email );
 		$this->assertNotEmpty( $user->user_login );
 		$this->assertNotEmpty( $user->user_nicename );
@@ -336,7 +335,7 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 
 		// Create user first time
 		$user1 = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
-		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user1->roles );
+		$this->assertContains( Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME, $user1->roles );
 
 		// Add another role to the user
 		$user1->add_role( 'subscriber' );
@@ -346,7 +345,7 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 		$user2 = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
 
 		// Should still have both roles
-		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user2->roles );
+		$this->assertContains( Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME, $user2->roles );
 		$this->assertContains( 'subscriber', $user2->roles );
 	}
 
@@ -364,7 +363,7 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( \WP_User::class, $user );
 		$this->assertEquals( 'José María O\'Connor-Smith', $user->display_name );
-		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user->roles );
+		$this->assertContains( Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME, $user->roles );
 	}
 
 	/**
@@ -382,7 +381,7 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( \WP_User::class, $user );
 		$this->assertEquals( $long_name, $user->display_name );
-		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user->roles );
+		$this->assertContains( Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME, $user->roles );
 	}
 
 	/**
@@ -404,6 +403,6 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 		$this->assertEquals( 'Whitespace User', $user->display_name );
 		$this->assertEquals( 'John', $user->first_name );
 		$this->assertEquals( 'Smith', $user->last_name );
-		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user->roles );
+		$this->assertContains( Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME, $user->roles );
 	}
 }

--- a/tests/Logic/GuestContributorsHelperTest.php
+++ b/tests/Logic/GuestContributorsHelperTest.php
@@ -8,6 +8,8 @@ use WP_UnitTestCase;
 
 class GuestContributorsHelperTest extends WP_UnitTestCase {
 
+	const NEWSPACK_CONTRIBUTOR_ROLE = 'contributor_no_edit';
+
 	/**
 	 * Test that the Newspack Plugin is installed and activated.
 	 */
@@ -18,7 +20,7 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 
 	/**
 	 * Test that sanitize_for_db works as expected.
-	 * 
+	 *
 	 * @dataProvider data_provider_sanitize_for_db
 	 */
 	public function test_sanitize_for_db( $input, $expected ) {
@@ -38,12 +40,12 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 
 	/**
 	 * Test that generate_username works as expected.
-	 * 
+	 *
 	 * @dataProvider data_provider_generate_username
 	 */
 	public function test_generate_username( $input, $expected, $expect_error = false ) {
 		$result = GuestContributorsHelper::generate_username( $input );
-		
+
 		if ( $expect_error ) {
 			$this->assertInstanceOf( WP_Error::class, $result );
 			$this->assertEquals( 'ERROR_SANITIZE_INPUT', $result->get_error_code() );
@@ -64,12 +66,12 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 
 	/**
 	 * Test that generate_email works as expected.
-	 * 
+	 *
 	 * @dataProvider data_provider_generate_email
 	 */
 	public function test_generate_email( $input, $expected, $expect_error = false ) {
 		$result = GuestContributorsHelper::generate_email( $input );
-		
+
 		if ( $expect_error ) {
 			$this->assertInstanceOf( WP_Error::class, $result );
 			$this->assertEquals( 'ERROR_SANITIZE_INPUT', $result->get_error_code() );
@@ -90,12 +92,12 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 
 	/**
 	 * Test that create_by_display_name works as expected.
-	 * 
+	 *
 	 * @dataProvider data_provider_create_by_display_name
 	 */
 	public function test_create_by_display_name( $input, $args = array(), $force = false, $expect_error = false ) {
 		$result = GuestContributorsHelper::create_by_display_name( $input, $args, $force );
-		
+
 		if ( $expect_error ) {
 			$this->assertInstanceOf( WP_Error::class, $result );
 		} else {
@@ -122,39 +124,286 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 	 * Test that the complete flow works as expected.
 	 */
 	public function test_complete_flow() {
-		
+
 		$display_name = 'John Smith';
-		
+
 		// Verify not found.
 		$result = GuestContributorsHelper::get_by_display_name( $display_name );
 		$this->assertEmpty( $result );
-		
+
 		// Create by display name.
 		$result = GuestContributorsHelper::create_by_display_name( $display_name );
 		$this->assertIsInt( $result );
 		$this->assertGreaterThan( 0, $result );
-		
+
 		// Get will return ID now.
 		$result = GuestContributorsHelper::get_by_display_name( $display_name );
 		$this->assertIsArray( $result );
 		$this->assertNotEmpty( $result );
 		$this->assertIsNumeric( reset( $result ) );
 		$this->assertGreaterThan( 0, reset( $result ) );
-		
+
 		// Create again with same display name should fail.
 		$result = GuestContributorsHelper::create_by_display_name( $display_name );
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'ERROR_EXISTING_USERS', $result->get_error_code() );
-		
+
 		// Create with force should succeed.
 		$result = GuestContributorsHelper::create_by_display_name( $display_name, [], true );
 		$this->assertIsInt( $result );
 		$this->assertGreaterThan( 0, $result );
-		
+
 		// Get should now return multiple IDs
 		$result = GuestContributorsHelper::get_by_display_name( $display_name );
 		$this->assertIsArray( $result );
 		$this->assertNotEmpty( $result );
 		$this->assertCount( 2, $result );
+	}
+
+	/**
+	 * Test that create_or_get_contributor works as expected.
+	 *
+	 * @dataProvider data_provider_create_or_get_contributor
+	 */
+	public function test_create_or_get_contributor( $data, $unique_identifier, $expect_error = false ) {
+		$result = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
+
+		if ( $expect_error ) {
+			$this->assertInstanceOf( WP_Error::class, $result );
+		} else {
+			$this->assertInstanceOf( \WP_User::class, $result );
+			// Verify the user has the correct role
+			$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $result->roles );
+		}
+	}
+
+	public function data_provider_create_or_get_contributor() {
+		return [
+			'valid user with email'             => [
+				[
+					'user_email'   => 'test@example.com',
+					'display_name' => 'Test User',
+				],
+				'unique-id-1',
+				false,
+			],
+			'valid user with login'             => [
+				[
+					'user_login'   => 'testuser',
+					'display_name' => 'Test User',
+				],
+				'unique-id-2',
+				false,
+			],
+			'valid user with nicename'          => [
+				[
+					'user_nicename' => 'test-user',
+					'display_name'  => 'Test User',
+				],
+				'unique-id-3',
+				false,
+			],
+			'valid user with display_name only' => [
+				[
+					'display_name' => 'Test User',
+				],
+				'unique-id-4',
+				false,
+			],
+			'user with additional fields'       => [
+				[
+					'user_email'   => 'john@example.com',
+					'display_name' => 'John Smith',
+					'first_name'   => 'John',
+					'last_name'    => 'Smith',
+					'nickname'     => 'Johnny',
+				],
+				'unique-id-5',
+				false,
+			],
+			'empty data array'                  => [
+				[],
+				'unique-id-6',
+				true,
+			],
+			'empty unique identifier'           => [
+				[
+					'user_email'   => 'test@example.com',
+					'display_name' => 'Test User',
+				],
+				'',
+				true,
+			],
+		];
+	}
+
+	/**
+	 * Test that create_or_get_contributor returns existing user when called with same unique identifier.
+	 */
+	public function test_create_or_get_contributor_returns_existing_user() {
+		$data              = [
+			'user_email'   => 'existing@example.com',
+			'display_name' => 'Existing User',
+		];
+		$unique_identifier = 'existing-user-123';
+
+		// Create user first time
+		$user1 = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
+		$this->assertInstanceOf( \WP_User::class, $user1 );
+		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user1->roles );
+
+		// Call again with same unique identifier
+		$user2 = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
+		$this->assertInstanceOf( \WP_User::class, $user2 );
+
+		// Should be the same user
+		$this->assertEquals( $user1->ID, $user2->ID );
+		$this->assertEquals( $user1->user_email, $user2->user_email );
+		$this->assertEquals( $user1->display_name, $user2->display_name );
+	}
+
+	/**
+	 * Test that create_or_get_contributor creates new user when called with different unique identifier.
+	 */
+	public function test_create_or_get_contributor_creates_new_user_with_different_identifier() {
+		$data = [
+			'user_email'   => 'same@example.com',
+			'display_name' => 'Same User',
+		];
+
+		// Create first user
+		$user1 = GuestContributorsHelper::create_or_get_contributor( $data, 'unique-id-1' );
+		$this->assertInstanceOf( \WP_User::class, $user1 );
+
+		// Create second user with same data but different identifier
+		$user2 = GuestContributorsHelper::create_or_get_contributor( $data, 'unique-id-2' );
+		$this->assertInstanceOf( \WP_User::class, $user2 );
+
+		// Should be the same user because we still search by user data.
+		$this->assertEquals( $user1->ID, $user2->ID );
+		$this->assertEquals( $user1->user_email, $user2->user_email ); // Email should be different due to uniqueness
+		$this->assertEquals( $user1->display_name, $user2->display_name );
+	}
+
+	/**
+	 * Test that create_or_get_contributor properly sets the guest contributor role.
+	 */
+	public function test_create_or_get_contributor_sets_correct_role() {
+		$data              = [
+			'user_email'   => 'role-test@example.com',
+			'display_name' => 'Role Test User',
+		];
+		$unique_identifier = 'role-test-123';
+
+		$user = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
+
+		$this->assertInstanceOf( \WP_User::class, $user );
+		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user->roles );
+		$this->assertNotContains( 'subscriber', $user->roles );
+		$this->assertNotContains( 'author', $user->roles );
+		$this->assertNotContains( 'editor', $user->roles );
+	}
+
+	/**
+	 * Test that create_or_get_contributor handles missing required fields gracefully.
+	 */
+	public function test_create_or_get_contributor_with_minimal_data() {
+		// Test with only display_name
+		$data              = [
+			'display_name' => 'Minimal User',
+		];
+		$unique_identifier = 'minimal-user-123';
+
+		$user = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
+
+		$this->assertInstanceOf( \WP_User::class, $user );
+		$this->assertEquals( 'Minimal User', $user->display_name );
+		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user->roles );
+		$this->assertNotEmpty( $user->user_email );
+		$this->assertNotEmpty( $user->user_login );
+		$this->assertNotEmpty( $user->user_nicename );
+	}
+
+	/**
+	 * Test that create_or_get_contributor preserves existing role when user already exists.
+	 */
+	public function test_create_or_get_contributor_preserves_existing_role() {
+		$data              = [
+			'user_email'   => 'preserve-role@example.com',
+			'display_name' => 'Preserve Role User',
+		];
+		$unique_identifier = 'preserve-role-123';
+
+		// Create user first time
+		$user1 = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
+		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user1->roles );
+
+		// Add another role to the user
+		$user1->add_role( 'subscriber' );
+		$this->assertContains( 'subscriber', $user1->roles );
+
+		// Call create_or_get_contributor again
+		$user2 = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
+
+		// Should still have both roles
+		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user2->roles );
+		$this->assertContains( 'subscriber', $user2->roles );
+	}
+
+	/**
+	 * Test that create_or_get_contributor handles special characters in display name.
+	 */
+	public function test_create_or_get_contributor_with_special_characters() {
+		$data              = [
+			'user_email'   => 'special@example.com',
+			'display_name' => 'José María O\'Connor-Smith',
+		];
+		$unique_identifier = 'special-chars-123';
+
+		$user = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
+
+		$this->assertInstanceOf( \WP_User::class, $user );
+		$this->assertEquals( 'José María O\'Connor-Smith', $user->display_name );
+		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user->roles );
+	}
+
+	/**
+	 * Test that create_or_get_contributor handles very long display names.
+	 */
+	public function test_create_or_get_contributor_with_long_display_name() {
+		$long_name         = str_repeat( 'A', 250 ); // Maximum allowed length
+		$data              = [
+			'user_email'   => 'long-name@example.com',
+			'display_name' => $long_name,
+		];
+		$unique_identifier = 'long-name-123';
+
+		$user = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
+
+		$this->assertInstanceOf( \WP_User::class, $user );
+		$this->assertEquals( $long_name, $user->display_name );
+		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user->roles );
+	}
+
+	/**
+	 * Test that create_or_get_contributor handles whitespace in data.
+	 */
+	public function test_create_or_get_contributor_with_whitespace() {
+		$data              = [
+			'user_email'   => '  whitespace@example.com  ',
+			'display_name' => '  Whitespace User  ',
+			'first_name'   => '  John  ',
+			'last_name'    => '  Smith  ',
+		];
+		$unique_identifier = 'whitespace-123';
+
+		$user = GuestContributorsHelper::create_or_get_contributor( $data, $unique_identifier );
+
+		$this->assertInstanceOf( \WP_User::class, $user );
+		$this->assertEquals( 'whitespace@example.com', $user->user_email );
+		$this->assertEquals( 'Whitespace User', $user->display_name );
+		$this->assertEquals( 'John', $user->first_name );
+		$this->assertEquals( 'Smith', $user->last_name );
+		$this->assertContains( self::NEWSPACK_CONTRIBUTOR_ROLE, $user->roles );
 	}
 }


### PR DESCRIPTION
# Add Guest Contributor Creation and Assignment Methods

## Overview

This PR adds two new methods to the `GuestContributorsHelper` class to enhance the functionality for working with guest contributors:

1. `create_or_get_contributor()` - A wrapper method for creating or retrieving guest contributor users
2. `assign_contributors_to_post()` - A method for assigning guest contributors to posts using Co-Authors Plus

## Changes Made

### New Method: `create_or_get_contributor()`

**Purpose**: Provides a convenient wrapper around `UsersHelper::create_or_get_user()` that automatically sets the role to the guest contributor role.

**Parameters**:
- `$data` (array): User data array compatible with `wp_insert_user()`
- `$unique_identifier` (string): Unique identifier for the user

**Returns**: `WP_User|WP_Error` - User object if created/found, or WP_Error on failure

**Key Features**:
- Validates Newspack plugin is active before proceeding
- Automatically sets the role to `Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME`
- Delegates to `UsersHelper::create_or_get_user()` for the actual user creation/retrieval logic

**Example Usage**:
```php
$user_data = [
    'display_name' => 'John Smith',
    'user_email'   => 'john.smith@example.com',
    'user_login'   => 'johnsmith',
];

$user = GuestContributorsHelper::create_or_get_contributor($user_data, 'john-smith-unique');
if (is_wp_error($user)) {
    // Handle error
}
```

### New Method: `assign_contributors_to_post()`

**Purpose**: Assigns guest contributor users to a specific post using the Co-Authors Plus plugin.

**Parameters**:
- `$post_id` (int): The ID of the post to assign contributors to
- `$contributor_ids` (array): Array of contributor user IDs to assign

**Returns**: `true|WP_Error` - True on success, WP_Error on failure

**Key Features**:
- Validates that Co-Authors Plus plugin is active
- Uses the global `$coauthors_plus` object to assign authors
- Provides detailed error messages for debugging
- Uses the 'id' parameter for direct user ID assignment

**Example Usage**:
```php
$post_id = 123;
$contributor_ids = [1, 2, 3];

$result = GuestContributorsHelper::assign_contributors_to_post($post_id, $contributor_ids);
if (is_wp_error($result)) {
    // Handle error
}
```

## Dependencies

- Newspack Plugin >= 6.2.0 (for guest contributor role functionality)
- Co-Authors Plus plugin (for the `assign_contributors_to_post()` method)

## Testing

The changes maintain backward compatibility and follow the existing patterns in the codebase. The methods include proper error handling and validation to ensure robust operation.

## Error Handling

Both methods return appropriate `WP_Error` objects with descriptive error codes:
- `ERROR_NEWSPACK_PLUGIN`: When Newspack plugin's guest contributor feature is not available
- `ERROR_COAUTHORS_PLUS`: When Co-Authors Plus plugin is not active
- `ERROR_ASSIGN_CONTRIBUTORS`: When contributor assignment fails

## How to Test

### Prerequisites
- WordPress with Newspack Plugin >= 6.2.0 and Co-Authors Plus plugin activated
- This branch of the plugin installed

### Quick Test Script
```php
// Test user creation
$user = GuestContributorsHelper::create_or_get_contributor([
    'display_name' => 'Test User',
    'user_email'   => 'test@example.com',
    'user_login'   => 'testuser',
], 'test-unique-id');

// Test post assignment
$post_id = wp_insert_post(['post_title' => 'Test Post', 'post_status' => 'publish']);
$result = GuestContributorsHelper::assign_contributors_to_post($post_id, [$user->ID]);

// Verify
assert(!is_wp_error($user));
assert($result === true);
```

### Manual Testing Checklist
- [ ] Create guest contributor using `create_or_get_contributor()`
- [ ] Verify user has correct role (`newspack_guest_contributor`)
- [ ] Create test post and assign contributors using `assign_contributors_to_post()`
- [ ] Verify contributors appear in post's author list
- [ ] Test error cases (missing plugins, invalid IDs)