### PR TITLE
Attachments: Prevent image sizes creation

### DIFF
--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -54,6 +54,9 @@ class Attachments {
 	 * @return int|WP_Error Attachment ID.
 	 */
 	public static function import_external_file( $path, $title = null, $caption = null, $description = null, $alt = null, $post_id = 0, $args = [], $desired_filename = '', $try_existing = true ) {
+		// Prevent creation of additional images.
+		add_filter( 'intermediate_image_sizes_advanced', '__return_null' );
+
 		// Fetch remote or local file.
 		$is_http = 'http' == substr( $path, 0, 4 );
 		if ( $is_http ) {


### PR DESCRIPTION
## Overview

This PR adds a filter to prevent creating new image sizes when importing external images.

## How to Test

* Upload an image
* Check the uploads folder
* There shouldn't be any cropped images except for `image.{jpg}` and `image-scaled.{jpg}`