### PR TITLE
Add MemoryCleanupHook

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -79,7 +79,7 @@ $collection_post_id = $collections_helper
     ->update_collection_metadata(
         $collection_id,
         [
-            'thumbnail'      => 1234,                            // Attachment ID
+            'thumbnail_id'   => 1234,                            // Attachment ID
             'volume'         => 1,                               // Collection Volume
             'number'         => 1,                               // Collection Number
             'period'         => 'January 1970',                  // Collection Period

--- a/src/Hooks/MemoryCleanupHook.php
+++ b/src/Hooks/MemoryCleanupHook.php
@@ -9,13 +9,25 @@ class MemoryCleanupHook {
 	 * @static
 	 * @access public
 	 * 
-	 * @param int $sleep_time
+	 * @param int $sleep_time     Number of seconds to sleep between each flush.
+	 * @param int $current_step   Current counter/step. If provided $current_step and $flush_interval, will only flush every $flush_interval steps.
+	 * @param int $flush_interval Number of steps to wait before flushing again.
 	 */
-	public static function cleanup( int $sleep_time = 3 ): void {
-		self::reset_local_object_cache();
-		self::reset_db_query_log();
+	public static function cleanup( int $sleep_time = 0, int $current_step = null, int $flush_interval = null ): void {
 
-		sleep( $sleep_time );
+		// Determine if we should perform cleanup based on whether interval and step are provided.
+		$should_cleanup = ( is_null( $current_step ) || is_null( $flush_interval ) )
+			? true
+			: ( 0 === ( $current_step % $flush_interval ) );
+
+		if ( $should_cleanup ) {
+			self::reset_local_object_cache();
+			self::reset_db_query_log();
+
+			if ( $sleep_time > 0 ) {
+				sleep( $sleep_time );
+			}
+		}
 	}
 
 	/**
@@ -42,9 +54,15 @@ class MemoryCleanupHook {
 
 		foreach ( $properties as $property ) {
 			if ( property_exists( $wp_object_cache, $property ) ) {
-				$wp_object_cache->$property = [];
+				// Only set if the property is actually declared (not a magic property).
+				$reflection = new \ReflectionObject( $wp_object_cache );
+				if ( $reflection->hasProperty( $property ) ) {
+					$wp_object_cache->$property = [];
+				}
 			}
 		}
+
+		gc_collect_cycles();
 
 		if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
 			$wp_object_cache->__remoteset(); // important
@@ -61,6 +79,10 @@ class MemoryCleanupHook {
 	 */
 	public static function reset_db_query_log(): void {
 		global $wpdb;
+
+		unset( $wpdb->queries );
+
+		gc_collect_cycles();
 
 		$wpdb->queries = [];
 	}

--- a/src/Hooks/MemoryCleanupHook.php
+++ b/src/Hooks/MemoryCleanupHook.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Newspack\MigrationTools\Hooks;
+
+class MemoryCleanupHook {
+    /**
+     * Cleanup memory.
+     * 
+     * @static
+     * @access public
+     * 
+     * @param int $sleep_time
+     */
+    public static function cleanup( int $sleep_time = 3 ): void {
+        self::reset_local_object_cache();
+        self::reset_db_query_log();
+
+        sleep( $sleep_time );
+    }
+
+    /**
+     * Reset the local WordPress object cache
+     *
+     * This only cleans the local cache in WP_Object_Cache, without
+     * affecting memcache.
+     * 
+     * @static
+     * @access public
+     */
+    public static function reset_local_object_cache() {
+        global $wp_object_cache;
+
+        if ( ! is_object( $wp_object_cache ) ) {
+            return;
+        }
+
+        $properties = [
+            'group_ops',
+            'memcache_debug',
+            'cache',
+        ];
+
+        foreach ( $properties as $property ) {
+            if ( property_exists( $wp_object_cache, $property ) ) {
+                $wp_object_cache->$property = [];
+            }
+        }
+
+        if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
+            $wp_object_cache->__remoteset(); // important
+        }
+    }
+
+    /**
+     * Resets the WordPress DB query log.
+     * 
+     * @static
+     * @access public
+     * 
+     * @return void
+     */
+    public static function reset_db_query_log(): void {
+        global $wpdb;
+
+        $wpdb->queries = [];
+    }
+}

--- a/src/Hooks/MemoryCleanupHook.php
+++ b/src/Hooks/MemoryCleanupHook.php
@@ -3,65 +3,65 @@
 namespace Newspack\MigrationTools\Hooks;
 
 class MemoryCleanupHook {
-    /**
-     * Cleanup memory.
-     * 
-     * @static
-     * @access public
-     * 
-     * @param int $sleep_time
-     */
-    public static function cleanup( int $sleep_time = 3 ): void {
-        self::reset_local_object_cache();
-        self::reset_db_query_log();
+	/**
+	 * Cleanup memory.
+	 * 
+	 * @static
+	 * @access public
+	 * 
+	 * @param int $sleep_time
+	 */
+	public static function cleanup( int $sleep_time = 3 ): void {
+		self::reset_local_object_cache();
+		self::reset_db_query_log();
 
-        sleep( $sleep_time );
-    }
+		sleep( $sleep_time );
+	}
 
-    /**
-     * Reset the local WordPress object cache
-     *
-     * This only cleans the local cache in WP_Object_Cache, without
-     * affecting memcache.
-     * 
-     * @static
-     * @access public
-     */
-    public static function reset_local_object_cache() {
-        global $wp_object_cache;
+	/**
+	 * Reset the local WordPress object cache
+	 *
+	 * This only cleans the local cache in WP_Object_Cache, without
+	 * affecting memcache.
+	 * 
+	 * @static
+	 * @access public
+	 */
+	public static function reset_local_object_cache() {
+		global $wp_object_cache;
 
-        if ( ! is_object( $wp_object_cache ) ) {
-            return;
-        }
+		if ( ! is_object( $wp_object_cache ) ) {
+			return;
+		}
 
-        $properties = [
-            'group_ops',
-            'memcache_debug',
-            'cache',
-        ];
+		$properties = [
+			'group_ops',
+			'memcache_debug',
+			'cache',
+		];
 
-        foreach ( $properties as $property ) {
-            if ( property_exists( $wp_object_cache, $property ) ) {
-                $wp_object_cache->$property = [];
-            }
-        }
+		foreach ( $properties as $property ) {
+			if ( property_exists( $wp_object_cache, $property ) ) {
+				$wp_object_cache->$property = [];
+			}
+		}
 
-        if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
-            $wp_object_cache->__remoteset(); // important
-        }
-    }
+		if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
+			$wp_object_cache->__remoteset(); // important
+		}
+	}
 
-    /**
-     * Resets the WordPress DB query log.
-     * 
-     * @static
-     * @access public
-     * 
-     * @return void
-     */
-    public static function reset_db_query_log(): void {
-        global $wpdb;
+	/**
+	 * Resets the WordPress DB query log.
+	 * 
+	 * @static
+	 * @access public
+	 * 
+	 * @return void
+	 */
+	public static function reset_db_query_log(): void {
+		global $wpdb;
 
-        $wpdb->queries = [];
-    }
+		$wpdb->queries = [];
+	}
 }

--- a/src/Logic/CollectionsHelper.php
+++ b/src/Logic/CollectionsHelper.php
@@ -140,9 +140,11 @@ class CollectionsHelper {
 			]
 		);
 
