### PR TITLE
Add PostUpdateHook

### DIFF
--- a/src/Hooks/PostUpdateHook.php
+++ b/src/Hooks/PostUpdateHook.php
@@ -3,48 +3,48 @@
 namespace Newspack\MigrationTools\Hooks;
 
 class PostUpdateHook {
-    /**
-     * Attaches a callback to prevent updating post_modified and post_modified_gmt
-     * when a post is being updated.
-     * 
-     * @return void
-     */
-    public static function attach_hook_to_prevent_modified_date_update(): void {
-        add_filter( 'wp_insert_post_data', [ __CLASS__, 'fallback_to_current_post_modified_datetime' ], 10, 4 );
-    }
+	/**
+	 * Attaches a callback to prevent updating post_modified and post_modified_gmt
+	 * when a post is being updated.
+	 * 
+	 * @return void
+	 */
+	public static function attach_hook_to_prevent_modified_date_update(): void {
+		add_filter( 'wp_insert_post_data', [ __CLASS__, 'fallback_to_current_post_modified_datetime' ], 10, 4 );
+	}
 
-    /**
-     * Detaches a callback to prevent updating post_modified and post_modified_gmt
-     * when a post is being updated.
-     * 
-     * @return void
-     */
-    public static function detach_hook_to_prevent_modified_date_update(): void {
-        remove_filter( 'wp_insert_post_data', [ __CLASS__, 'fallback_to_current_post_modified_datetime' ], 10 );
-    }
+	/**
+	 * Detaches a callback to prevent updating post_modified and post_modified_gmt
+	 * when a post is being updated.
+	 * 
+	 * @return void
+	 */
+	public static function detach_hook_to_prevent_modified_date_update(): void {
+		remove_filter( 'wp_insert_post_data', [ __CLASS__, 'fallback_to_current_post_modified_datetime' ], 10 );
+	}
 
-    /**
-     * Prevents updating the `post_modifed` and `post_modified_gmt` fields when updating a post.
-     * 
-     * The `$postarr` parameter contains the post object prior to being updated. The method
-     * below uses the original `post_modified` and `post_modified_gmt` values from there.
-     * 
-     * @see https://developer.wordpress.org/reference/hooks/wp_insert_post_data/
-     * 
-     * @param $data array An array of slashed, sanitized, and processed post data.
-     * @param $postarr array An array of sanitized (and slashed) but otherwise unmodified post data.
-     * @param $unsanitized_postarr array An array of slashed yet *unsanitized* and unprocessed post data as originally passed to wp_insert_post().
-     * @param $update bool Whether this is an existing post being updated.
-     * @return array The post data to update.
-     */
-    public static function fallback_to_current_post_modified_datetime( $data, $postarr, $unsanitized_postarr, $update ) {
-        if ( ! $update ) {
-            return $data;
-        }
+	/**
+	 * Prevents updating the `post_modifed` and `post_modified_gmt` fields when updating a post.
+	 * 
+	 * The `$postarr` parameter contains the post object prior to being updated. The method
+	 * below uses the original `post_modified` and `post_modified_gmt` values from there.
+	 * 
+	 * @see https://developer.wordpress.org/reference/hooks/wp_insert_post_data/
+	 * 
+	 * @param array $data An array of slashed, sanitized, and processed post data.
+	 * @param array $postarr An array of sanitized (and slashed) but otherwise unmodified post data.
+	 * @param array $unsanitized_postarr An array of slashed yet *unsanitized* and unprocessed post data as originally passed to wp_insert_post().
+	 * @param bool  $update Whether this is an existing post being updated.
+	 * @return array The post data to update.
+	 */
+	public static function fallback_to_current_post_modified_datetime( $data, $postarr, $unsanitized_postarr, $update ) {
+		if ( ! $update ) {
+			return $data;
+		}
 
-        $data['post_modified']     = $postarr['post_modified'];
-        $data['post_modified_gmt'] = $postarr['post_modified_gmt'];
+		$data['post_modified']     = $postarr['post_modified'];
+		$data['post_modified_gmt'] = $postarr['post_modified_gmt'];
 
-        return $data;
-    }
+		return $data;
+	}
 }

