### PR TITLE
Fix User Email Generation and User Lookup Logic

### DIFF
--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -232,10 +232,6 @@ class UsersHelper {
 
 		// First try with the uniqid for the user.
 		$wp_user = self::get_user_by_unique_identifier( $unique_identifier );
-		if ( ! $wp_user ) {
-			// OK, no unique identifier found, let's try to find the user by the data.
-			$wp_user = self::get_user( $data );
-		}
 		if ( $wp_user ) { // Great – we already have the user!
 			if ( ! empty( $data['role'] ) ) {
 				// If the role was passed in the data array – add it before returning.

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -150,20 +150,23 @@ class UsersHelper {
 	public static function get_unused_fake_email( string $desired_email ): string {
 		$original_email = $desired_email;
 		if ( strlen( $desired_email ) > 100 ) {
-			// If the email is too long, we'll peel off a couple of characters from the beginning.
-			$desired_email = substr( $desired_email, 4 );
+			// If the email is too long, we'll peel off characters till we get 96 characters.
+			$email_parts   = explode( '@', $desired_email );
+			$desired_email = substr( $email_parts[0], 0, ( 96 - strlen( $email_parts[1] ) - 1 ) ) . '@' . $email_parts[1];
 			FileLog::get_logger( 'UsersHelper' )->warning( sprintf( 'Shortened email to under 100 chars from "%s" to "%s".', $original_email, $desired_email ) );
 		}
 
+		$generated_email = $desired_email;
+
 		$i = 0;
-		while ( false !== get_user_by( 'email', $desired_email ) ) {
-			$desired_email = ( ++$i ) . $desired_email; // Prepend.
+		while ( false !== get_user_by( 'email', $generated_email ) ) {
+			$generated_email = ( ++$i ) . $desired_email; // Prepend.
 		}
 		if ( $i > 0 ) {
-			CliLog::get_logger( 'UsersHelper' )->debug( sprintf( 'Generated fake email: %s.', $desired_email ) );
+			CliLog::get_logger( 'UsersHelper' )->debug( sprintf( 'Generated fake email: %s.', $generated_email ) );
 		}
 
-		return $desired_email;
+		return $generated_email;
 	}
 
 	/**

--- a/tests/Logic/GuestContributorsHelperTest.php
+++ b/tests/Logic/GuestContributorsHelperTest.php
@@ -278,9 +278,9 @@ class GuestContributorsHelperTest extends WP_UnitTestCase {
 		$user2 = GuestContributorsHelper::create_or_get_contributor( $data, 'unique-id-2' );
 		$this->assertInstanceOf( \WP_User::class, $user2 );
 
-		// Should be the same user because we still search by user data.
-		$this->assertEquals( $user1->ID, $user2->ID );
-		$this->assertEquals( $user1->user_email, $user2->user_email ); // Email should be different due to uniqueness
+		// Should be the different user.
+		$this->assertNotEquals( $user1->ID, $user2->ID );
+		$this->assertNotEquals( $user1->user_email, $user2->user_email ); // Email should be different due to uniqueness
 		$this->assertEquals( $user1->display_name, $user2->display_name );
 	}
 

--- a/tests/Logic/TestUsersHelper.php
+++ b/tests/Logic/TestUsersHelper.php
@@ -157,4 +157,97 @@ class TestUsersHelper extends WP_UnitTestCase {
 		$should_also_be_shorter_and_different = UsersHelper::get_unused_nicename( $long_nicename );
 		$this->assertTrue( strlen( $should_also_be_shorter_and_different ) <= $max_length );
 	}
+
+	/**
+	 * Comprehensive test for get_unused_fake_email method.
+	 *
+	 * Tests various scenarios including the bug fix where long emails were not properly handled
+	 * when generating unique emails with prepended numbers.
+	 */
+	public function test_get_unused_fake_email_comprehensive() {
+		// Test 1: Basic functionality - email that doesn't exist
+		$test_email = 'test@example.com';
+		$result     = UsersHelper::get_unused_fake_email( $test_email );
+		$this->assertEquals( $test_email, $result );
+		$this->assertNotFalse( is_email( $result ) );
+
+		// Test 2: Email that already exists - should prepend a number
+		$existing_user = $this->factory()->user->create(
+			[
+				'user_email' => 'existing@example.com',
+			]
+		);
+		$result        = UsersHelper::get_unused_fake_email( 'existing@example.com' );
+		$this->assertNotEquals( 'existing@example.com', $result );
+		$this->assertStringStartsWith( '1', $result );
+		$this->assertStringEndsWith( 'existing@example.com', $result );
+		$this->assertNotFalse( is_email( $result ) );
+
+		// Test 3: Multiple existing emails - should increment the prepended number
+		$existing_user2 = $this->factory()->user->create(
+			[
+				'user_email' => '1existing@example.com',
+			]
+		);
+		$result         = UsersHelper::get_unused_fake_email( 'existing@example.com' );
+		$this->assertStringStartsWith( '2', $result );
+		$this->assertStringEndsWith( 'existing@example.com', $result );
+		$this->assertNotFalse( is_email( $result ) );
+
+		// Test 4: Email that is too long (>100 characters) - should be shortened
+		$long_email = str_repeat( 'a', 88 ) . '@example.com'; // 100 characters total (88 + 1 + 11)
+		$result     = UsersHelper::get_unused_fake_email( $long_email );
+		$this->assertEquals( 100, strlen( $result ) );
+		$this->assertNotFalse( is_email( $result ) );
+		$this->assertStringEndsWith( '@example.com', $result );
+
+		// Test 5: The bug fix - long email that needs to be shortened AND has conflicts
+		// This tests the critical bug where $original_email was used instead of $desired_email
+		$very_long_email           = str_repeat( 'b', 89 ) . '@example.com'; // 101 characters (89 + 1 + 11)
+		$very_long_email_shortened = str_repeat( 'b', 84 ) . '@example.com'; // 100 characters (84 + 1 + 11). peeled off 4 characters.
+		$existing_user3            = $this->factory()->user->create(
+			[
+				'user_email' => $very_long_email_shortened, // The shortened version
+			]
+		);
+		$result                    = UsersHelper::get_unused_fake_email( $very_long_email );
+		$this->assertLessThanOrEqual( 100, strlen( $result ) );
+		$this->assertStringStartsWith( '1', $result );
+		$this->assertStringEndsWith( '@example.com', $result );
+		$this->assertNotFalse( is_email( $result ) );
+
+		// Test 6: Multiple conflicts with long email
+		$existing_user4 = $this->factory()->user->create(
+			[
+				'user_email' => '1' . $very_long_email_shortened,
+			]
+		);
+		$result         = UsersHelper::get_unused_fake_email( $very_long_email );
+		$this->assertLessThanOrEqual( 100, strlen( $result ) );
+		$this->assertStringStartsWith( '2', $result );
+		$this->assertStringEndsWith( '@example.com', $result );
+		$this->assertNotFalse( is_email( $result ) );
+
+		// Test 7: Edge case - extremely long email
+		$extremely_long_email = str_repeat( 'c', 200 ) . '@example.com';
+		$result               = UsersHelper::get_unused_fake_email( $extremely_long_email );
+		$this->assertLessThanOrEqual( 100, strlen( $result ) );
+		$this->assertNotFalse( is_email( $result ) );
+
+		// Test 8: Empty string (edge case)
+		$result = UsersHelper::get_unused_fake_email( '' );
+		$this->assertFalse( is_email( $result ) );
+
+		// Test 9: Email with special characters
+		$special_email = 'test+tag@example.com';
+		$result        = UsersHelper::get_unused_fake_email( $special_email );
+		$this->assertEquals( $special_email, $result );
+		$this->assertNotFalse( is_email( $result ) );
+
+		// Test 10: Email that is exactly 100 characters
+		$exact_length_email = str_repeat( 'd', 88 ) . '@example.com'; // 100 characters (88 + 1 + 11)
+		$result             = UsersHelper::get_unused_fake_email( $exact_length_email );
+		$this->assertEquals( $exact_length_email, $result );
+		$this->assertNotFalse( is_email( $result ) );
+	}
 }

--- a/tests/Logic/TestUsersHelper.php
+++ b/tests/Logic/TestUsersHelper.php
@@ -159,10 +159,7 @@ class TestUsersHelper extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that create_or_get_user no longer falls back to looking for users by other fields
-	 * when the unique identifier is not found.
-	 *
-	 * This ensures that users are only found by their unique identifier, not by email, login, or nicename.
+	 * Test that ensures that create_or_get_user only looks for users by their unique identifier, not by email, login, or nicename.
 	 */
 	public function test_create_or_get_user_only_looks_by_unique_identifier() {
 		// Create a user with a specific unique identifier

--- a/tests/Logic/TestUsersHelper.php
+++ b/tests/Logic/TestUsersHelper.php
@@ -159,95 +159,59 @@ class TestUsersHelper extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Comprehensive test for get_unused_fake_email method.
+	 * Test that create_or_get_user no longer falls back to looking for users by other fields
+	 * when the unique identifier is not found.
 	 *
-	 * Tests various scenarios including the bug fix where long emails were not properly handled
-	 * when generating unique emails with prepended numbers.
+	 * This ensures that users are only found by their unique identifier, not by email, login, or nicename.
 	 */
-	public function test_get_unused_fake_email_comprehensive() {
-		// Test 1: Basic functionality - email that doesn't exist
-		$test_email = 'test@example.com';
-		$result     = UsersHelper::get_unused_fake_email( $test_email );
-		$this->assertEquals( $test_email, $result );
-		$this->assertNotFalse( is_email( $result ) );
+	public function test_create_or_get_user_only_looks_by_unique_identifier() {
+		// Create a user with a specific unique identifier
+		$user_data = [
+			'user_email'   => 'test@example.com',
+			'user_login'   => 'testuser',
+			'display_name' => 'Test User',
+		];
+		$unique_id = 'unique-123';
 
-		// Test 2: Email that already exists - should prepend a number
-		$existing_user = $this->factory()->user->create(
-			[
-				'user_email' => 'existing@example.com',
-			]
-		);
-		$result        = UsersHelper::get_unused_fake_email( 'existing@example.com' );
-		$this->assertNotEquals( 'existing@example.com', $result );
-		$this->assertStringStartsWith( '1', $result );
-		$this->assertStringEndsWith( 'existing@example.com', $result );
-		$this->assertNotFalse( is_email( $result ) );
+		$user1 = UsersHelper::create_or_get_user( $user_data, $unique_id );
+		$this->assertInstanceOf( 'WP_User', $user1 );
+		$this->assertEquals( 'test@example.com', $user1->user_email );
+		$this->assertEquals( 'testuser', $user1->user_login );
 
-		// Test 3: Multiple existing emails - should increment the prepended number
-		$existing_user2 = $this->factory()->user->create(
-			[
-				'user_email' => '1existing@example.com',
-			]
-		);
-		$result         = UsersHelper::get_unused_fake_email( 'existing@example.com' );
-		$this->assertStringStartsWith( '2', $result );
-		$this->assertStringEndsWith( 'existing@example.com', $result );
-		$this->assertNotFalse( is_email( $result ) );
+		// Test 1: Try to get the same user with the same unique identifier (should succeed)
+		$user2 = UsersHelper::create_or_get_user( $user_data, $unique_id );
+		$this->assertEquals( $user1->ID, $user2->ID );
+		$this->assertEquals( $user1->user_email, $user2->user_email );
 
-		// Test 4: Email that is too long (>100 characters) - should be shortened
-		$long_email = str_repeat( 'a', 88 ) . '@example.com'; // 100 characters total (88 + 1 + 11)
-		$result     = UsersHelper::get_unused_fake_email( $long_email );
-		$this->assertEquals( 100, strlen( $result ) );
-		$this->assertNotFalse( is_email( $result ) );
-		$this->assertStringEndsWith( '@example.com', $result );
+		// Test 2: Try to get a user with the same email but different unique identifier (should create new user)
+		$different_unique_id = 'unique-456';
+		$user3               = UsersHelper::create_or_get_user( $user_data, $different_unique_id );
+		$this->assertNotEquals( $user1->ID, $user3->ID );
+		$this->assertNotEquals( $user1->user_email, $user3->user_email ); // Should have different email due to conflict resolution
 
-		// Test 5: The bug fix - long email that needs to be shortened AND has conflicts
-		// This tests the critical bug where $original_email was used instead of $desired_email
-		$very_long_email           = str_repeat( 'b', 89 ) . '@example.com'; // 101 characters (89 + 1 + 11)
-		$very_long_email_shortened = str_repeat( 'b', 84 ) . '@example.com'; // 100 characters (84 + 1 + 11). peeled off 4 characters.
-		$existing_user3            = $this->factory()->user->create(
-			[
-				'user_email' => $very_long_email_shortened, // The shortened version
-			]
-		);
-		$result                    = UsersHelper::get_unused_fake_email( $very_long_email );
-		$this->assertLessThanOrEqual( 100, strlen( $result ) );
-		$this->assertStringStartsWith( '1', $result );
-		$this->assertStringEndsWith( '@example.com', $result );
-		$this->assertNotFalse( is_email( $result ) );
+		// Test 3: Try to get a user with the same login but different unique identifier (should create new user)
+		$user_data_same_login = [
+			'user_login'   => 'testuser',
+			'display_name' => 'Another Test User',
+		];
+		$another_unique_id    = 'unique-789';
+		$user4                = UsersHelper::create_or_get_user( $user_data_same_login, $another_unique_id );
+		$this->assertNotEquals( $user1->ID, $user4->ID );
+		$this->assertNotEquals( $user1->user_login, $user4->user_login ); // Should have different login due to conflict resolution
 
-		// Test 6: Multiple conflicts with long email
-		$existing_user4 = $this->factory()->user->create(
-			[
-				'user_email' => '1' . $very_long_email_shortened,
-			]
-		);
-		$result         = UsersHelper::get_unused_fake_email( $very_long_email );
-		$this->assertLessThanOrEqual( 100, strlen( $result ) );
-		$this->assertStringStartsWith( '2', $result );
-		$this->assertStringEndsWith( '@example.com', $result );
-		$this->assertNotFalse( is_email( $result ) );
+		// Test 4: Verify that all users have their respective unique identifiers
+		$this->assertEquals( $unique_id, get_user_meta( $user1->ID, UsersHelper::UNIQUE_IDENTIFIER_META_KEY, true ) );
+		$this->assertEquals( $different_unique_id, get_user_meta( $user3->ID, UsersHelper::UNIQUE_IDENTIFIER_META_KEY, true ) );
+		$this->assertEquals( $another_unique_id, get_user_meta( $user4->ID, UsersHelper::UNIQUE_IDENTIFIER_META_KEY, true ) );
 
-		// Test 7: Edge case - extremely long email
-		$extremely_long_email = str_repeat( 'c', 200 ) . '@example.com';
-		$result               = UsersHelper::get_unused_fake_email( $extremely_long_email );
-		$this->assertLessThanOrEqual( 100, strlen( $result ) );
-		$this->assertNotFalse( is_email( $result ) );
-
-		// Test 8: Empty string (edge case)
-		$result = UsersHelper::get_unused_fake_email( '' );
-		$this->assertFalse( is_email( $result ) );
-
-		// Test 9: Email with special characters
-		$special_email = 'test+tag@example.com';
-		$result        = UsersHelper::get_unused_fake_email( $special_email );
-		$this->assertEquals( $special_email, $result );
-		$this->assertNotFalse( is_email( $result ) );
-
-		// Test 10: Email that is exactly 100 characters
-		$exact_length_email = str_repeat( 'd', 88 ) . '@example.com'; // 100 characters (88 + 1 + 11)
-		$result             = UsersHelper::get_unused_fake_email( $exact_length_email );
-		$this->assertEquals( $exact_length_email, $result );
-		$this->assertNotFalse( is_email( $result ) );
+		// Test 5: Try to get a user with completely different data but same unique identifier (should return existing user)
+		$different_data = [
+			'user_email'   => 'different@example.com',
+			'user_login'   => 'differentuser',
+			'display_name' => 'Different User',
+		];
+		$user5          = UsersHelper::create_or_get_user( $different_data, $unique_id );
+		$this->assertEquals( $user1->ID, $user5->ID );
+		$this->assertEquals( $user1->user_email, $user5->user_email ); // Should return original user, not create new one
 	}
 }


### PR DESCRIPTION
## Overview

This PR addresses two critical issues in the `UsersHelper` class:

1. **Improved email shortening logic** - Fixes email generation to preserve domain parts while ensuring proper length constraints
2. **Enhanced user lookup behavior** - Ensures users are only retrieved by unique identifier, preventing unintended user matching

## Changes Made

### Fix 1: Improved Email Shortening Logic (`get_unused_fake_email`)

The previous implementation had a bug that caused long emails to be improperly shortened, potentially resulting in emails that were still too long or had truncated domains. It also appended the numbers prefix to the previously attempted email address.

**Solution**: Refactored the email shortening logic to:
- Preserve the full domain part when shortening emails
- Calculate the maximum local part length as `(96 - domain_length - 1)` to ensure total email stays under 100 characters
- Use `explode('@', $desired_email)` to properly separate local and domain parts
- Maintain email validity throughout the shortening process
- Append the count of iterations to the original email

### Fix 2: Unique Identifier Only User Lookup (`create_or_get_user`)

The method was falling back to searching for users by email, login, or nicename when the unique identifier wasn't found, which could lead to unintended user matching and data inconsistencies, which we were handling by generating fake unused email addresses, usernames, and nicenames.

**Solution**: Modified the user lookup logic to:
- Only search for users by their unique identifier
- Remove fallback searches by other fields (email, login, nicename)
- Ensure that users with the same email/login but different unique identifiers create separate user accounts
- Maintain data integrity by preventing accidental user merging

## How to Test

### Testing Fix 1: Email Shortening Logic

Run the new tests.

```bash
vendor/bin/phpunit tests/Logic/TestUsersHelper.php
```

**Manual Testing Steps**:
1. Create a user with a the same email address but different unique identifiers:

```php
   foreach ( range( 1, 10 ) as $i ) {
	$created_users[] = UsersHelper::create_or_get_user(
		[
			'user_login' => 'test' . $i,
			'user_email' => 'test@example.com',
		],
		'test' . $i 
	);
}
```

3. Check the email of the users created that have appended numbers like this

```
1test@example.com
21test@example.com
321test@example.com
...
```

4. Pull this PR and rerun the same code, and notice the appended numbers are fixed:

```
1test@example.com
2test@example.com
3test@example.com
...
```

### Testing Fix 2: Unique Identifier Only Lookup

Run the specific test for user lookup behavior:

**Manual Testing Steps**:
1. Create a user with specific data:
   ```php
   $user1 = UsersHelper::create_or_get_user([
       'user_email' => 'test@example.com',
       'user_login' => 'testuser',
       'display_name' => 'Test User'
   ], 'unique-123');
   ```

2. Try to create another user with the same email but a different unique identifier:
   ```php
   $user2 = UsersHelper::create_or_get_user([
       'user_email' => 'test@example.com',
       'user_login' => 'testuser',
       'display_name' => 'Test User'
   ], 'unique-456');
   ```

5. Verify that a new user is created (with a different email address)

**Expected Behavior**:
- Users with different unique identifiers should always create separate accounts
- Same unique identifier should always return the same user (regardless of other data)
- No fallback to email/login/nicename matching should occur
