### PR TITLE
NMT loggers 'debug' default level

### DIFF
--- a/src/NMT.php
+++ b/src/NMT.php
@@ -28,13 +28,13 @@ class NMT {
 	 * Private on purpose
 	 */
 	private function __construct() {
-		$this->log_level = Level::fromName( LogLevel::INFO );
+		$this->log_level = Level::fromName( LogLevel::DEBUG );
 
 		if ( defined( 'NMT_LOG_LEVEL' ) ) {
 			try {
 				$this->log_level = Level::fromName( NMT_LOG_LEVEL );
 			} catch ( UnhandledMatchError $e ) {
-				$this->log_level = Level::fromName( Level::Info );
+				$this->log_level = Level::Debug;
 			}
 		}
 	}


### PR DESCRIPTION
Instead of "info", we should have "debug" as default level. When "info" was the default level, everything on CLI was always green, which kind of beats the purpose of any green highlighting. Additionally the gray "debug" output did not work at all. Now that "debug" is set as default, info and everything else still works as usual, we just have debug, too.

Memo -- available log levels, from lowest to highest:
- DEBUG
- INFO
- NOTICE
- WARNING
- ERROR
- CRITICAL
- ALERT
- EMERGENCY