### PR TITLE
Add Simple Local Avatars initialization in constructor

### DIFF
--- a/src/Logic/SimpleLocalAvatars.php
+++ b/src/Logic/SimpleLocalAvatars.php
@@ -46,6 +46,10 @@ class SimpleLocalAvatars {
 			NMT::exit_with_message( 'The simple-local-avatars plugin is a dependency, and will have to be installed and activated before this helper class can be used.' );
 		}
 
+		if ( ! class_exists( 'Simple_Local_Avatars' ) ) {
+			require_once ABSPATH . 'wp-content/plugins/simple-local-avatars/simple-local-avatars.php';
+		}
+
 		$this->simple_local_avatars = new Simple_Local_Avatars();
 	}
 

--- a/src/Logic/SimpleLocalAvatars.php
+++ b/src/Logic/SimpleLocalAvatars.php
@@ -45,6 +45,8 @@ class SimpleLocalAvatars {
 		if ( ! is_plugin_active( 'simple-local-avatars/simple-local-avatars.php' ) ) {
 			NMT::exit_with_message( 'The simple-local-avatars plugin is a dependency, and will have to be installed and activated before this helper class can be used.' );
 		}
+
+		$this->simple_local_avatars = new Simple_Local_Avatars();
 	}
 
 	/**


### PR DESCRIPTION
Fix the Simple Local Avatar helper class.

## Test This PR

1. Set a user avatar using the `assign_avatar` method.

```php
// 1 is the user ID, 2 is the attachment ID.
$this->simple_local_avatars_logic = new SimpleLocalAvatars();
$this->simple_local_avatars_logic->assign_avatar( 1, 2 );
```

2. Notice the PHP error `Fatal error: Uncaught Error: Call to a member function assign_new_user_avatar() on null`
3. Pull this PR.
4. Re-run the code from step 1.
5. Check that the user got the avatar set in their profile.