### PR TITLE
Add filtered_items method to JsonIterator for JSON file item 

### DIFF
--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -1176,6 +1176,7 @@ HTML;
 
 			return [];
 		}
+		$args['specificMode']  = true;
 		$args['specificPosts'] = $post_ids;
 		if ( is_array( $args['className'] ?? false ) ) {
 			$args['className'] = implode( ' ', $args['className'] );

--- a/src/Logic/Posts.php
+++ b/src/Logic/Posts.php
@@ -738,7 +738,7 @@ SQL;
 	 */
 	public static function get_post_by_unique_identifier( string $unique_identifier ): int|false {
 		if ( empty( $unique_identifier ) ) {
-			FileLog::get_logger( 'Posts' )->error(
+			FileLog::get_logger( __CLASS__ )->error(
 				'Value is empty. Refusing to find a post with empty values.',
 				[
 					'unique_identifier' => $unique_identifier,

--- a/src/Logic/Posts.php
+++ b/src/Logic/Posts.php
@@ -25,6 +25,10 @@ class Posts {
 	 * @return int|WP_Error The post ID if created or found, or a WP_Error if the post cannot be created.
 	 */
 	public static function create_or_get_post( array $data, string $unique_identifier ): int|WP_Error {
+		// Validate that the unique identifier is not empty.
+		if ( empty( $unique_identifier ) ) {
+			return new WP_Error( 'empty_unique_identifier', __( 'The unique identifier cannot be empty.', 'newspack-migration-tools' ) );
+		}
 		// First try with the uniqid for the post.
 		$wp_post_id = self::get_post_by_unique_identifier( $unique_identifier );
 		if ( $wp_post_id ) { // Great – we already have the post!

--- a/src/Logic/Posts.php
+++ b/src/Logic/Posts.php
@@ -3,11 +3,46 @@
 namespace Newspack\MigrationTools\Logic;
 
 use Newspack\MigrationTools\Util\Log\CliLog;
+use Newspack\MigrationTools\Util\Log\FileLog;
+use WP_Post;
+use WP_Error;
 
 /**
  * Posts logic class.
  */
 class Posts {
+	/**
+	 * Meta key for the unique identifier for posts.
+	 */
+	public const UNIQUE_POST_IDENTIFIER_META_KEY = '_nmt_post_uniqid';
+
+	/**
+	 * Create or get a post.
+	 *
+	 * @param array  $data              The data to create the post with. The array is the same as wp_insert_post accepts. https://developer.wordpress.org/reference/functions/wp_insert_post.
+	 * @param string $unique_identifier The unique identifier for the post.
+	 *
+	 * @return int|WP_Error The post ID if created or found, or a WP_Error if the post cannot be created.
+	 */
+	public static function create_or_get_post( array $data, string $unique_identifier ): int|WP_Error {
+		// First try with the uniqid for the post.
+		$wp_post_id = self::get_post_by_unique_identifier( $unique_identifier );
+		if ( $wp_post_id ) { // Great – we already have the post!
+			return $wp_post_id;
+		}
+
+		// If it doesn't exist, then create it.
+		$wp_post_id = wp_insert_post( $data );
+		if ( is_wp_error( $wp_post_id ) ) {
+			return $wp_post_id;
+		}
+
+		// Set the unique identifier for the post.
+		update_post_meta( $wp_post_id, self::UNIQUE_POST_IDENTIFIER_META_KEY, $unique_identifier );
+
+		return $wp_post_id;
+	}
+
 	/**
 	 * @param string|array $post_type   Post type(s).
 	 * @param array        $post_status Post statuses.
@@ -685,5 +720,40 @@ SQL;
 		wp_cache_flush();
 
 		return $updated;
+	}
+
+	/**
+	 * Get a post by its unique identifier.
+	 *
+	 * The identifier was set when the post was created (if it was created by this class), so you probably know what it is.
+	 * Make sure you read the docs linked to at the top of the class.
+	 *
+	 * @param string $unique_identifier The unique identifier to search for.
+	 *
+	 * @return int|false The post ID if found, false otherwise.
+	 */
+	public static function get_post_by_unique_identifier( string $unique_identifier ): int|false {
+		if ( empty( $unique_identifier ) ) {
+			FileLog::get_logger( 'Posts' )->error(
+				'Value is empty. Refusing to find a post with empty values.',
+				[
+					'unique_identifier' => $unique_identifier,
+				]
+			);
+
+			return false;
+		}
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$post_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT post_id FROM $wpdb->postmeta WHERE meta_key = %s AND meta_value = %s LIMIT 1",
+				self::UNIQUE_POST_IDENTIFIER_META_KEY,
+				$unique_identifier
+			)
+		);
+
+		return empty( $post_id ) ? false : (int) $post_id;
 	}
 }

--- a/src/Util/JsonIterator.php
+++ b/src/Util/JsonIterator.php
@@ -117,7 +117,7 @@ class JsonIterator {
 	 *
 	 * @return iterable
 	 */
-	public function filtered_items( string $json_file, string $key, string $value ): iterable {
+	public function filtered_items( string $json_file, string $key, ?string $value = null ): iterable {
 		$file_exists = str_starts_with( $json_file, 'http' ) ? $this->url_responds( $json_file ) : file_exists( $json_file );
 
 		if ( ! $file_exists ) {
@@ -128,7 +128,13 @@ class JsonIterator {
 		try {
 			$items = Items::fromFile( $json_file );
 			foreach ( $items as $item ) {
-				if ( isset( $item->$key ) && $item->$key === $value ) {
+				// If value is null, only check if the key exists.
+				if ( null === $value ) {
+					if ( isset( $item->$key ) ) {
+						yield $item;
+					}
+				} elseif ( isset( $item->$key ) && $item->$key === $value ) {
+					// If value is set, check both key existence and value equality
 					yield $item;
 				}
 			}

--- a/src/Util/JsonIterator.php
+++ b/src/Util/JsonIterator.php
@@ -118,12 +118,25 @@ class JsonIterator {
 	 * @return iterable
 	 */
 	public function filtered_items( string $json_file, string $key, string $value ): iterable {
-		$items = Items::fromFile( $json_file );
-		foreach ( $items as $item ) {
-			if ( isset( $item->$key ) && $item->$key === $value ) {
-				yield $item;
-			}
+		$file_exists = str_starts_with( $json_file, 'http' ) ? $this->url_responds( $json_file ) : file_exists( $json_file );
+
+		if ( ! $file_exists ) {
+			NMT::exit_with_message( sprintf( 'File does not exist: %s', $json_file ), [ $this->file_logger ] );
+			return new \EmptyIterator();
 		}
+
+		try {
+			$items = Items::fromFile( $json_file );
+			foreach ( $items as $item ) {
+				if ( isset( $item->$key ) && $item->$key === $value ) {
+					yield $item;
+				}
+			}
+		} catch ( Exception $o_0 ) {
+			NMT::exit_with_message( sprintf( 'Could not read the JSON from: %s', $json_file ), [ $this->file_logger ] );
+		}
+
+		return new \EmptyIterator();
 	}
 
 	/**

--- a/src/Util/JsonIterator.php
+++ b/src/Util/JsonIterator.php
@@ -109,6 +109,24 @@ class JsonIterator {
 	}
 
 	/**
+	 * Will read a JSON file and return an iterable of objects from the JSON, filtered by a key and value.
+	 *
+	 * @param string $json_file Path to the JSON file – can be a URL too.
+	 * @param string $key       The key to filter by.
+	 * @param string $value     The value to filter by.
+	 *
+	 * @return iterable
+	 */
+	public function filtered_items( string $json_file, string $key, string $value ): iterable {
+		$items = Items::fromFile( $json_file );
+		foreach ( $items as $item ) {
+			if ( isset( $item->$key ) && $item->$key === $value ) {
+				yield $item;
+			}
+		}
+	}
+
+	/**
 	 * Will count number of entries in a JSON file where the root is an array.
 	 *
 	 * Handy for getting a "total" number for progress bars and such.
@@ -123,7 +141,7 @@ class JsonIterator {
 		if ( file_exists( $json_file_path ) ) {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
 			exec( 'cat ' . escapeshellarg( $json_file_path ) . " | jq 'length'", $count );
-			if ( ! empty( $count[0] ) ) {
+			if ( isset( $count[0] ) ) {
 				return (int) $count[0];
 			}
 		}

--- a/src/Util/JsonIterator.php
+++ b/src/Util/JsonIterator.php
@@ -101,8 +101,8 @@ class JsonIterator {
 
 		try {
 			return Items::fromFile( $json_file, $options );
-		} catch ( Exception $o_0 ) {
-			NMT::exit_with_message( sprintf( 'Could not read the JSON from: %s', $json_file ), [ $this->file_logger ] );
+		} catch ( Exception $e ) {
+			NMT::exit_with_message( sprintf( 'Could not read the JSON from "%s": %s', $json_file, $e->getMessage() ), [ $this->file_logger ] );
 		}
 
 		return new \EmptyIterator();
@@ -132,8 +132,8 @@ class JsonIterator {
 					yield $item;
 				}
 			}
-		} catch ( Exception $o_0 ) {
-			NMT::exit_with_message( sprintf( 'Could not read the JSON from: %s', $json_file ), [ $this->file_logger ] );
+		} catch ( Exception $e ) {
+			NMT::exit_with_message( sprintf( 'Could not read the JSON from "%s": %s', $json_file, $e->getMessage() ), [ $this->file_logger ] );
 		}
 
 		return new \EmptyIterator();

--- a/tests/Logic/PostsTest.php
+++ b/tests/Logic/PostsTest.php
@@ -433,7 +433,7 @@ class PostsTest extends WP_UnitTestCase {
 	 * Test creating a post with a future date.
 	 */
 	public function test_create_post_with_future_date() {
-		$future_date       = date( 'Y-m-d H:i:s', strtotime( '+1 day' ) );
+		$future_date       = gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) );
 		$post_data         = [
 			'post_title'   => 'Future Post',
 			'post_content' => 'Future content',

--- a/tests/Logic/PostsTest.php
+++ b/tests/Logic/PostsTest.php
@@ -1,0 +1,455 @@
+<?php
+/**
+ * Tests for the Posts class.
+ */
+
+namespace Newspack\MigrationTools\Tests\Logic;
+
+use Newspack\MigrationTools\Logic\Posts;
+use WP_UnitTestCase;
+use WP_Error;
+
+/**
+ * Test the Posts class.
+ */
+class PostsTest extends WP_UnitTestCase {
+	/**
+	 * The Posts instance.
+	 *
+	 * @var Posts
+	 */
+	private $posts;
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->posts = new Posts();
+	}
+
+	/**
+	 * Test creating a new post with valid data.
+	 */
+	public function test_create_new_post() {
+		$post_data         = [
+			'post_title'   => 'Test Post',
+			'post_content' => 'Test content',
+			'post_status'  => 'publish',
+			'post_type'    => 'post',
+		];
+		$unique_identifier = 'test-post-123';
+
+		$result = Posts::create_or_get_post( $post_data, $unique_identifier );
+
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		$post = get_post( $result );
+		$this->assertEquals( 'Test Post', $post->post_title );
+		$this->assertEquals( 'Test content', $post->post_content );
+		$this->assertEquals( 'publish', $post->post_status );
+		$this->assertEquals( 'post', $post->post_type );
+
+		// Check that the unique identifier meta was set
+		$meta_value = get_post_meta( $result, Posts::UNIQUE_POST_IDENTIFIER_META_KEY, true );
+		$this->assertEquals( $unique_identifier, $meta_value );
+	}
+
+	/**
+	 * Test getting an existing post by unique identifier.
+	 */
+	public function test_get_existing_post() {
+		$post_data         = [
+			'post_title'   => 'Existing Post',
+			'post_content' => 'Existing content',
+			'post_status'  => 'publish',
+			'post_type'    => 'post',
+		];
+		$unique_identifier = 'existing-post-456';
+
+		// Create the post first
+		$first_result = Posts::create_or_get_post( $post_data, $unique_identifier );
+		$this->assertIsInt( $first_result );
+
+		// Try to create/get the same post again
+		$second_result = Posts::create_or_get_post( $post_data, $unique_identifier );
+
+		$this->assertEquals( $first_result, $second_result );
+
+		// Verify the post wasn't duplicated
+		$post_count = get_posts(
+			[
+				'post_type'      => 'post',
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+			]
+		);
+		$this->assertCount( 1, $post_count );
+	}
+
+	/**
+	 * Test error when unique identifier is empty.
+	 */
+	public function test_error_empty_unique_identifier() {
+		$post_data = [
+			'post_title'   => 'Test Post',
+			'post_content' => 'Test content',
+			'post_status'  => 'publish',
+		];
+
+		$result = Posts::create_or_get_post( $post_data, '' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'empty_unique_identifier', $result->get_error_code() );
+		$this->assertEquals( 'The unique identifier cannot be empty.', $result->get_error_message() );
+	}
+
+	/**
+	 * Test creating a post with minimal required data.
+	 */
+	public function test_create_post_with_minimal_data() {
+		$post_data         = [
+			'post_title' => 'Minimal Post',
+		];
+		$unique_identifier = 'minimal-post-789';
+
+		$result = Posts::create_or_get_post( $post_data, $unique_identifier );
+
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		$post = get_post( $result );
+		$this->assertEquals( 'Minimal Post', $post->post_title );
+		$this->assertEquals( 'draft', $post->post_status ); // Default status
+		$this->assertEquals( 'post', $post->post_type ); // Default type
+	}
+
+	/**
+	 * Test creating a page instead of a post.
+	 */
+	public function test_create_page() {
+		$post_data         = [
+			'post_title'   => 'Test Page',
+			'post_content' => 'Page content',
+			'post_status'  => 'publish',
+			'post_type'    => 'page',
+		];
+		$unique_identifier = 'test-page-101';
+
+		$result = Posts::create_or_get_post( $post_data, $unique_identifier );
+
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		$post = get_post( $result );
+		$this->assertEquals( 'Test Page', $post->post_title );
+		$this->assertEquals( 'page', $post->post_type );
+	}
+
+	/**
+	 * Test creating a custom post type.
+	 */
+	public function test_create_custom_post_type() {
+		// Register a custom post type for testing
+		register_post_type(
+			'test_cpt',
+			[
+				'public' => true,
+				'label'  => 'Test CPT',
+			]
+		);
+
+		$post_data         = [
+			'post_title'   => 'Custom Post Type',
+			'post_content' => 'CPT content',
+			'post_status'  => 'publish',
+			'post_type'    => 'test_cpt',
+		];
+		$unique_identifier = 'custom-cpt-202';
+
+		$result = Posts::create_or_get_post( $post_data, $unique_identifier );
+
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		$post = get_post( $result );
+		$this->assertEquals( 'Custom Post Type', $post->post_title );
+		$this->assertEquals( 'test_cpt', $post->post_type );
+	}
+
+	/**
+	 * Test creating a post with all available fields.
+	 */
+	public function test_create_post_with_all_fields() {
+		$post_data         = [
+			'post_title'     => 'Full Post',
+			'post_content'   => 'Full content',
+			'post_excerpt'   => 'Post excerpt',
+			'post_status'    => 'publish',
+			'post_type'      => 'post',
+			'post_name'      => 'full-post-slug',
+			'post_author'    => 1,
+			'post_parent'    => 0,
+			'menu_order'     => 0,
+			'comment_status' => 'open',
+			'ping_status'    => 'open',
+		];
+		$unique_identifier = 'full-post-303';
+
+		$result = Posts::create_or_get_post( $post_data, $unique_identifier );
+
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		$post = get_post( $result );
+		$this->assertEquals( 'Full Post', $post->post_title );
+		$this->assertEquals( 'Full content', $post->post_content );
+		$this->assertEquals( 'Post excerpt', $post->post_excerpt );
+		$this->assertEquals( 'full-post-slug', $post->post_name );
+		$this->assertEquals( 1, $post->post_author );
+		$this->assertEquals( 'open', $post->comment_status );
+		$this->assertEquals( 'open', $post->ping_status );
+	}
+
+	/**
+	 * Test that posts with different unique identifiers are treated as separate posts.
+	 */
+	public function test_posts_with_different_unique_identifiers() {
+		$post_data = [
+			'post_title'   => 'Same Title Post',
+			'post_content' => 'Same content',
+			'post_status'  => 'publish',
+		];
+
+		$result1 = Posts::create_or_get_post( $post_data, 'unique-id-1' );
+		$result2 = Posts::create_or_get_post( $post_data, 'unique-id-2' );
+
+		$this->assertIsInt( $result1 );
+		$this->assertIsInt( $result2 );
+		$this->assertNotEquals( $result1, $result2 );
+
+		// Both posts should exist
+		$post1 = get_post( $result1 );
+		$post2 = get_post( $result2 );
+
+		$this->assertEquals( 'Same Title Post', $post1->post_title );
+		$this->assertEquals( 'Same Title Post', $post2->post_title );
+
+		// Check unique identifiers
+		$meta1 = get_post_meta( $result1, Posts::UNIQUE_POST_IDENTIFIER_META_KEY, true );
+		$meta2 = get_post_meta( $result2, Posts::UNIQUE_POST_IDENTIFIER_META_KEY, true );
+
+		$this->assertEquals( 'unique-id-1', $meta1 );
+		$this->assertEquals( 'unique-id-2', $meta2 );
+	}
+
+	/**
+	 * Test that updating post data doesn't affect existing post retrieval.
+	 */
+	public function test_update_post_data_doesnt_affect_retrieval() {
+		$original_data     = [
+			'post_title'   => 'Original Title',
+			'post_content' => 'Original content',
+			'post_status'  => 'publish',
+		];
+		$unique_identifier = 'update-test-404';
+
+		// Create the post
+		$post_id = Posts::create_or_get_post( $original_data, $unique_identifier );
+		$this->assertIsInt( $post_id );
+
+		// Try to create with updated data
+		$updated_data = [
+			'post_title'   => 'Updated Title',
+			'post_content' => 'Updated content',
+			'post_status'  => 'draft',
+		];
+
+		$result = Posts::create_or_get_post( $updated_data, $unique_identifier );
+
+		// Should return the same post ID
+		$this->assertEquals( $post_id, $result );
+
+		// The post should still have the original data (not updated)
+		$post = get_post( $post_id );
+		$this->assertEquals( 'Original Title', $post->post_title );
+		$this->assertEquals( 'Original content', $post->post_content );
+		$this->assertEquals( 'publish', $post->post_status );
+	}
+
+	/**
+	 * Test creating a post with special characters in the unique identifier.
+	 */
+	public function test_create_post_with_special_characters_in_identifier() {
+		$post_data         = [
+			'post_title'   => 'Special Chars Post',
+			'post_content' => 'Content with special chars',
+		];
+		$unique_identifier = 'special-chars-!@#$%^&*()_+-=[]{}|;:,.<>?';
+
+		$result = Posts::create_or_get_post( $post_data, $unique_identifier );
+
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		$meta_value = get_post_meta( $result, Posts::UNIQUE_POST_IDENTIFIER_META_KEY, true );
+		$this->assertEquals( $unique_identifier, $meta_value );
+	}
+
+	/**
+	 * Test creating a post with a very long unique identifier.
+	 */
+	public function test_create_post_with_long_identifier() {
+		$post_data         = [
+			'post_title'   => 'Long ID Post',
+			'post_content' => 'Content for long ID post',
+		];
+		$unique_identifier = str_repeat( 'a', 1000 ); // Very long identifier
+
+		$result = Posts::create_or_get_post( $post_data, $unique_identifier );
+
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		$meta_value = get_post_meta( $result, Posts::UNIQUE_POST_IDENTIFIER_META_KEY, true );
+		$this->assertEquals( $unique_identifier, $meta_value );
+	}
+
+	/**
+	 * Test creating a post with numeric unique identifier.
+	 */
+	public function test_create_post_with_numeric_identifier() {
+		$post_data         = [
+			'post_title'   => 'Numeric ID Post',
+			'post_content' => 'Content for numeric ID post',
+		];
+		$unique_identifier = '12345';
+
+		$result = Posts::create_or_get_post( $post_data, $unique_identifier );
+
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		$meta_value = get_post_meta( $result, Posts::UNIQUE_POST_IDENTIFIER_META_KEY, true );
+		$this->assertEquals( $unique_identifier, $meta_value );
+	}
+
+	/**
+	 * Test that the get_post_by_unique_identifier method works correctly.
+	 */
+	public function test_get_post_by_unique_identifier() {
+		$post_data         = [
+			'post_title'   => 'Get By ID Post',
+			'post_content' => 'Content for get by ID post',
+		];
+		$unique_identifier = 'get-by-id-505';
+
+		// Create the post
+		$post_id = Posts::create_or_get_post( $post_data, $unique_identifier );
+		$this->assertIsInt( $post_id );
+
+		// Get the post by unique identifier
+		$found_post_id = Posts::get_post_by_unique_identifier( $unique_identifier );
+
+		$this->assertEquals( $post_id, $found_post_id );
+	}
+
+	/**
+	 * Test that get_post_by_unique_identifier returns false for non-existent identifier.
+	 */
+	public function test_get_post_by_unique_identifier_not_found() {
+		$result = Posts::get_post_by_unique_identifier( 'non-existent-id' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that get_post_by_unique_identifier returns false for empty identifier.
+	 */
+	public function test_get_post_by_unique_identifier_empty() {
+		$result = Posts::get_post_by_unique_identifier( '' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test creating multiple posts and verifying they all have unique IDs.
+	 */
+	public function test_multiple_posts_have_unique_ids() {
+		$post_ids           = [];
+		$unique_identifiers = [];
+
+		// Create 10 posts
+		for ( $i = 1; $i <= 10; $i++ ) {
+			$post_data         = [
+				'post_title'   => "Post $i",
+				'post_content' => "Content for post $i",
+				'post_status'  => 'publish',
+			];
+			$unique_identifier = "post-$i-identifier";
+
+			$post_id              = Posts::create_or_get_post( $post_data, $unique_identifier );
+			$post_ids[]           = $post_id;
+			$unique_identifiers[] = $unique_identifier;
+		}
+
+		// All post IDs should be unique
+		$this->assertCount( 10, array_unique( $post_ids ) );
+
+		// All unique identifiers should be unique
+		$this->assertCount( 10, array_unique( $unique_identifiers ) );
+
+		// Verify each post has the correct meta
+		foreach ( $post_ids as $index => $post_id ) {
+			$meta_value = get_post_meta( $post_id, Posts::UNIQUE_POST_IDENTIFIER_META_KEY, true );
+			$this->assertEquals( $unique_identifiers[ $index ], $meta_value );
+		}
+	}
+
+	/**
+	 * Test creating a post with an empty title.
+	 */
+	public function test_wp_insert_post_error_handling() {
+		$post_data         = [
+			'post_title'   => '', // Empty title should not cause an error
+			'post_content' => 'Content',
+			'post_status'  => 'publish',
+		];
+		$unique_identifier = 'error-test-606';
+
+		$result = Posts::create_or_get_post( $post_data, $unique_identifier );
+
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		$post = get_post( $result );
+		$this->assertEquals( 'Content', $post->post_content );
+		$this->assertEquals( 'publish', $post->post_status );
+		$this->assertEquals( $unique_identifier, get_post_meta( $result, Posts::UNIQUE_POST_IDENTIFIER_META_KEY, true ) );
+	}
+
+	/**
+	 * Test creating a post with a future date.
+	 */
+	public function test_create_post_with_future_date() {
+		$future_date       = date( 'Y-m-d H:i:s', strtotime( '+1 day' ) );
+		$post_data         = [
+			'post_title'   => 'Future Post',
+			'post_content' => 'Future content',
+			'post_status'  => 'future',
+			'post_date'    => $future_date,
+		];
+		$unique_identifier = 'future-post-707';
+
+		$result = Posts::create_or_get_post( $post_data, $unique_identifier );
+
+		$this->assertIsInt( $result );
+		$this->assertGreaterThan( 0, $result );
+
+		$post = get_post( $result );
+		$this->assertEquals( 'Future Post', $post->post_title );
+		$this->assertEquals( 'future', $post->post_status );
+		$this->assertEquals( $future_date, $post->post_date );
+	}
+}

--- a/tests/Util/JsonIteratorTest.php
+++ b/tests/Util/JsonIteratorTest.php
@@ -41,7 +41,7 @@ class JsonIteratorTest extends WP_UnitTestCase {
 			[
 				'start'     => 10,
 				'num-items' => 42,
-			] 
+			]
 		);
 		$this->assertEquals( 10, $batch_args['start'] );
 		$this->assertEquals( 52, $batch_args['end'] );
@@ -103,11 +103,69 @@ class JsonIteratorTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test filtering items by key existence when value is null.
+	 *
+	 * @return void
+	 */
+	public function test_filtered_items_by_key_existence(): void {
+		$iterator = new JsonIterator();
+
+		// Test filtering by 'fruit' key existence (should return all items that have a fruit property)
+		$items_with_fruit = iterator_to_array( $iterator->filtered_items( self::$trees_json_file_path, 'fruit', null ) );
+
+		// Should return 3 items (Apple Tree, Orange Tree, Mango Tree) that have fruit values
+		$this->assertCount( 3, $items_with_fruit );
+		$this->assertEquals( 'Apple Tree', $items_with_fruit[0]->tree_name );
+		$this->assertEquals( 'Orange Tree', $items_with_fruit[1]->tree_name );
+		$this->assertEquals( 'Mango Tree', $items_with_fruit[2]->tree_name );
+
+		// Test filtering by 'metadata' key existence (should return all items)
+		$items_with_metadata = iterator_to_array( $iterator->filtered_items( self::$trees_json_file_path, 'metadata', null ) );
+		$this->assertCount( 5, $items_with_metadata );
+
+		// Test filtering by non-existent key (should return empty array)
+		$items_with_nonexistent = iterator_to_array( $iterator->filtered_items( self::$trees_json_file_path, 'nonexistent_key', null ) );
+		$this->assertCount( 0, $items_with_nonexistent );
+	}
+
+	/**
+	 * Test filtering items by key and specific value.
+	 *
+	 * @return void
+	 */
+	public function test_filtered_items_by_key_and_value(): void {
+		$iterator = new JsonIterator();
+
+		// Test filtering by 'type' with value 'fruit'
+		$fruit_trees = iterator_to_array( $iterator->filtered_items( self::$trees_json_file_path, 'type', 'fruit' ) );
+		$this->assertCount( 3, $fruit_trees );
+		$this->assertEquals( 'Apple Tree', $fruit_trees[0]->tree_name );
+		$this->assertEquals( 'Orange Tree', $fruit_trees[1]->tree_name );
+		$this->assertEquals( 'Mango Tree', $fruit_trees[2]->tree_name );
+
+		// Test filtering by 'type' with value 'non-fruit'
+		$non_fruit_trees = iterator_to_array( $iterator->filtered_items( self::$trees_json_file_path, 'type', 'non-fruit' ) );
+		$this->assertCount( 2, $non_fruit_trees );
+		$this->assertEquals( 'Maple Tree', $non_fruit_trees[0]->tree_name );
+		$this->assertEquals( 'Pine Tree', $non_fruit_trees[1]->tree_name );
+
+		// Test filtering by 'fruit' with value 'apple'
+		$apple_trees = iterator_to_array( $iterator->filtered_items( self::$trees_json_file_path, 'fruit', 'apple' ) );
+		$this->assertCount( 1, $apple_trees );
+		$this->assertEquals( 'Apple Tree', $apple_trees[0]->tree_name );
+
+		// Test filtering by non-existent value (should return empty array)
+		$nonexistent_value = iterator_to_array( $iterator->filtered_items( self::$trees_json_file_path, 'type', 'nonexistent' ) );
+		$this->assertCount( 0, $nonexistent_value );
+	}
+
+	/**
 	 * Mock the JsonIterator class for methods we can't use in unittests.
 	 *
-	 * @return JsonIterator
+	 * @param int $num_entries Number of entries to mock.
+	 * @return JsonIterator|MockObject
 	 */
-	private function get_mocked_iterator( int $num_entries ): JsonIterator {
+	private function get_mocked_iterator( int $num_entries ) {
 		$iterator_mock = $this->getMockBuilder( JsonIterator::class )
 								->onlyMethods( [ 'count_json_array_entries' ] )
 								->getMock();


### PR DESCRIPTION
This PR introduces a new method, `filtered_items`, to the `JsonIterator` class.
The new method allows you to iterate over objects in a JSON file and yield only objects with a specified key matching a specified value.

### New Method

```php
public function filtered_items( string $json_file, string $key, string $value ): iterable
```

- **$json_file:** Path or URL to a JSON file (root should be an array of objects).
- **$key:** The key to filter objects by.
- **$value:** The value must match the specified key.

### Usage Example

Given the following JSON file (save as `sample.json`):

```JSON
[
  { "id": 1, "type": "post", "author": "alice" },
  { "id": 2, "type": "page", "author": "bob" },
  { "id": 3, "type": "post", "author": "carol" },
  { "id": 4, "type": "post", "author": "bob" }
]
```

#### Example 1: Filter by type = "post"

```php
$iterator = new JsonIterator();
foreach ( $iterator->filtered_items( 'sample.json', 'type', 'post' ) as $item ) {
    print_r( $item );
}
```

Expected Output:

```php
stdClass Object
(
    [id] => 1
    [type] => post
    [author] => alice
)
stdClass Object
(
    [id] => 3
    [type] => post
    [author] => carol
)
stdClass Object
(
    [id] => 4
    [type] => post
    [author] => bob
)
```

#### Example 2: Filter by author = "bob"

```php
$iterator = new JsonIterator();
foreach ( $iterator->filtered_items( 'sample.json', 'author', 'bob' ) as $item ) {
    print_r( $item );
}
```

Expected Output:

```php
stdClass Object
(
    [id] => 2
    [type] => page
    [author] => bob
)
stdClass Object
(
    [id] => 4
    [type] => post
    [author] => bob
)
```

### Additional Changes

- Minor improvement: Use `isset` instead of `empty` when checking the result of `jq` in `count_json_array_entries`, because `jq` can return `0` when the JSON array is empty and this breaks the method.