### PR TITLE
Fix Redirection Plugin Needs Setup for DB

### DIFF
--- a/src/Logic/Redirection.php
+++ b/src/Logic/Redirection.php
@@ -16,8 +16,8 @@ class Redirection {
 			NMT::exit_with_message( 'The Redirection plugin ( redirection ) is a dependency, and will have to be installed and activated before this helper class can be used.' );
 		}
 
-		// Make sure the Redirections plugin is "setup" (ie: it's database tables were installed).
-		// Setup can be performed in wp-admin or with cli command: wp redirection database install
+		// Make sure the Redirections plugin is setup (ie: it's database tables were installed).
+		// Setup can be performed in wp-admin > tools > redirection or with cli command: wp redirection database install
 		global $wpdb;
 		$table_name = $wpdb->prefix . 'redirection_items';
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/src/Logic/Redirection.php
+++ b/src/Logic/Redirection.php
@@ -19,11 +19,10 @@ class Redirection {
 		// Make sure the Redirections plugin is "setup" (ie: it's database tables were installed).
 		// Setup can be performed in wp-admin or with cli command: wp redirection database install
 		global $wpdb;
-		$table_name = $wpdb->prefix . "redirection_items";
-		if( $wpdb->get_var( $wpdb->prepare( "SHOW TABLES LIKE %s", $table_name ) ) !== $table_name ) {
-            NMT::exit_with_message( "The Redirection plugin setup is required: DB table {$table_name} not found."	 );
-        }
-
+		$table_name = $wpdb->prefix . 'redirection_items';
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
+			NMT::exit_with_message( "The Redirection plugin setup is required: DB table {$table_name} not found." );
+		}
 	}
 
 	/**

--- a/src/Logic/Redirection.php
+++ b/src/Logic/Redirection.php
@@ -20,6 +20,7 @@ class Redirection {
 		// Setup can be performed in wp-admin or with cli command: wp redirection database install
 		global $wpdb;
 		$table_name = $wpdb->prefix . 'redirection_items';
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
 			NMT::exit_with_message( "The Redirection plugin setup is required: DB table {$table_name} not found." );
 		}

--- a/src/Logic/Redirection.php
+++ b/src/Logic/Redirection.php
@@ -15,6 +15,15 @@ class Redirection {
 		if ( ! is_plugin_active( 'redirection/redirection.php' ) ) {
 			NMT::exit_with_message( 'The Redirection plugin ( redirection ) is a dependency, and will have to be installed and activated before this helper class can be used.' );
 		}
+
+		// Make sure the Redirections plugin is "setup" (ie: it's database tables were installed).
+		// Setup can be performed in wp-admin or with cli command: wp redirection database install
+		global $wpdb;
+		$table_name = $wpdb->prefix . "redirection_items";
+		if( $wpdb->get_var( $wpdb->prepare( "SHOW TABLES LIKE %s", $table_name ) ) !== $table_name ) {
+            NMT::exit_with_message( "The Redirection plugin setup is required: DB table {$table_name} not found."	 );
+        }
+
 	}
 
 	/**


### PR DESCRIPTION
It's not enough to just check if the Redirection plugin is installed/active to use this helper.  The Redirection plugin's own setup method needs to be run before using this helper, otherwise the functions will not work properly, and errors will be written to the debug log.

This code makes sure the Redirection plugin's setup was run by checking the existence of one of the Redirection db tables.

As noted in the php comments:

```
// Setup can be performed in wp-admin > tools > Redirection ...
// or with cli command: wp redirection database install
```

**Developer notes:**

Install with CLI:

```
wp redirection database install
````

Or run the setup in WP-Admin:

<img width="1003" height="701" alt="redirection-setup" src="https://github.com/user-attachments/assets/e4ea917f-af74-4fda-8233-fa93acc193e3" />

