### PR TITLE
Add JSONWriter Util class

### DIFF
--- a/src/Util/JsonWriter.php
+++ b/src/Util/JsonWriter.php
@@ -52,16 +52,16 @@ class JsonWriter {
 	 */
 	public function put( array $item ): void {
 		if ( $this->is_first_item ) {
-            // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
 			fwrite( $this->file_pointer, "[\n" );
 		} else {
-            // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
 			fwrite( $this->file_pointer, ",\n" );
 		}
 
 		$json = wp_json_encode( $item, $this->flags );
 
-        // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
 		fwrite( $this->file_pointer, "$json" );
 
 		$this->is_first_item = false;
@@ -74,7 +74,7 @@ class JsonWriter {
 	 * @throws Exception If the file cannot be closed.
 	 */
 	public function close(): void {
-        // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
 		fwrite( $this->file_pointer, "\n]\n" );
 
 		if ( false === fclose( $this->file_pointer ) ) {

--- a/src/Util/JsonWriter.php
+++ b/src/Util/JsonWriter.php
@@ -72,6 +72,11 @@ class JsonWriter {
 	/**
 	 * Writes an object to the JSON file.
 	 * 
+	 * Handles three scenarios:
+	 * 1. First item in a new file: writes opening bracket and item
+	 * 2. First item when appending to existing file: removes closing bracket, adds comma, writes item
+	 * 3. Subsequent items: adds comma and writes item
+	 * 
 	 * @param  array $item The object data to write.
 	 * @return void
 	 * @throws Exception If the object cannot be written to the file.
@@ -103,7 +108,10 @@ class JsonWriter {
 	}
 
 	/**
-	 * Closes the file pointer.
+	 * Closes the file pointer and finalizes the JSON array.
+	 * 
+	 * Writes the closing bracket and newline to complete the JSON array structure,
+	 * then closes the file pointer. This method is called automatically via __destruct().
 	 * 
 	 * @return void
 	 * @throws Exception If the file cannot be closed.

--- a/src/Util/JsonWriter.php
+++ b/src/Util/JsonWriter.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Wrapper class for writing JSON files.
+ *
+ * @package Newspack\MigrationTools\Util
+ */
+
+namespace Newspack\MigrationTools\Util;
+
+use Exception;
+
+class JsonWriter {
+	/**
+	 * JSON file pointer.
+	 * 
+	 * @var resource
+	 */
+	private $file_pointer;
+
+	/**
+	 * A flag to indicate if the first item is being written.
+	 * 
+	 * @var bool
+	 */
+	private $is_first_item = true;
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param string $filename The name of the CSV file to write to.
+	 * @throws Exception If the file cannot be opened.
+	 */
+	public function __construct(
+		private string $filename,
+		private int $flags = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT
+	) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		$this->file_pointer = fopen( getcwd() . '/' . $this->filename, 'a+' );
+
+		if ( false === $this->file_pointer ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new Exception( "Could not open file: {$this->filename}" );
+		}
+
+		fwrite( $this->file_pointer, "[\n" );
+	}
+
+	/**
+	 * Writes an object to the JSON file.
+	 * 
+	 * @param  array $item The object data to write.
+	 * @return void
+	 * @throws Exception If the object cannot be written to the file.
+	 */
+	public function put( array $item ): void {
+		if ( ! $this->is_first_item ) {
+			fwrite( $this->file_pointer, ",\n" );
+		}
+
+		$json = json_encode( $item, $this->flags );
+
+		fwrite( $this->file_pointer, "  $json" );
+
+		$this->is_first_item = false;
+	}
+
+	/**
+	 * Closes the file pointer.
+	 * 
+	 * @return void
+	 * @throws Exception If the file cannot be closed.
+	 */
+	public function close(): void {
+		fwrite( $this->file_pointer, "\n]\n" );
+
+		if ( false === fclose( $this->file_pointer ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new Exception( "Could not close file: {$this->filename}" );
+		}
+	}
+
+	/**
+	 * Handles proper file ending when the object is destroyed.
+	 */
+	public function __destruct() {
+		if ( is_resource( $this->file_pointer ) ) {
+			$this->close();
+		}
+	}
+}

--- a/src/Util/JsonWriter.php
+++ b/src/Util/JsonWriter.php
@@ -25,10 +25,17 @@ class JsonWriter {
 	private $is_first_item = true;
 
 	/**
+	 * A flag to indicate if we're appending to an existing file and need to remove the closing bracket.
+	 * 
+	 * @var bool
+	 */
+	private $should_truncate_closing_bracket = false;
+
+	/**
 	 * Constructor.
 	 * 
 	 * @param string $filename The name of the JSON file to write to.
-	 * @throws Exception If the file cannot be opened.
+	 * @throws Exception If the file cannot be opened or contains invalid JSON.
 	 */
 	public function __construct(
 		private string $filename,
@@ -40,6 +47,25 @@ class JsonWriter {
 		if ( false === $this->file_pointer ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new Exception( "Could not open file: {$this->filename}" );
+		}
+
+		// Check if file has existing content and validate JSON
+		fseek( $this->file_pointer, 0, SEEK_END );
+		$file_size = ftell( $this->file_pointer );
+		
+		if ( $file_size > 0 ) {
+			rewind( $this->file_pointer );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread
+			$content = fread( $this->file_pointer, $file_size );
+			
+			if ( null === json_decode( $content ) && JSON_ERROR_NONE !== json_last_error() ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+				throw new Exception( "File contains invalid JSON: {$this->filename}" );
+			}
+			
+			$this->is_first_item                   = false;
+			$this->should_truncate_closing_bracket = true;
+			fseek( $this->file_pointer, 0, SEEK_END );
 		}
 	}
 
@@ -54,7 +80,16 @@ class JsonWriter {
 		if ( $this->is_first_item ) {
 			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
 			fwrite( $this->file_pointer, "[\n" );
+		} elseif ( $this->should_truncate_closing_bracket ) {
+			// Remove the closing bracket before appending to existing file
+			$current_position = ftell( $this->file_pointer );
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_ftruncate
+			ftruncate( $this->file_pointer, max( 0, $current_position - 2 ) );
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
+			fwrite( $this->file_pointer, ",\n" );
+			$this->should_truncate_closing_bracket = false;
 		} else {
+			// Subsequent items in same session
 			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
 			fwrite( $this->file_pointer, ",\n" );
 		}

--- a/src/Util/JsonWriter.php
+++ b/src/Util/JsonWriter.php
@@ -27,7 +27,7 @@ class JsonWriter {
 	/**
 	 * Constructor.
 	 * 
-	 * @param string $filename The name of the CSV file to write to.
+	 * @param string $filename The name of the JSON file to write to.
 	 * @throws Exception If the file cannot be opened.
 	 */
 	public function __construct(

--- a/src/Util/JsonWriter.php
+++ b/src/Util/JsonWriter.php
@@ -41,8 +41,6 @@ class JsonWriter {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new Exception( "Could not open file: {$this->filename}" );
 		}
-
-		fwrite( $this->file_pointer, "[\n" );
 	}
 
 	/**
@@ -53,13 +51,18 @@ class JsonWriter {
 	 * @throws Exception If the object cannot be written to the file.
 	 */
 	public function put( array $item ): void {
-		if ( ! $this->is_first_item ) {
+		if ( $this->is_first_item ) {
+            // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
+			fwrite( $this->file_pointer, "[\n" );
+		} else {
+            // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
 			fwrite( $this->file_pointer, ",\n" );
 		}
 
-		$json = json_encode( $item, $this->flags );
+		$json = wp_json_encode( $item, $this->flags );
 
-		fwrite( $this->file_pointer, "  $json" );
+        // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
+		fwrite( $this->file_pointer, "$json" );
 
 		$this->is_first_item = false;
 	}
@@ -71,6 +74,7 @@ class JsonWriter {
 	 * @throws Exception If the file cannot be closed.
 	 */
 	public function close(): void {
+        // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
 		fwrite( $this->file_pointer, "\n]\n" );
 
 		if ( false === fclose( $this->file_pointer ) ) {

--- a/tests/Util/JsonWriterTest.php
+++ b/tests/Util/JsonWriterTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Newspack\MigrationTools\Util\JsonWriter;
+
+class JsonWriterTest extends TestCase {
+	private string $test_file = 'test_output.json';
+
+	protected function tearDown(): void {
+		if ( file_exists( $this->test_file ) ) {
+			unlink( $this->test_file );
+		}
+	}
+
+	public function testWritesSingleItem() {
+		$writer = new JsonWriter( $this->test_file );
+		$item   = [
+			'foo' => 'bar',
+			'baz' => 123,
+		];
+		$writer->put( $item );
+		$writer->close();
+
+		$content = file_get_contents( $this->test_file );
+		$this->assertJsonStringEqualsJsonString(
+			json_encode( [ $item ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+			$content
+		);
+	}
+
+	public function testWritesMultipleItems() {
+		$writer = new JsonWriter( $this->test_file );
+		$item1  = [ 'a' => 1 ];
+		$item2  = [ 'b' => 2 ];
+		$writer->put( $item1 );
+		$writer->put( $item2 );
+		$writer->close();
+
+		$content = file_get_contents( $this->test_file );
+		$this->assertJsonStringEqualsJsonString(
+			json_encode( [ $item1, $item2 ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+			$content
+		);
+	}
+
+	public function test_fileIsClosedOnDestruct() {
+		$item     = [ 'x' => 'y' ];
+		$filename = $this->test_file;
+		// Use a closure to force __destruct
+		$createAndWrite = function() use ( $filename, $item ) {
+			$writer = new JsonWriter( $filename );
+			$writer->put( $item );
+			// No explicit close
+		};
+		$createAndWrite();
+		$content = file_get_contents( $filename );
+		$this->assertJsonStringEqualsJsonString(
+			json_encode( [ $item ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+			$content
+		);
+	}
+}

--- a/tests/Util/JsonWriterTest.php
+++ b/tests/Util/JsonWriterTest.php
@@ -21,9 +21,10 @@ class JsonWriterTest extends TestCase {
 		$writer->put( $item );
 		$writer->close();
 
+        // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 		$content = file_get_contents( $this->test_file );
 		$this->assertJsonStringEqualsJsonString(
-			json_encode( [ $item ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+			wp_json_encode( [ $item ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
 			$content
 		);
 	}
@@ -36,9 +37,10 @@ class JsonWriterTest extends TestCase {
 		$writer->put( $item2 );
 		$writer->close();
 
+        // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 		$content = file_get_contents( $this->test_file );
 		$this->assertJsonStringEqualsJsonString(
-			json_encode( [ $item1, $item2 ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+			wp_json_encode( [ $item1, $item2 ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
 			$content
 		);
 	}
@@ -47,15 +49,17 @@ class JsonWriterTest extends TestCase {
 		$item     = [ 'x' => 'y' ];
 		$filename = $this->test_file;
 		// Use a closure to force __destruct
-		$createAndWrite = function() use ( $filename, $item ) {
+		$create_and_write = function() use ( $filename, $item ) {
 			$writer = new JsonWriter( $filename );
 			$writer->put( $item );
 			// No explicit close
 		};
-		$createAndWrite();
+		$create_and_write();
+
+        // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 		$content = file_get_contents( $filename );
 		$this->assertJsonStringEqualsJsonString(
-			json_encode( [ $item ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+			wp_json_encode( [ $item ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
 			$content
 		);
 	}

--- a/tests/Util/JsonWriterTest.php
+++ b/tests/Util/JsonWriterTest.php
@@ -63,4 +63,29 @@ class JsonWriterTest extends TestCase {
 			$content
 		);
 	}
+
+	public function testItWorksWithExistingFile() {
+		$existing_item = [ 'a' => 'b' ];
+		$item          = [ 'x' => 'y' ];
+		$filename      = $this->test_file;
+
+		// Create a file with an existing JSON array containing one item
+		file_put_contents( $filename, wp_json_encode( [ $existing_item ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) );
+
+		// Use a closure to force __destruct
+		$create_and_write = function() use ( $filename, $item ) {
+			$writer = new JsonWriter( $filename );
+			$writer->put( $item );
+			// No explicit close
+		};
+		$create_and_write();
+
+        // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		$content = file_get_contents( $filename );
+
+		$this->assertJsonStringEqualsJsonString(
+			wp_json_encode( [ $existing_item, $item ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+			$content
+		);
+	}
 }


### PR DESCRIPTION
## Summary

Adds a `JSONWriter` utility class for writing JSON files.

## Purpose

The `JSONWriter` class makes it easy to write data to JSON files with minimal setup.

## Usage Example

```php

use Newspack\MigrationTools\Util\JSONWriter;

try {
    $json = new JSONWriter( 'output.json' ); // The file is created in the current working directory
    $json->put( [
        'name' => 'Alice',
        'email' => 'alice@example.com',
        'age' => 30,
    ] );
    $json->put( [
        'name' => 'Bob',
        'email' => 'bob@example.com',
        'age' => 23,
    ] );
    $json->close();
} catch ( Exception $e ) {
    error_log( $e->getMessage() );
}
```

## Tests

Unit tests are included in `tests/Util/JSONWriterTest.php` to cover file creation, row writing, and error conditions.