### PR TITLE
Add CustomRedirectGenerator class for managing and generating redirects

### DIFF
--- a/src/Util/CustomRedirectGenerator.php
+++ b/src/Util/CustomRedirectGenerator.php
@@ -32,6 +32,7 @@ class CustomRedirectGenerator {
 
 		// Convert redirects to the required format
 		foreach ( $this->redirects as $redirect ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 			$redirects[] = '    ' . var_export( $redirect['from'], true ) . ' => ' . var_export( $redirect['to'], true );
 		}
 

--- a/src/Util/CustomRedirectGenerator.php
+++ b/src/Util/CustomRedirectGenerator.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Wrapper class for writing CSV files.
+ *
+ * @package Newspack\MigrationTools\Util
+ */
+
+namespace Newspack\MigrationTools\Util;
+
+use Exception;
+
+class CustomRedirectGenerator {
+	private $redirects = [];
+
+	public function __construct() {
+		$this->redirects = [];
+	}
+
+	public function add_redirect( $from, $to ) {
+		$this->redirects[] = [
+			'from' => $from,
+			'to'   => $to,
+		];
+	}
+
+	public function add_redirects( $redirects ) {
+		$this->redirects = array_merge( $this->redirects, $redirects );
+	}
+
+	public function generate_redirects() {
+		$redirects = [];
+
+		// Convert redirects to the required format
+		foreach ( $this->redirects as $redirect ) {
+			$redirects[] = "    '" . addslashes( $redirect['from'] ) . "' => '" . addslashes( $redirect['to'] ) . "'";
+		}
+
+		$redirects_string = implode( ",\n", $redirects );
+
+		return "<?php
+/**
+ * Newspack legacy redirects.
+ * 'From' keys are without trailing slashes or query parameters.
+ */
+\$redirects_from_to = [
+{$redirects_string}
+];
+
+// Clean up \$current_url.
+\$current_url    = \$_SERVER['REQUEST_URI'];
+\$query_position = strpos( \$current_url, '?' );
+if ( false !== \$query_position ) {
+    \$current_url = substr( \$current_url, 0, \$query_position );
+}
+\$current_url = rtrim( \$current_url, '/' );
+
+// Do redirect.
+if ( array_key_exists( \$current_url, \$redirects_from_to ) ) {
+    // Send all the headers.
+    header('HTTP/1.1 302 Moved Permanently');
+    header('cache-control: max-age=300, must-revalidate');
+    header('Location: ' . \$redirects_from_to[ \$current_url ] );
+    exit;
+}";
+	}
+
+	public function save_redirects() {
+		$content = $this->generate_redirects();
+		return file_put_contents( 'custom-redirects.php', $content );
+	}
+}

--- a/src/Util/CustomRedirectGenerator.php
+++ b/src/Util/CustomRedirectGenerator.php
@@ -32,7 +32,7 @@ class CustomRedirectGenerator {
 
 		// Convert redirects to the required format
 		foreach ( $this->redirects as $redirect ) {
-			$redirects[] = "    '" . addslashes( $redirect['from'] ) . "' => '" . addslashes( $redirect['to'] ) . "'";
+			$redirects[] = '    ' . var_export( $redirect['from'], true ) . ' => ' . var_export( $redirect['to'], true );
 		}
 
 		$redirects_string = implode( ",\n", $redirects );

--- a/src/Util/CustomRedirectGenerator.php
+++ b/src/Util/CustomRedirectGenerator.php
@@ -58,7 +58,7 @@ if ( false !== \$query_position ) {
 if ( array_key_exists( \$current_url, \$redirects_from_to ) ) {
     // Send all the headers.
     header('HTTP/1.1 302 Found');
-    header('cache-control: max-age=300, must-revalidate');
+    header('Cache-Control: max-age=300, must-revalidate');
     header('Location: ' . \$redirects_from_to[ \$current_url ] );
     exit;
 }";

--- a/src/Util/CustomRedirectGenerator.php
+++ b/src/Util/CustomRedirectGenerator.php
@@ -57,7 +57,7 @@ if ( false !== \$query_position ) {
 // Do redirect.
 if ( array_key_exists( \$current_url, \$redirects_from_to ) ) {
     // Send all the headers.
-    header('HTTP/1.1 302 Moved Permanently');
+    header('HTTP/1.1 302 Found');
     header('cache-control: max-age=300, must-revalidate');
     header('Location: ' . \$redirects_from_to[ \$current_url ] );
     exit;


### PR DESCRIPTION
# Add CustomRedirectGenerator utility class

## Overview

This PR introduces a new utility class `CustomRedirectGenerator` that provides a streamlined way to generate `custom-redirect.php` file.

## Features

### Core Functionality
- **Batch redirect management**: Add individual redirects or bulk import redirect arrays
- **PHP file generation**: Automatically generates a complete PHP redirect file with proper headers and logic
- **URL sanitization**: Handles URL escaping and trailing slash normalization
- **SEO-friendly redirects**: Implements 302 redirects with appropriate cache headers

### Key Methods
- `add_redirect($from, $to)`: Add a single redirect rule
- `add_redirects($redirects)`: Bulk import redirect rules
- `generate_redirects()`: Generate the complete PHP redirect code
- `save_redirects()`: Save the generated code to `custom-redirects.php`

## Example Usage

```php
use Newspack\MigrationTools\Util\CustomRedirectGenerator;

$generator = new CustomRedirectGenerator();

// Add individual redirects
$generator->add_redirect('/old-post-slug', '/new-post-slug');
$generator->add_redirect('/category/old-cat', '/new-category');

// Or bulk import
$redirects = [
    ['from' => '/old-url-1', 'to' => '/new-url-1'],
    ['from' => '/old-url-2', 'to' => '/new-url-2'],
];
$generator->add_redirects($redirects);

// Generate and save the redirect file
$generator->save_redirects();
```