### PR TITLE
Fix specificMode argument to the homepage articles block

### DIFF
--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -1176,6 +1176,7 @@ HTML;
 
 			return [];
 		}
+		$args['specificMode']  = true;
 		$args['specificPosts'] = $post_ids;
 		if ( is_array( $args['className'] ?? false ) ) {
 			$args['className'] = implode( ' ', $args['className'] );


### PR DESCRIPTION
This PR fixes the `get_homepage_articles_for_specific_posts` block generator. Before this PR, that method generated a broken block because it was missing a parameter.

## Test This PR

1. Update the post content with the `method get_homepage_articles_for_specific_posts()`.

```php
// 1 is the ID of the updated post. 2 and 3 are two related posts.
global $wpdb;

$wpdb->update(
    $wpdb->posts,
    [ 'post_content' => serialize_block( $this->block_generator->get_homepage_articles_for_specific_posts( [ 2, 3 ], [] ) ) ],
    [ 'ID' => 1 ]
);
```

2. Check the post backend and notice how it loads all posts in the block.
3. Pull this PR.
4. Run the same code from step 1.
5. Check the post backend and notice that only the two posts are loaded in the block.