### PR TITLE
Byline parsing

### DIFF
--- a/src/Logic/Bylines.php
+++ b/src/Logic/Bylines.php
@@ -14,19 +14,30 @@ class Bylines {
 	 * - filters out unsupported characters,
 	 * - applies manual substitutions,
 	 *     e.g. when you wish to preserve certain unexploded bylines. Let's say you have a separator ',',
-	 *     but you wish to preserve 'Arthur Author, Ph.D.' as a single author name, or even remove the 'Ph.D.' suffix.   * 
+	 *     but you wish to preserve 'Arthur Author, Ph.D.' as a single author name, or even remove the
+	 *     'Ph.D.' suffix.   * 
 	 *
 	 * @param string $byline          Byline with one or multiple authors.
-	 * @param array  $separators      Separators to explode. Typical separators could be: [ '&', ', and ', ',', ' and ', ' y ' ].
+	 * @param array  $separators      Separators to explode. Typical separators could be:
+	 *                                  [ '&', ', and ', ',', ' and ', ' y ' ].
 	 *                                ⚠️ Important:
-	 *                                  - the order of separators matters. One separator is a substring of another separator (e.g. ',' and ', and'), make sure to explode by the longer separator first to avoid incorrect splitting.
-	 *                                  - be mindful of spaces used to surround separators (e.g. ' and ' vs 'and').
+	 *                                  - the order of separators matters. One separator is a substring of
+	 *                                    another separator (e.g. ',' and ', and'), make sure to explode by
+	 *                                    the longer separator first to avoid incorrect splitting.
+	 *                                  - be mindful of spaces used to surround separators (e.g. ' and '
+	 *                                    vs 'and').
 	 * @param array  $manual_bylines  Keys are bylines and values are resulting author names.
-	 *                                If there are some bylines that require special handling, you can specify the entire byline as a key, and the final author names as subarray with one or more values.
-	 *                                This will skip parsing these bylines and just return them, e.g. [ 'Arthur Author, Ph.D.' => [ 'Arthur Author' ] ].
-	 * @param array  $remove_prefixes Prefixes to remove from beginning of byline's author names, case-insensitive. E.g. 'By ' or 'Byline: '.
-	 * @param array  $remove_suffixes Suffixes to remove from end of byline's author names, case-insensitive. E.g. ', Daily News', or '| Daily News', etc..
-	 * @param array  $remove_chars    Characters to remove. Unsupported polluting characters found in byline metas.
+	 *                                If there are some bylines that require special handling, you can
+	 *                                specify the entire byline as a key, and the final author names as
+	 *                                subarray with one or more values.
+	 *                                This will skip parsing these bylines and just return them,
+	 *                                e.g. [ 'Arthur Author, Ph.D.' => [ 'Arthur Author' ] ].
+	 * @param array  $remove_prefixes Prefixes to remove from beginning of byline's author names,
+	 *                                case-insensitive. E.g. 'By ' or 'Byline: '.
+	 * @param array  $remove_suffixes Suffixes to remove from end of byline's author names,
+	 *                                case-insensitive. E.g. ', Daily News', or '| Daily News', etc.
+	 * @param array  $remove_chars    Characters to remove. Unsupported polluting characters found in
+	 *                                byline metas.
 	 * 
 	 * @return string[]               Exploded author names from byline.
 	 */

--- a/src/Logic/Bylines.php
+++ b/src/Logic/Bylines.php
@@ -17,9 +17,13 @@ class Bylines {
 	 *     but you wish to preserve 'Arthur Author, Ph.D.' as a single author name, or even remove the 'Ph.D.' suffix.   * 
 	 *
 	 * @param string $byline               Byline with one or multiple authors.
-	 * @param array  $separators           Separators to explode by. E.g. ' and ', '&', ','. Be mindful of spaces needed, depending on the separator.
-	 * @param array  $manual_substitutions Will skip parsing these bylines and just return them. Keys are bylines and values are resulting author names.
-	 *                                     E.g. [ 'Arthur Author, Ph.D.' => [ 'Arthur Author' ] ].
+	 * @param array  $separators           Separators to explode. Typical separators could be: [ '&', ', and ', ',', ' and ', ' y ' ].
+	 *                                     ⚠️ Important:
+	 *                                       - the order of separators matters. One separator is a substring of another separator (e.g. ',' and ', and'), make sure to explode by the longer separator first to avoid incorrect splitting.
+	 *                                       - be mindful of spaces used to surround separators (e.g. ' and ' vs 'and').
+	 * @param array  $manual_substitutions Keys are bylines and values are resulting author names.
+	 *                                     If there are some bylines that require special handling, you can include the entire byline as a key, and the final author names as value.
+	 *                                     This will skip parsing these bylines and just return them, e.g. [ 'Arthur Author, Ph.D.' => [ 'Arthur Author' ] ].
 	 * @param array  $remove_chars         Characters to remove. Unsupported polluting characters found in byline metas.
 	 * @param array  $remove_prefixes      Prefixes to remove from beginning of byline, case-insensitive. E.g. 'By ' or 'Byline: '.
 	 * @param array  $remove_suffixes      Suffixes to remove from end of byline, case-insensitive. E.g. 'Ph.D.'.

--- a/src/Logic/Bylines.php
+++ b/src/Logic/Bylines.php
@@ -24,8 +24,8 @@ class Bylines {
 	 * @param array  $manual_bylines  Keys are bylines and values are resulting author names.
 	 *                                If there are some bylines that require special handling, you can specify the entire byline as a key, and the final author names as subarray with one or more values.
 	 *                                This will skip parsing these bylines and just return them, e.g. [ 'Arthur Author, Ph.D.' => [ 'Arthur Author' ] ].
-	 * @param array  $remove_prefixes Prefixes to remove from beginning of byline, case-insensitive. E.g. 'By ' or 'Byline: '.
-	 * @param array  $remove_suffixes Suffixes to remove from end of byline, case-insensitive. E.g. 'Ph.D.'.
+	 * @param array  $remove_prefixes Prefixes to remove from beginning of byline's author names, case-insensitive. E.g. 'By ' or 'Byline: '.
+	 * @param array  $remove_suffixes Suffixes to remove from end of byline's author names, case-insensitive. E.g. 'Ph.D.'.
 	 * @param array  $remove_chars    Characters to remove. Unsupported polluting characters found in byline metas.
 	 * 
 	 * @return string[]               Exploded author names from byline.

--- a/src/Logic/Bylines.php
+++ b/src/Logic/Bylines.php
@@ -16,26 +16,27 @@ class Bylines {
 	 *     e.g. when you wish to preserve certain unexploded bylines. Let's say you have a separator ',',
 	 *     but you wish to preserve 'Arthur Author, Ph.D.' as a single author name, or even remove the 'Ph.D.' suffix.   * 
 	 *
-	 * @param string $byline               Byline with one or multiple authors.
-	 * @param array  $separators           Separators to explode. Typical separators could be: [ '&', ', and ', ',', ' and ', ' y ' ].
-	 *                                     ⚠️ Important:
-	 *                                       - the order of separators matters. One separator is a substring of another separator (e.g. ',' and ', and'), make sure to explode by the longer separator first to avoid incorrect splitting.
-	 *                                       - be mindful of spaces used to surround separators (e.g. ' and ' vs 'and').
-	 * @param array  $manual_substitutions Keys are bylines and values are resulting author names.
-	 *                                     If there are some bylines that require special handling, you can include the entire byline as a key, and the final author names as value.
-	 *                                     This will skip parsing these bylines and just return them, e.g. [ 'Arthur Author, Ph.D.' => [ 'Arthur Author' ] ].
-	 * @param array  $remove_chars         Characters to remove. Unsupported polluting characters found in byline metas.
-	 * @param array  $remove_prefixes      Prefixes to remove from beginning of byline, case-insensitive. E.g. 'By ' or 'Byline: '.
-	 * @param array  $remove_suffixes      Suffixes to remove from end of byline, case-insensitive. E.g. 'Ph.D.'.
-	 * @return string[]                    Exploded author names from byline.
+	 * @param string $byline          Byline with one or multiple authors.
+	 * @param array  $separators      Separators to explode. Typical separators could be: [ '&', ', and ', ',', ' and ', ' y ' ].
+	 *                                ⚠️ Important:
+	 *                                  - the order of separators matters. One separator is a substring of another separator (e.g. ',' and ', and'), make sure to explode by the longer separator first to avoid incorrect splitting.
+	 *                                  - be mindful of spaces used to surround separators (e.g. ' and ' vs 'and').
+	 * @param array  $manual_bylines  Keys are bylines and values are resulting author names.
+	 *                                If there are some bylines that require special handling, you can specify the entire byline as a key, and the final author names as subarray with one or more values.
+	 *                                This will skip parsing these bylines and just return them, e.g. [ 'Arthur Author, Ph.D.' => [ 'Arthur Author' ] ].
+	 * @param array  $remove_prefixes Prefixes to remove from beginning of byline, case-insensitive. E.g. 'By ' or 'Byline: '.
+	 * @param array  $remove_suffixes Suffixes to remove from end of byline, case-insensitive. E.g. 'Ph.D.'.
+	 * @param array  $remove_chars    Characters to remove. Unsupported polluting characters found in byline metas.
+	 * 
+	 * @return string[]               Exploded author names from byline.
 	 */
 	public function parse_byline(
 		string $byline,
 		array $separators,
-		array $manual_substitutions = [],
-		array $remove_chars = [],
+		array $manual_bylines = [],
 		array $remove_prefixes = [],
 		array $remove_suffixes = [],
+		array $remove_chars = [],
 	): array {
 		if ( empty( $byline ) ) {
 			return [];
@@ -46,19 +47,22 @@ class Bylines {
 
 		// Trim.
 		$byline = trim( $byline );
+		
+		// Check for manual substitutions before processing.
+		if ( isset( $manual_bylines[ $byline ] ) ) {
+			return $manual_bylines[ $byline ];
+		}
 
 		// Remove prefixes and suffixes case-insensitively.
 		foreach ( $remove_prefixes as $prefix ) {
-			$byline = preg_replace( '/^' . $prefix . ' /i', '', $byline );
+			$byline = preg_replace( '/^' . preg_quote( $prefix, '/' ) . '/i', '', $byline );
 		}
 		foreach ( $remove_suffixes as $suffix ) {
-			$byline = preg_replace( '/ ' . $suffix . '$/i', '', $byline );
+			$byline = preg_replace( '/ ' . preg_quote( $suffix, '/' ) . '$/i', '', $byline );
 		}
-
-		// Check for manual substitutions after cleaning but before processing separators.
-		if ( isset( $manual_substitutions[ $byline ] ) ) {
-			return $manual_substitutions[ $byline ];
-		}
+		
+		// Trim again after removing prefixes and suffixes.
+		$byline = trim( $byline );
 
 		// Explode by multiple separators.
 		foreach ( $separators as $separator ) {
@@ -69,19 +73,19 @@ class Bylines {
 			// Explode and trim each exploded part.
 			$byline_exploded_parts = array_map( 'trim', explode( $separator, $byline ) );
 			
-			// Recursively process each exploded part to explode by remaining separators.
+			// Recursively parse each exploded part to explode everything by all separators.
 			$result = [];
 			foreach ( $byline_exploded_parts as $part ) {
 				$result = array_merge(
 					$result,
-					$this->parse_byline( $part, $separators, $manual_substitutions, $remove_chars, $remove_prefixes, $remove_suffixes )
+					$this->parse_byline( $part, $separators, $manual_bylines, $remove_chars, $remove_prefixes, $remove_suffixes )
 				);
 			}
 			
 			return $result;
 		}
 		
-		// After recursion -- if no more separators are found, return the cleaned byline.
+		// After recursion -- if no more separators are found, return the trimmed byline.
 		$byline = trim( $byline );
 
 		return [ $byline ];

--- a/src/Logic/Bylines.php
+++ b/src/Logic/Bylines.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Newspack\MigrationTools\Logic;
+
+/**
+ * Bylines logic.
+ */
+class Bylines {
+
+	/**
+	 * Parse byline string into author names,
+	 * - explodes by multiple separators,
+	 * - trims each individual part/name,
+	 * - filters out unsupported characters,
+	 * - applies manual substitutions without parsing
+	 *     e.g. when you wish to preserve certain unexploded bylines. Let's say you have a separator ',',
+	 *     but you wish to preserve 'Arthur Author, Ph.D.' as a single author name, or remove the 'Ph.D.' suffix manually.
+	 * 
+	 * @param string $byline               Byline.
+	 * @param array  $separators           Separators to explode by. E.g. ' and ', '&', ','. Be mindful of spaces needed, depending on the separator.
+	 * @param array  $manual_substitutions Will not parse these bylines, just return them as given in this array. Keys are bylines, values are resulting author names.
+	 *                                     E.g. [ 'Arthur Author, Ph.D.' => 'Arthur Author' ]
+	 * @param array  $remove_chars         Characters to remove. Unsupported polluting characters found in byline metas.
+	 * @param array  $remove_prefixes      Prefixes to remove from beginning of byline, case-insensitive. E.g. 'By ' or 'Byline: '.
+	 * @param array  $remove_suffixes      Suffixes to remove from end of byline, case-insensitive. E.g. 'Ph.D.'.
+	 * @return string[]                    Exploded and trimmed author names from byline.
+	 */
+	public function get_author_names_from_byline(
+		string $byline,
+		array $separators,
+		array $manual_substitutions = [],
+		array $remove_chars = [],
+		array $remove_prefixes = [],
+		array $remove_suffixes = [],
+	): array {
+		// If empty return empty array.
+		if ( empty( $byline ) ) {
+			return [];
+		}
+		
+		// Remove unsupported characters.
+		$byline = str_replace( $remove_chars, '', $byline );
+
+		// Trim.
+		$byline = trim( $byline );
+
+		// Remove prefixes and suffixes case-insensitively.
+		foreach ( $remove_prefixes as $prefix ) {
+			$byline = preg_replace( '/^' . $prefix . ' /i', '', $byline );
+		}
+		foreach ( $remove_suffixes as $suffix ) {
+			$byline = preg_replace( '/ ' . $suffix . '$/i', '', $byline );
+		}
+
+		// Explode by multiple separators.
+		foreach ( $separators as $separator ) {
+			if ( false === stripos( $byline, $separator ) ) {
+				continue;
+			}
+			
+			// Explode and trim each exploded part.
+			$byline_exploded_parts = array_map( 'trim', explode( $separator, $byline ) );
+			
+			// Recursively process each exploded part to explode by remaining separators.
+			$result = [];
+			foreach ( $byline_exploded_parts as $part ) {
+				$result = array_merge(
+					$result,
+					$this->get_author_names_from_byline( $part, $separators, $remove_chars, $remove_prefixes )
+				);
+			}
+			
+			return $result;
+		}
+		
+		// After recursion -- if no more separators are found, return the cleaned byline.
+		$byline = trim( $byline );
+
+		// Finally, apply manual substitutions.
+		if ( isset( $manual_substitutions[ $byline ] ) ) {
+			return [ $manual_substitutions[ $byline ] ];
+		}
+
+		return [ $byline ];
+	}
+}

--- a/src/Logic/Bylines.php
+++ b/src/Logic/Bylines.php
@@ -8,24 +8,24 @@ namespace Newspack\MigrationTools\Logic;
 class Bylines {
 
 	/**
-	 * Parse byline string into author names,
+	 * Parses byline string into author names,
 	 * - explodes by multiple separators,
-	 * - trims each individual part/name,
+	 * - trims each individual exploded part/author name,
 	 * - filters out unsupported characters,
-	 * - applies manual substitutions without parsing
+	 * - applies manual substitutions,
 	 *     e.g. when you wish to preserve certain unexploded bylines. Let's say you have a separator ',',
-	 *     but you wish to preserve 'Arthur Author, Ph.D.' as a single author name, or remove the 'Ph.D.' suffix manually.
-	 * 
-	 * @param string $byline               Byline.
+	 *     but you wish to preserve 'Arthur Author, Ph.D.' as a single author name, or even remove the 'Ph.D.' suffix.   * 
+	 *
+	 * @param string $byline               Byline with one or multiple authors.
 	 * @param array  $separators           Separators to explode by. E.g. ' and ', '&', ','. Be mindful of spaces needed, depending on the separator.
-	 * @param array  $manual_substitutions Will not parse these bylines, just return them as given in this array. Keys are bylines, values are resulting author names.
-	 *                                     E.g. [ 'Arthur Author, Ph.D.' => 'Arthur Author' ]
+	 * @param array  $manual_substitutions Will skip parsing these bylines and just return them. Keys are bylines and values are resulting author names.
+	 *                                     E.g. [ 'Arthur Author, Ph.D.' => [ 'Arthur Author' ] ].
 	 * @param array  $remove_chars         Characters to remove. Unsupported polluting characters found in byline metas.
 	 * @param array  $remove_prefixes      Prefixes to remove from beginning of byline, case-insensitive. E.g. 'By ' or 'Byline: '.
 	 * @param array  $remove_suffixes      Suffixes to remove from end of byline, case-insensitive. E.g. 'Ph.D.'.
-	 * @return string[]                    Exploded and trimmed author names from byline.
+	 * @return string[]                    Exploded author names from byline.
 	 */
-	public function get_author_names_from_byline(
+	public function parse_byline(
 		string $byline,
 		array $separators,
 		array $manual_substitutions = [],
@@ -33,7 +33,6 @@ class Bylines {
 		array $remove_prefixes = [],
 		array $remove_suffixes = [],
 	): array {
-		// If empty return empty array.
 		if ( empty( $byline ) ) {
 			return [];
 		}
@@ -52,12 +51,17 @@ class Bylines {
 			$byline = preg_replace( '/ ' . $suffix . '$/i', '', $byline );
 		}
 
+		// Check for manual substitutions after cleaning but before processing separators.
+		if ( isset( $manual_substitutions[ $byline ] ) ) {
+			return $manual_substitutions[ $byline ];
+		}
+
 		// Explode by multiple separators.
 		foreach ( $separators as $separator ) {
 			if ( false === stripos( $byline, $separator ) ) {
 				continue;
 			}
-			
+
 			// Explode and trim each exploded part.
 			$byline_exploded_parts = array_map( 'trim', explode( $separator, $byline ) );
 			
@@ -66,7 +70,7 @@ class Bylines {
 			foreach ( $byline_exploded_parts as $part ) {
 				$result = array_merge(
 					$result,
-					$this->get_author_names_from_byline( $part, $separators, $remove_chars, $remove_prefixes )
+					$this->parse_byline( $part, $separators, $manual_substitutions, $remove_chars, $remove_prefixes, $remove_suffixes )
 				);
 			}
 			
@@ -75,11 +79,6 @@ class Bylines {
 		
 		// After recursion -- if no more separators are found, return the cleaned byline.
 		$byline = trim( $byline );
-
-		// Finally, apply manual substitutions.
-		if ( isset( $manual_substitutions[ $byline ] ) ) {
-			return [ $manual_substitutions[ $byline ] ];
-		}
 
 		return [ $byline ];
 	}

--- a/src/Logic/Bylines.php
+++ b/src/Logic/Bylines.php
@@ -8,12 +8,12 @@ namespace Newspack\MigrationTools\Logic;
 class Bylines {
 
 	/**
-	 * Parses byline string into author names,
-	 * - explodes by multiple separators,
-	 * - trims each individual exploded part/author name,
-	 * - optionally cleans unsupported characters,
-	 * - can remove various prefixes and suffixes,
-	 * - works with manually provided exceptions.
+	 * Parses byline string into author names:
+	 *   - can explode by multiple separators,
+	 *   - trims each individual exploded part/author name,
+	 *   - can optionally clean unsupported characters,
+	 *   - can remove various prefixes and suffixes,
+	 *   - can work with manually provided exceptions which override parsing.
 	 *
 	 * @param string $byline            Byline with one or multiple authors names.
 	 * @param array  $separators        Separators by which to explode. Typical separators could be:

--- a/src/Logic/Bylines.php
+++ b/src/Logic/Bylines.php
@@ -89,7 +89,7 @@ class Bylines {
 			foreach ( $byline_exploded_parts as $part ) {
 				$result = array_merge(
 					$result,
-					$this->parse_byline( $part, $separators, $manual_exceptions, $remove_chars, $remove_prefixes, $remove_suffixes )
+					$this->parse_byline( $part, $separators, $manual_exceptions, $remove_prefixes, $remove_suffixes, $remove_chars )
 				);
 			}
 			

--- a/src/Logic/Bylines.php
+++ b/src/Logic/Bylines.php
@@ -25,7 +25,7 @@ class Bylines {
 	 *                                If there are some bylines that require special handling, you can specify the entire byline as a key, and the final author names as subarray with one or more values.
 	 *                                This will skip parsing these bylines and just return them, e.g. [ 'Arthur Author, Ph.D.' => [ 'Arthur Author' ] ].
 	 * @param array  $remove_prefixes Prefixes to remove from beginning of byline's author names, case-insensitive. E.g. 'By ' or 'Byline: '.
-	 * @param array  $remove_suffixes Suffixes to remove from end of byline's author names, case-insensitive. E.g. 'Ph.D.'.
+	 * @param array  $remove_suffixes Suffixes to remove from end of byline's author names, case-insensitive. E.g. ', Daily News', or '| Daily News', etc..
 	 * @param array  $remove_chars    Characters to remove. Unsupported polluting characters found in byline metas.
 	 * 
 	 * @return string[]               Exploded author names from byline.
@@ -58,7 +58,7 @@ class Bylines {
 			$byline = preg_replace( '/^' . preg_quote( $prefix, '/' ) . '/i', '', $byline );
 		}
 		foreach ( $remove_suffixes as $suffix ) {
-			$byline = preg_replace( '/ ' . preg_quote( $suffix, '/' ) . '$/i', '', $byline );
+			$byline = preg_replace( '/' . preg_quote( $suffix, '/' ) . '$/i', '', $byline );
 		}
 		
 		// Trim again after removing prefixes and suffixes.

--- a/src/Logic/Bylines.php
+++ b/src/Logic/Bylines.php
@@ -11,40 +11,40 @@ class Bylines {
 	 * Parses byline string into author names,
 	 * - explodes by multiple separators,
 	 * - trims each individual exploded part/author name,
-	 * - filters out unsupported characters,
-	 * - applies manual substitutions,
-	 *     e.g. when you wish to preserve certain unexploded bylines. Let's say you have a separator ',',
-	 *     but you wish to preserve 'Arthur Author, Ph.D.' as a single author name, or even remove the
-	 *     'Ph.D.' suffix.   * 
+	 * - optionally cleans unsupported characters,
+	 * - can remove various prefixes and suffixes,
+	 * - works with manually provided exceptions.
 	 *
-	 * @param string $byline          Byline with one or multiple authors.
-	 * @param array  $separators      Separators to explode. Typical separators could be:
+	 * @param string $byline            Byline with one or multiple authors names.
+	 * @param array  $separators        Separators by which to explode. Typical separators could be:
 	 *                                  [ '&', ', and ', ',', ' and ', ' y ' ].
-	 *                                ⚠️ Important:
-	 *                                  - the order of separators matters. One separator is a substring of
-	 *                                    another separator (e.g. ',' and ', and'), make sure to explode by
-	 *                                    the longer separator first to avoid incorrect splitting.
-	 *                                  - be mindful of spaces used to surround separators (e.g. ' and '
-	 *                                    vs 'and').
-	 * @param array  $manual_bylines  Keys are bylines and values are resulting author names.
-	 *                                If there are some bylines that require special handling, you can
-	 *                                specify the entire byline as a key, and the final author names as
-	 *                                subarray with one or more values.
-	 *                                This will skip parsing these bylines and just return them,
-	 *                                e.g. [ 'Arthur Author, Ph.D.' => [ 'Arthur Author' ] ].
-	 * @param array  $remove_prefixes Prefixes to remove from beginning of byline's author names,
-	 *                                case-insensitive. E.g. 'By ' or 'Byline: '.
-	 * @param array  $remove_suffixes Suffixes to remove from end of byline's author names,
-	 *                                case-insensitive. E.g. ', Daily News', or '| Daily News', etc.
-	 * @param array  $remove_chars    Characters to remove. Unsupported polluting characters found in
-	 *                                byline metas.
+	 *                                  ⚠️ Important:
+	 *                                  - the order of separators matters. If one separator is a substring of
+	 *                                    another separator (e.g. ',' and ', and') make sure to provide and
+	 *                                    explode by the longer separator first (first ', and', then ',').
+	 *                                  - be mindful of spaces used to surround separators, e.g. use ' and '
+	 *                                    not 'and'.
+	 * @param array  $manual_exceptions If there are some bylines that require special handling, you can
+	 *                                  specify the entire byline and resulting authors. These bylines will
+	 *                                  be skipped from parsing and just returned as is. Keys are bylines and
+	 *                                  values are subarrays with resulting author names. E.g. two exceptions:
+	 *                                  [
+	 *                                    'John Doe, Jr., Jane Doe' => [ 'John Doe Jr.', 'Jane Doe' ],
+	 *                                    'John Doe Jane Doe' => [ 'John Doe', 'Jane Doe' ]
+	 *                                  ].
+	 * @param array  $remove_prefixes   Prefixes to remove from beginning of byline's author names,
+	 *                                  case-insensitive. E.g. 'By ' or 'Byline: '.
+	 * @param array  $remove_suffixes   Suffixes to remove from end of byline's author names,
+	 *                                  case-insensitive. E.g. ', Daily News', or '| Daily News', etc.
+	 * @param array  $remove_chars      Characters to remove. Unsupported polluting characters found in
+	 *                                  byline metas.
 	 * 
-	 * @return string[]               Exploded author names from byline.
+	 * @return string[]                 Exploded author names from byline.
 	 */
 	public function parse_byline(
 		string $byline,
 		array $separators,
-		array $manual_bylines = [],
+		array $manual_exceptions = [],
 		array $remove_prefixes = [],
 		array $remove_suffixes = [],
 		array $remove_chars = [],
@@ -59,9 +59,9 @@ class Bylines {
 		// Trim.
 		$byline = trim( $byline );
 		
-		// Check for manual substitutions before processing.
-		if ( isset( $manual_bylines[ $byline ] ) ) {
-			return $manual_bylines[ $byline ];
+		// Check for manual exceptions before processing.
+		if ( isset( $manual_exceptions[ $byline ] ) ) {
+			return $manual_exceptions[ $byline ];
 		}
 
 		// Remove prefixes and suffixes case-insensitively.
@@ -89,7 +89,7 @@ class Bylines {
 			foreach ( $byline_exploded_parts as $part ) {
 				$result = array_merge(
 					$result,
-					$this->parse_byline( $part, $separators, $manual_bylines, $remove_chars, $remove_prefixes, $remove_suffixes )
+					$this->parse_byline( $part, $separators, $manual_exceptions, $remove_chars, $remove_prefixes, $remove_suffixes )
 				);
 			}
 			

--- a/src/Util/Log/CliLog.php
+++ b/src/Util/Log/CliLog.php
@@ -23,12 +23,12 @@ class CliLog {
 	 *
 	 * It also logs to /dev/null if the script is not running in CLI mode.
 	 *
-	 * @param string             $name      The name of the logger (used in the output).
-	 * @param FormatterInterface $formatter Optional formatter to use. Defaults to Bramus\Monolog\Formatter\ColoredLineFormatter.
+	 * @param string                  $name      The name of the logger (used in the output).
+	 * @param FormatterInterface|null $formatter Optional formatter to use. Defaults to Bramus\Monolog\Formatter\ColoredLineFormatter.
 	 *
 	 * @return Logger Logger instance.
 	 */
-	public static function get_logger( string $name, FormatterInterface $formatter = null ): LoggerInterface {
+	public static function get_logger( string $name, ?FormatterInterface $formatter = null ): LoggerInterface {
 		$logger = self::get_existing_logger( $name );
 		if ( $logger ) {
 			return $logger;

--- a/src/Util/Log/FileLog.php
+++ b/src/Util/Log/FileLog.php
@@ -29,7 +29,7 @@ class FileLog {
 	 *
 	 * @return Logger
 	 */
-	public static function get_logger( string $name, string $log_file_name = '', FormatterInterface $formatter = null ): LoggerInterface {
+	public static function get_logger( string $name, string $log_file_name = '', ?FormatterInterface $formatter = null ): LoggerInterface {
 		if ( empty( $log_file_name ) ) {
 			// Just stick ".log" to the end of the name and sanitize it.
 			$log_file_name = sanitize_file_name( $name . '.log' );

--- a/tests/Logic/BylinesTest.php
+++ b/tests/Logic/BylinesTest.php
@@ -68,6 +68,16 @@ class BylinesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test parse_byline() removing prefixes and suffixes.
+	 * 
+	 * @dataProvider data_byline_remove_prefixes_and_suffixes
+	 */
+	public function test_byline_remove_prefixes_and_suffixes( string $byline, array $remove_prefixes, array $remove_suffixes, array $expected ) {
+		$result = $this->bylines->parse_byline( $byline, [], [], $remove_prefixes, $remove_suffixes );
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
 	 * Data provider for test_byline_no_separators.
 	 */
 	public function data_byline_no_separators() {
@@ -142,6 +152,24 @@ class BylinesTest extends WP_UnitTestCase {
 				[ 'John Doe', 'School of Journalism and Mass Communication' ],
 			],
 			
+		];
+	}
+
+	/**
+	 * Data provider for test_byline_remove_prefixes_and_suffixes.
+	 */
+	public function data_byline_remove_prefixes_and_suffixes() {
+		return [
+			[
+				// Byline.
+				'By John Doe | copyright',
+				// Remove prefixes, case-insensitive.
+				[ 'by ' ],
+				// Remove suffixes.
+				[ '| copyright' ],
+				// Expected.
+				[ 'John Doe' ],
+			],
 		];
 	}
 }

--- a/tests/Logic/BylinesTest.php
+++ b/tests/Logic/BylinesTest.php
@@ -1,20 +1,19 @@
 <?php
 /**
- * Tests for the Posts class.
+ * Tests for the Bylines class.
  */
 
 namespace Newspack\MigrationTools\Tests\Logic;
 
 use Newspack\MigrationTools\Logic\Bylines;
 use WP_UnitTestCase;
-use WP_Error;
 
 /**
- * Test the Posts class.
+ * Test the Bylines class.
  */
 class BylinesTest extends WP_UnitTestCase {
 	/**
-	 * The Posts instance.
+	 * The Bylines instance.
 	 *
 	 * @var Bylines
 	 */
@@ -29,23 +28,92 @@ class BylinesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test parsing byline with single separator.
+	 * Test parse_byline() without separators.
 	 * 
-	 * @dataProvider data_explode_by_single_separator
+	 * @dataProvider data_byline_no_separators
 	 */
-	public function test_byline_explode_by_single_separator( string $byline, array $expected ) {
-		$result = $this->bylines->get_author_names_from_byline( $byline, [ ',' ] );
-		$this->assertEquals( $expected, $result );	
+	public function test_byline_no_separators( string $byline, array $separators, array $expected ) {
+		$result = $this->bylines->parse_byline( $byline, $separators );
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test parse_byline() using a single separator.
+	 * 
+	 * @dataProvider data_byline_explode_by_single_separator
+	 */
+	public function test_byline_explode_by_single_separator( string $byline, array $separators, array $expected ) {
+		$result = $this->bylines->parse_byline( $byline, $separators );
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test parse_byline() using manual substitutions.
+	 * 
+	 * @dataProvider data_byline_manual_substitutions
+	 */
+	public function test_byline_manual_substitutions( string $byline, array $separators, array $manual_substitutions, array $expected ) {
+		$result = $this->bylines->parse_byline( $byline, $separators, $manual_substitutions );
+		$this->assertEquals( $expected, $result );
 	}
 
 	/**
 	 * Data provider for test_byline_explode_by_single_separator.
 	 */
-	public function data_explode_by_single_separator() {
+	public function data_byline_no_separators() {
 		return [
-			[ 'John Doe', [ 'John Doe' ] ],
-			[ 'John Doe, Jane Doe', [ 'John Doe', 'Jane Doe' ] ],
-			[ 'John Doe, Jane Doe, Jim Doe', [ 'John Doe', 'Jane Doe', 'Jim Doe' ] ],
+			// No separators provided, nothing changes.
+			[ 'John Doe', [], [ 'John Doe' ] ],
+			[ 'John Doe, Jane Doe', [], [ 'John Doe, Jane Doe' ] ],
+		];
+	}
+
+	/**
+	 * Data provider for test_byline_explode_by_single_separator.
+	 */
+	public function data_byline_explode_by_single_separator() {
+		return [
+			// Single separator provided but not used.
+			[ 'John Doe', [ ',' ], [ 'John Doe' ] ],
+			[ 'John Doe', [ ' and ' ], [ 'John Doe' ] ],
+			[ 'John Doe', [ '&' ], [ 'John Doe' ] ],
+			// Different single separators.
+			[ 'John Doe, Jane Doe', [ ',' ], [ 'John Doe', 'Jane Doe' ] ],
+			[ 'John Doe and Jane Doe', [ ' and ' ], [ 'John Doe', 'Jane Doe' ] ],
+			[ 'John Doe & Jane Doe', [ '&' ], [ 'John Doe', 'Jane Doe' ] ],
+			// Wrong separator doesn't explode.
+			[ 'John Doe & Jane Doe', [ ' and ' ], [ 'John Doe & Jane Doe' ] ],
+		];
+	}
+
+	/**
+	 * Data provider for test_byline_manual_substitutions.
+	 */
+	public function data_byline_manual_substitutions() {
+		return [
+			[
+				'School of Journalism and Mass Communication',
+				[ ' and ' ],
+				[
+					'School of Journalism and Mass Communication' => [
+						'School of Journalism and Mass Communication',
+					],
+				],
+				[ 'School of Journalism and Mass Communication' ],
+			],
+			// Manual substitution is applied before exploding, this prevents returning [ 'John Doe', 'School of Journalism', 'Mass Communication' ] which would be wrong.
+			[
+				'John Doe and School of Journalism and Mass Communication',
+				[ ' and ' ],
+				[
+					'John Doe and School of Journalism and Mass Communication' => [
+						'John Doe',
+						'School of Journalism and Mass Communication',
+					],
+				],
+				[ 'John Doe', 'School of Journalism and Mass Communication' ],
+			],
+			
 		];
 	}
 }

--- a/tests/Logic/BylinesTest.php
+++ b/tests/Logic/BylinesTest.php
@@ -72,8 +72,8 @@ class BylinesTest extends WP_UnitTestCase {
 	 * 
 	 * @dataProvider data_byline_remove_prefixes_and_suffixes
 	 */
-	public function test_byline_remove_prefixes_and_suffixes( string $byline, array $remove_prefixes, array $remove_suffixes, array $expected ) {
-		$result = $this->bylines->parse_byline( $byline, [], [], $remove_prefixes, $remove_suffixes );
+	public function test_byline_remove_prefixes_and_suffixes( string $byline, array $separators, array $remove_prefixes, array $remove_suffixes, array $expected ) {
+		$result = $this->bylines->parse_byline( $byline, $separators, [], $remove_prefixes, $remove_suffixes );
 		$this->assertEquals( $expected, $result );
 	}
 
@@ -250,6 +250,8 @@ class BylinesTest extends WP_UnitTestCase {
 			[
 				// Byline.
 				'By John Doe | copyright',
+				// Separators.
+				[],
 				// Remove prefixes, case-insensitive.
 				[ 'by ', 'Author:' ],
 				// Remove suffixes.
@@ -260,12 +262,38 @@ class BylinesTest extends WP_UnitTestCase {
 			[
 				// Byline.
 				'Author: John Doe',
+				// Separators.
+				[],
 				// Remove prefixes, case-insensitive.
 				[ 'by ', 'author:' ],
 				// Remove suffixes.
 				[ '| copyright' ],
 				// Expected.
 				[ 'John Doe' ],
+			],
+			[
+				// Byline.
+				'John Doe / Daily News, Jane Doe / Daily News',
+				// Separators.
+				[ ',' ],
+				// Remove prefixes, case-insensitive.
+				[],
+				// Remove suffixes.
+				[ '/ Daily News' ],
+				// Expected.
+				[ 'John Doe', 'Jane Doe' ],
+			],
+			[
+				// Byline.
+				'John Doe / Daily News, Jane Doe | Daily News',
+				// Separators.
+				[ ',' ],
+				// Remove prefixes, case-insensitive.
+				[],
+				// Remove suffixes.
+				[ '/ Daily News', '| Daily News' ],
+				// Expected.
+				[ 'John Doe', 'Jane Doe' ],
 			],
 		];
 	}

--- a/tests/Logic/BylinesTest.php
+++ b/tests/Logic/BylinesTest.php
@@ -58,12 +58,12 @@ class BylinesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test parse_byline() using manual substitutions.
+	 * Test parse_byline() using manual exceptions.
 	 * 
-	 * @dataProvider data_byline_manual_substitutions
+	 * @dataProvider data_byline_manual_exceptions
 	 */
-	public function test_byline_manual_substitutions( string $byline, array $separators, array $manual_substitutions, array $expected ) {
-		$result = $this->bylines->parse_byline( $byline, $separators, $manual_substitutions );
+	public function test_byline_manual_exceptions( string $byline, array $separators, array $manual_exceptions, array $expected ) {
+		$result = $this->bylines->parse_byline( $byline, $separators, $manual_exceptions );
 		$this->assertEquals( $expected, $result );
 	}
 
@@ -204,16 +204,16 @@ class BylinesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for test_byline_manual_substitutions.
+	 * Data provider for test_byline_manual_exceptions.
 	 */
-	public function data_byline_manual_substitutions() {
+	public function data_byline_manual_exceptions() {
 		return [
 			[
 				// Byline.
 				'School of Journalism and Mass Communication',
 				// Separators.
 				[ ' and ' ],
-				// Manual substitutions.
+				// Manual exceptions.
 				[
 					'School of Journalism and Mass Communication' => [
 						'School of Journalism and Mass Communication',
@@ -222,13 +222,14 @@ class BylinesTest extends WP_UnitTestCase {
 				// Expected.
 				[ 'School of Journalism and Mass Communication' ],
 			],
-			// Manual substitution is applied before exploding, this prevents returning [ 'John Doe', 'School of Journalism', 'Mass Communication' ] which would be wrong.
+			// Manual exception should be applied before exploding,
+			// to prevent wrongly returning [ 'John Doe', 'School of Journalism', 'Mass Communication' ].
 			[
 				// Byline.
 				'John Doe and School of Journalism and Mass Communication',
 				// Separators.
 				[ ' and ' ],
-				// Manual substitutions.
+				// Manual exceptions.
 				[
 					'John Doe and School of Journalism and Mass Communication' => [
 						'John Doe',

--- a/tests/Logic/BylinesTest.php
+++ b/tests/Logic/BylinesTest.php
@@ -83,8 +83,22 @@ class BylinesTest extends WP_UnitTestCase {
 	public function data_byline_no_separators() {
 		return [
 			// No separators provided, nothing changes.
-			[ 'John Doe', [], [ 'John Doe' ] ],
-			[ 'John Doe, Jane Doe', [], [ 'John Doe, Jane Doe' ] ],
+			[
+				// Byline.
+				'John Doe',
+				// Separators.
+				[],
+				// Expected.
+				[ 'John Doe' ],
+			],
+			[
+				// Byline.
+				'John Doe, Jane Doe',
+				// Separators.
+				[],
+				// Expected.
+				[ 'John Doe, Jane Doe' ],
+			],
 		];
 	}
 
@@ -94,15 +108,64 @@ class BylinesTest extends WP_UnitTestCase {
 	public function data_byline_single_separator() {
 		return [
 			// Single separator provided but not used.
-			[ 'John Doe', [ ',' ], [ 'John Doe' ] ],
-			[ 'John Doe', [ ' and ' ], [ 'John Doe' ] ],
-			[ 'John Doe', [ '&' ], [ 'John Doe' ] ],
+			[
+				// Byline.
+				'John Doe',
+				// Separators.
+				[ ',' ],
+				// Expected.
+				[ 'John Doe' ],
+			],
+			[
+				// Byline.
+				'John Doe',
+				// Separators.
+				[ ' and ' ],
+				// Expected.
+				[ 'John Doe' ],
+			],
+			[
+				// Byline.
+				'John Doe',
+				// Separators.
+				[ '&' ],
+				// Expected.
+				[ 'John Doe' ],
+			],
 			// Different single separators.
-			[ 'John Doe, Jane Doe', [ ',' ], [ 'John Doe', 'Jane Doe' ] ],
-			[ 'John Doe and Jane Doe', [ ' and ' ], [ 'John Doe', 'Jane Doe' ] ],
-			[ 'John Doe & Jane Doe', [ '&' ], [ 'John Doe', 'Jane Doe' ] ],
-			// Wrong separator doesn't explode.
-			[ 'John Doe & Jane Doe', [ ' and ' ], [ 'John Doe & Jane Doe' ] ],
+			[
+				// Byline.
+				'John Doe, Jane Doe',
+				// Separators.
+				[ ',' ],
+				// Expected.
+				[ 'John Doe', 'Jane Doe' ],
+			],
+			[
+				// Byline.
+				'John Doe and Jane Doe',
+				// Separators.
+				[ ' and ' ],
+				// Expected.
+				[ 'John Doe', 'Jane Doe' ],
+			],
+			[
+				// Byline.
+				'John Doe & Jane Doe',
+				// Separators.
+				[ '&' ],
+				// Expected.
+				[ 'John Doe', 'Jane Doe' ],
+			],
+			// Irrelevant separator will not explode anything.
+			[
+				// Byline.
+				'John Doe & Jane Doe',
+				// Separators.
+				[ ' and ' ],
+				// Expected.
+				[ 'John Doe & Jane Doe' ],
+			],
 		];
 	}
 
@@ -112,13 +175,19 @@ class BylinesTest extends WP_UnitTestCase {
 	public function data_byline_order_of_exploding_multiple_separators() {
 		return [
 			[
+				// Byline.
 				'John Doe, Jane Doe, and Jim Doe',
+				// Separators.
 				[ ', and ', ',' ],
+				// Expected.
 				[ 'John Doe', 'Jane Doe', 'Jim Doe' ],
 			],
 			[
+				// Byline.
 				'John Doe, Jane Doe, and Jim Doe',
+				// Separators.
 				[ ',', ', and ' ],
+				// Expected.
 				[ 'John Doe', 'Jane Doe', 'and Jim Doe' ],
 			],
 		];
@@ -130,25 +199,33 @@ class BylinesTest extends WP_UnitTestCase {
 	public function data_byline_manual_substitutions() {
 		return [
 			[
+				// Byline.
 				'School of Journalism and Mass Communication',
+				// Separators.
 				[ ' and ' ],
+				// Manual substitutions.
 				[
 					'School of Journalism and Mass Communication' => [
 						'School of Journalism and Mass Communication',
 					],
 				],
+				// Expected.
 				[ 'School of Journalism and Mass Communication' ],
 			],
 			// Manual substitution is applied before exploding, this prevents returning [ 'John Doe', 'School of Journalism', 'Mass Communication' ] which would be wrong.
 			[
+				// Byline.
 				'John Doe and School of Journalism and Mass Communication',
+				// Separators.
 				[ ' and ' ],
+				// Manual substitutions.
 				[
 					'John Doe and School of Journalism and Mass Communication' => [
 						'John Doe',
 						'School of Journalism and Mass Communication',
 					],
 				],
+				// Expected.
 				[ 'John Doe', 'School of Journalism and Mass Communication' ],
 			],
 			
@@ -164,7 +241,17 @@ class BylinesTest extends WP_UnitTestCase {
 				// Byline.
 				'By John Doe | copyright',
 				// Remove prefixes, case-insensitive.
-				[ 'by ' ],
+				[ 'by ', 'Author:' ],
+				// Remove suffixes.
+				[ '| copyright' ],
+				// Expected.
+				[ 'John Doe' ],
+			],
+			[
+				// Byline.
+				'Author: John Doe',
+				// Remove prefixes, case-insensitive.
+				[ 'by ', 'author:' ],
 				// Remove suffixes.
 				[ '| copyright' ],
 				// Expected.

--- a/tests/Logic/BylinesTest.php
+++ b/tests/Logic/BylinesTest.php
@@ -78,6 +78,16 @@ class BylinesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test parse_byline() should not return empty author name after exploding.
+	 * 
+	 * @dataProvider data_byline_should_not_return_empty_author_name_after_exploding
+	 */
+	public function test_byline_should_not_return_empty_author_name_after_exploding( string $byline, array $separators, array $expected ) {
+		$result = $this->bylines->parse_byline( $byline, $separators );
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
 	 * Data provider for test_byline_no_separators.
 	 */
 	public function data_byline_no_separators() {
@@ -256,6 +266,30 @@ class BylinesTest extends WP_UnitTestCase {
 				[ '| copyright' ],
 				// Expected.
 				[ 'John Doe' ],
+			],
+		];
+	}
+
+	/**
+	 * Data provider for test_byline_should_not_return_empty_author_name_after_exploding.
+	 */
+	public function data_byline_should_not_return_empty_author_name_after_exploding() {
+		return [
+			[
+				// Byline.
+				'John Doe,',
+				// Separators.
+				[ ',' ],
+				// Expected.
+				[ 'John Doe' ],
+			],
+			[
+				// Byline.
+				'John Doe, Jane Doe,',
+				// Separators.
+				[ ',' ],
+				// Expected.
+				[ 'John Doe', 'Jane Doe' ],
 			],
 		];
 	}

--- a/tests/Logic/BylinesTest.php
+++ b/tests/Logic/BylinesTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Tests for the Posts class.
+ */
+
+namespace Newspack\MigrationTools\Tests\Logic;
+
+use Newspack\MigrationTools\Logic\Bylines;
+use WP_UnitTestCase;
+use WP_Error;
+
+/**
+ * Test the Posts class.
+ */
+class BylinesTest extends WP_UnitTestCase {
+	/**
+	 * The Posts instance.
+	 *
+	 * @var Bylines
+	 */
+	private $bylines;
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->bylines = new Bylines();
+	}
+
+	/**
+	 * Test parsing byline with single separator.
+	 * 
+	 * @dataProvider data_explode_by_single_separator
+	 */
+	public function test_byline_explode_by_single_separator( string $byline, array $expected ) {
+		$result = $this->bylines->get_author_names_from_byline( $byline, [ ',' ] );
+		$this->assertEquals( $expected, $result );	
+	}
+
+	/**
+	 * Data provider for test_byline_explode_by_single_separator.
+	 */
+	public function data_explode_by_single_separator() {
+		return [
+			[ 'John Doe', [ 'John Doe' ] ],
+			[ 'John Doe, Jane Doe', [ 'John Doe', 'Jane Doe' ] ],
+			[ 'John Doe, Jane Doe, Jim Doe', [ 'John Doe', 'Jane Doe', 'Jim Doe' ] ],
+		];
+	}
+}

--- a/tests/Logic/BylinesTest.php
+++ b/tests/Logic/BylinesTest.php
@@ -295,6 +295,30 @@ class BylinesTest extends WP_UnitTestCase {
 				// Expected.
 				[ 'John Doe', 'Jane Doe' ],
 			],
+			[
+				// Byline.
+				'John Doe/Daily News',
+				// Separators.
+				[],
+				// Remove prefixes, case-insensitive.
+				[],
+				// Remove suffixes.
+				[ '/Daily News' ],
+				// Expected.
+				[ 'John Doe' ],
+			],
+			[
+				// Byline.
+				'John Doe/Daily News, Jane Doe, Daily News',
+				// Separators.
+				[ ',' ],
+				// Remove prefixes, case-insensitive.
+				[],
+				// Remove suffixes.
+				[ '/Daily News', ', Daily News' ],
+				// Expected.
+				[ 'John Doe', 'Jane Doe' ],
+			],
 		];
 	}
 

--- a/tests/Logic/BylinesTest.php
+++ b/tests/Logic/BylinesTest.php
@@ -40,9 +40,19 @@ class BylinesTest extends WP_UnitTestCase {
 	/**
 	 * Test parse_byline() using a single separator.
 	 * 
-	 * @dataProvider data_byline_explode_by_single_separator
+	 * @dataProvider data_byline_single_separator
 	 */
-	public function test_byline_explode_by_single_separator( string $byline, array $separators, array $expected ) {
+	public function test_byline_single_separator( string $byline, array $separators, array $expected ) {
+		$result = $this->bylines->parse_byline( $byline, $separators );
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test parse_byline() correct order of exploding multiple separators.
+	 * 
+	 * @dataProvider data_byline_order_of_exploding_multiple_separators
+	 */
+	public function test_byline_order_of_exploding_multiple_separators( string $byline, array $separators, array $expected ) {
 		$result = $this->bylines->parse_byline( $byline, $separators );
 		$this->assertEquals( $expected, $result );
 	}
@@ -58,7 +68,7 @@ class BylinesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for test_byline_explode_by_single_separator.
+	 * Data provider for test_byline_no_separators.
 	 */
 	public function data_byline_no_separators() {
 		return [
@@ -69,9 +79,9 @@ class BylinesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for test_byline_explode_by_single_separator.
+	 * Data provider for test_byline_single_separator.
 	 */
-	public function data_byline_explode_by_single_separator() {
+	public function data_byline_single_separator() {
 		return [
 			// Single separator provided but not used.
 			[ 'John Doe', [ ',' ], [ 'John Doe' ] ],
@@ -83,6 +93,24 @@ class BylinesTest extends WP_UnitTestCase {
 			[ 'John Doe & Jane Doe', [ '&' ], [ 'John Doe', 'Jane Doe' ] ],
 			// Wrong separator doesn't explode.
 			[ 'John Doe & Jane Doe', [ ' and ' ], [ 'John Doe & Jane Doe' ] ],
+		];
+	}
+
+	/**
+	 * Data provider for test_byline_order_of_exploding_multiple_separators.
+	 */
+	public function data_byline_order_of_exploding_multiple_separators() {
+		return [
+			[
+				'John Doe, Jane Doe, and Jim Doe',
+				[ ', and ', ',' ],
+				[ 'John Doe', 'Jane Doe', 'Jim Doe' ],
+			],
+			[
+				'John Doe, Jane Doe, and Jim Doe',
+				[ ',', ', and ' ],
+				[ 'John Doe', 'Jane Doe', 'and Jim Doe' ],
+			],
 		];
 	}
 


### PR DESCRIPTION
## Byline parsing class

See docblock for functionality -- with useful examples of parameters, and caveats:
```
/**
 * Parses byline string into author names:
 *   - can explode by multiple separators,
 *   - trims each individual exploded part/author name,
 *   - can optionally clean unsupported characters,
 *   - can remove various prefixes and suffixes,
 *   - can work with manually provided exceptions which override parsing.
 *
 * @param string $byline            Byline with one or multiple authors names.
 * @param array  $separators        Separators by which to explode. Typical separators could be:
 *                                  [ '&', ', and ', ',', ' and ', ' y ' ].
 *                                  ⚠️ Important:
 *                                  - the order of separators matters. If one separator is a substring of
 *                                    another separator (e.g. ',' and ', and') make sure to provide and
 *                                    explode by the longer separator first (first ', and', then ',').
 *                                  - be mindful of spaces used to surround separators, e.g. use ' and '
 *                                    not 'and'.
 * @param array  $manual_exceptions If there are some bylines that require special handling, you can
 *                                  specify the entire byline and resulting authors. These bylines will
 *                                  be skipped from parsing and just returned as is. Keys are bylines and
 *                                  values are subarrays with resulting author names. E.g. two exceptions:
 *                                  [
 *                                    'John Doe, Jr., Jane Doe' => [ 'John Doe Jr.', 'Jane Doe' ],
 *                                    'John Doe Jane Doe' => [ 'John Doe', 'Jane Doe' ]
 *                                  ].
 * @param array  $remove_prefixes   Prefixes to remove from beginning of byline's author names,
 *                                  case-insensitive. E.g. 'By ' or 'Byline: '.
 * @param array  $remove_suffixes   Suffixes to remove from end of byline's author names,
 *                                  case-insensitive. E.g. ', Daily News', or '| Daily News', etc.
 * @param array  $remove_chars      Characters to remove. Unsupported polluting characters found in
 *                                  byline metas.
 * 
 * @return string[]                 Exploded author names from byline.
 */
public function parse_byline(
	string $byline,
	array $separators,
	array $manual_exceptions = [],
	array $remove_prefixes = [],
	array $remove_suffixes = [],
	array $remove_chars = [],
): array
```

## Extra unrelated features pushed in this PR

Updated argument type hinting for `FileLog::get_logger ` and `CliLog::get_logger` and added explicit nullables to remove PHP 8.4 deprecation warnings.