-		if ( ! is_wp_error( $collection_section ) ) {
-			update_term_meta( $collection_section['term_id'], self::UNIQUE_COLLECTION_SECTION_IDENTIFIER_META_KEY, $unique_identifier );
+		if ( is_wp_error( $collection_section ) ) {
+			return $collection_section;
 		}
+
+		update_term_meta( $collection_section['term_id'], self::UNIQUE_COLLECTION_SECTION_IDENTIFIER_META_KEY, $unique_identifier );
 
 		return get_term_by( 'term_id', $collection_section['term_id'], $this->get_collection_section_taxonomy() );
 	}
@@ -193,9 +195,11 @@ class CollectionsHelper {
 			]
 		);
 
-		if ( ! is_wp_error( $collection_category ) ) {
-			update_term_meta( $collection_category['term_id'], self::UNIQUE_COLLECTION_CATEGORY_IDENTIFIER_META_KEY, $unique_identifier );
+		if ( is_wp_error( $collection_category ) ) {
+			return $collection_category;
 		}
+
+		update_term_meta( $collection_category['term_id'], self::UNIQUE_COLLECTION_CATEGORY_IDENTIFIER_META_KEY, $unique_identifier );
 
 		return get_term_by( 'term_id', $collection_category['term_id'], $this->get_collection_category_taxonomy() );
 	}
@@ -231,7 +235,7 @@ class CollectionsHelper {
 			function ( $collection_post_id ) {
 				return $this->get_collection_linked_term_id( $collection_post_id );
 			},
-			$collection_posts_ids 
+			$collection_posts_ids
 		);
 
 		$this->assign_post_to_collections_terms( $post_id, $collection_terms_ids );
@@ -295,7 +299,7 @@ class CollectionsHelper {
 	 * @return int
 	 */
 	public function get_collection_linked_term_id( int $post_id ): int {
-		return get_post_meta( $post_id, \Newspack\Collections\Sync::LINKED_TERM_META_KEY, true );
+		return (int) get_post_meta( $post_id, \Newspack\Collections\Sync::LINKED_TERM_META_KEY, true );
 	} 
 
 	/**
@@ -305,7 +309,7 @@ class CollectionsHelper {
 	 * @return int
 	 */
 	public function get_collection_linked_post_id( int $term_id ): int {
-		return get_term_meta( $term_id, \Newspack\Collections\Sync::LINKED_POST_META_KEY, true );
+		return (int) get_term_meta( $term_id, \Newspack\Collections\Sync::LINKED_POST_META_KEY, true );
 	} 
 
 	/**


### PR DESCRIPTION
## Overview

This PR adds a `MemoryCleanupHook`.

This class allows running a migration on thousands of Posts, by cleaning the memory after on batches.

## How to Test

* Write a WP CLI migration
* Call `MemoryCleanupHook::cleanup` after processing e.g., 300 Posts.
* You should see a drop of memory usage compared to without cleaning the memory

## Example (Pseudo-code)

```
use Newspack\MigrationTools\Hooks\MemoryCleanupHook;

public function cmd_migration() {
    $page = 0;

    do {
        $posts = get_posts( [
            'posts_per_page' => 100,
            'paged' => $page,
        ] );

        foreach ( $posts as $post ) {
            // Processing Post.
        }

        MemoryCleanupHook::cleanup();

        $page++;
    } while ( count( $posts ) );
}
```