--- a/src/Hooks/PostUpdateHook.php
+++ b/src/Hooks/PostUpdateHook.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Newspack\MigrationTools\Hooks;
+
+class PostUpdateHook {
+    /**
+     * Attaches a callback to prevent updating post_modified and post_modified_gmt
+     * when a post is being updated.
+     * 
+     * @return void
+     */
+    public static function attach_hook_to_prevent_modified_date_update(): void {
+        add_filter( 'wp_insert_post_data', [ __CLASS__, 'fallback_to_current_post_modified_datetime' ], 10, 4 );
+    }
+
+    /**
+     * Detaches a callback to prevent updating post_modified and post_modified_gmt
+     * when a post is being updated.
+     * 
+     * @return void
+     */
+    public static function detach_hook_to_prevent_modified_date_update(): void {
+        remove_filter( 'wp_insert_post_data', [ __CLASS__, 'fallback_to_current_post_modified_datetime' ], 10 );
+    }
+
+    /**
+     * Prevents updating the `post_modifed` and `post_modified_gmt` fields when updating a post.
+     * 
+     * The `$postarr` parameter contains the post object prior to being updated. The method
+     * below uses the original `post_modified` and `post_modified_gmt` values from there.
+     * 
+     * @see https://developer.wordpress.org/reference/hooks/wp_insert_post_data/
+     * 
+     * @param $data array An array of slashed, sanitized, and processed post data.
+     * @param $postarr array An array of sanitized (and slashed) but otherwise unmodified post data.
+     * @param $unsanitized_postarr array An array of slashed yet *unsanitized* and unprocessed post data as originally passed to wp_insert_post().
+     * @param $update bool Whether this is an existing post being updated.
+     * @return array The post data to update.
+     */
+    public static function fallback_to_current_post_modified_datetime( $data, $postarr, $unsanitized_postarr, $update ) {
+        if ( ! $update ) {
+            return $data;
+        }
+
+        $data['post_modified']     = $postarr['post_modified'];
+        $data['post_modified_gmt'] = $postarr['post_modified_gmt'];
+
+        return $data;
+    }
+}

--- a/src/Logic/Posts.php
+++ b/src/Logic/Posts.php
@@ -2,6 +2,7 @@
 
 namespace Newspack\MigrationTools\Logic;
 
+use Newspack\MigrationTools\Hooks\PostUpdateHook;
 use Newspack\MigrationTools\Util\Log\CliLog;
 use Newspack\MigrationTools\Util\Log\FileLog;
 use WP_Post;
@@ -759,5 +760,33 @@ SQL;
 		);
 
 		return empty( $post_id ) ? false : (int) $post_id;
+	}
+
+	/**
+	 * Shorthand for updating a post without touching the post_modified and post_modified_gmt fields.
+	 *
+	 * Parameters are the same as for wp_update_post.
+	 *
+	 * @static
+	 * @access public
+	 *
+	 * @uses \Newspack\MigrationTools\Hooks\PostUpdateHook
+	 * @see https://developer.wordpress.org/reference/functions/wp_update_post/
+	 *
+	 * @param array|object $postarr          Optional. Post data. Arrays are expected to be escaped,
+	 *                                       objects are not. See wp_insert_post() for accepted arguments.
+	 *                                       Default array.
+	 * @param bool         $wp_error         Optional. Whether to return a WP_Error on failure. Default false.
+	 * @param bool         $fire_after_hooks Optional. Whether to fire the after insert hooks. Default true.
+	 * @return int|WP_Error The post ID on success. The value 0 or WP_Error on failure.
+	 */
+	public static function update_post_without_modified_date( $postarr = array(), $wp_error = false, $fire_after_hooks = true ) {
+		PostUpdateHook::attach_hook_to_prevent_modified_date_update();
+
+		$result = wp_update_post( $postarr, $wp_error, $fire_after_hooks );
+
+		PostUpdateHook::detach_hook_to_prevent_modified_date_update();
+
+		return $result;
 	}
 }


### PR DESCRIPTION
## Overview

Occasionally, we need to update a Post but without updating the `post_modified` and `post_modified_gmt` post fields.

By using `wp_update_post`, this cannot be prevented by default. The alternative was to use a direct `$wpdb->update` call, but by doing so, we are missing a lot of extra features around `wp_update_post`.

Those include:
* having an automatically generated Revision for the updated post
* making sure that the `post_name` is unique in the `post_type`

The `PostUpdateHook` class in this PR solves the initial issue by hooking a function just before the post is updated and setting the `post_modified` and `post_modified_gmt` fields to the current ones.

## API

The `\Newspack\MigrationTools\Hooks\PostUpdateHook` class contains three static methods.

`attach_hook_to_prevent_modified_date_update()`

This method registers the callback. Make sure to call it before using `wp_update_post`.

---

`detach_hook_to_prevent_modified_date_update()`

This method unregisters the callback. Make sure to call it after using `wp_update_post`.

---

`fallback_to_current_post_modified_datetime()`

This method is the callback used that handles using the original `post_modified` and `post_modified_gmt` fields.

## How to Use

You can use the following snippet and replace the placeholders with some real data.

```php
\Newspack\MigrationTools\Hooks\PostUpdateHook::attach_hook_to_prevent_modified_date_update();

wp_update_post(
	[
		'ID' => {POST_ID},
		'post_content' => {POST_CONTENT},
	]
);

\Newspack\MigrationTools\Hooks\PostUpdateHook::detach_hook_to_prevent_modified_date_update();
```

## Caveats

👉 Make sure the post that is being updated supports revisions.
👉 When the updated post doesn't have Revisions prior to the update, the first revision will be the latest (updated) Post Content, so you may not see the Revisions Count in WP Admin.

## Automated Tests

// TODO