### PR TITLE
Add missing user_login sanitization in create_or_get_user

### DIFF
--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -133,7 +133,8 @@ class UsersHelper {
 			$desired_username = trim( mb_substr( $desired_username, 0, strpos( $desired_username, '@' ) ) );
 		}
 
-		$desired_username = sanitize_user( $desired_username );
+		// Sanitize the username the same way that wp_insert_user() sanitizes it (with $strict = true).
+		$desired_username = sanitize_user( $desired_username, true );
 
 		if ( empty( $desired_username ) ) {
 			throw new InvalidArgumentException( 'Sanitation of desired username results in empty string, please choose another username.' );
@@ -341,8 +342,7 @@ class UsersHelper {
 			}
 		}
 
-		// Sanitize the user login in the same way that wp_insert_user() does it (@see \wp_insert_user()).
-		$user_login = sanitize_user( $user_login, true );
+		// Note that the $user_login will be further sanitized in get_unused_username call below.
 
 		if ( empty( $data['user_pass'] ) ) {
 			$data['user_pass'] = wp_generate_password( 42 );

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -341,6 +341,9 @@ class UsersHelper {
 			}
 		}
 
+		// Sanitize the user login in the same way that wp_insert_user() does it (@see \wp_insert_user()).
+		$user_login = sanitize_user( $user_login, true );
+
 		if ( empty( $data['user_pass'] ) ) {
 			$data['user_pass'] = wp_generate_password( 42 );
 		}


### PR DESCRIPTION
## Issue and TL;DR

`UsersHelper::create_or_get_user` does not properly sanitize `user_login` in scenario when only `display_name` is provided which contains special characters.

Internally `wp_insert_user` will sanitize the username provided as argument and strip special characters before insertion.

Our method `create_or_get_user` is unaware that the `user_login` will be sanitized during insertion, and so it is not checking correctly whether that username already exists in the DB, and tries to insert a duplicate which fails in error.

## Example
Consider this scenario,
- DB has this existing user

```
INSERT INTO wp_users (ID, user_login, user_pass, user_nicename, user_email, user_url, user_registered, user_activation_key, user_status, display_name) VALUES (850, 'Author Authorsson News Daily', '***************************************************************', 'author-authorsson-news-daily', '0885972a3e@example.com', '', '2025-07-12 20:35:15', '', 0, 'Author Authorsson | News Daily');
```
- next try to get or create this user

```
$data = [
  'display_name' => 'Author Authorsson (News Daily)',
  'role' => 'contributor_no_edit',
];
$unique_identifier = "newspack_migration_byline Author Authorsson (News Daily)";

$wp_user = UsersHelper::create_or_get_user( $data, $unique_identifier );
```

- it will return a `WP_Error` with message "Sorry, that username already exists!"

The error happens on [this line](https://github.com/Automattic/newspack-migration-tools/blob/trunk/src/Logic/UsersHelper.php#L358) in `create_or_get_user`:
```
$user_id = wp_insert_user( $data );
```
because `user_login` was not properly prepared and sanitized.

More explanation:
- for a `$data` array as provided in example above (just with `display_name` and `role`), our method `create_or_get_user` will try and assign the `user_login` directly from `display_name` [on this line](https://github.com/Automattic/newspack-migration-tools/blob/trunk/src/Logic/UsersHelper.php#L337):
```
$user_login = $data['display_name'];
```

That is incorrect because internally the `wp_insert_user()` method sanitizes `user_login` like this, [on this line](https://github.com/WordPress/wordpress-develop/blob/6.8.1/src/wp-includes/user.php#L2222):
```
$sanitized_user_login = sanitize_user( $userdata['user_login'], true );
```

In our example, we've provided `display_name` 'Author Authorsson (News Daily)', and we try and use the same value for `user_login`, while when user gets inserted by `wp_insert_user` the `user_login` will be sanitized/stripped to 'Author Authorsson News Daily'.

Our function `self::get_unused_username( $user_login )` will never know that the non-sanitized `user_name` is non-unique and invalid [in this line](https://github.com/Automattic/newspack-migration-tools/blob/trunk/src/Logic/UsersHelper.php#L351), because it will be testing with a non-sanitized `display_name` which it is true that it does not exist in the DB.

On the other hand it is worth noticing that [our method](https://github.com/Automattic/newspack-migration-tools/blob/trunk/src/Logic/UsersHelper.php#L136) `get_unused_username` does have the correct `user_login` sanitization, which is good, but we are also missing it here in `create_or_get_user`.