### PR TITLE
Fix default logger level

### DIFF
--- a/src/Util/Log/Logger.php
+++ b/src/Util/Log/Logger.php
@@ -42,7 +42,7 @@ class Logger {
 		try {
 			$log_level = Level::fromName( $level );
 		} catch ( UnhandledMatchError $e ) {
-			$log_level = Level::fromName( Level::Info );
+			$log_level = Level::fromName( LogLevel::INFO );
 		}
 
 		if ( $exit_on_error ) {


### PR DESCRIPTION
This PR fixes the default log level set by the `Logger` Util class.