### PR TITLE
Users Helper Assign Authors

### DIFF
--- a/docs/users-helper.md
+++ b/docs/users-helper.md
@@ -40,6 +40,26 @@ Obviously – the more data you pass the better, but the method will create a us
 
 Fake emails will be created that look something like f3e895c937@example.com. 
 
+## Assigning Authors to a Post
+
+The `assign_authors_to_post()` function can be used to assign author(s) to a post. The [Co-Authors Plus](https://wordpress.org/plugins/co-authors-plus/) plugin is required to use this function.  (Co-Authors Plus is Newspack's preferred plugin for managing "multiple authors per post").
+
+Co-Authors Plus will create author taxonomy relationships in the `terms` db tables, and also update the post's `post_author` column too.
+
+### Usage
+
+```php
+
+// Assign one author (single value array) to the post.
+UsersHelper::assign_authors_to_post( 1, [ 1 ] );
+
+// Assign multiple authors (multiple value array) to the post.
+UsersHelper::assign_authors_to_post( 1, [ 1, 2, 3 ] );
+
+```
+
+Please see the underlying Co-Authors Plus function [add_coauthors](https://github.com/Automattic/Co-Authors-Plus/blob/30602dbd59c6cd73bd4aa3ff8a3e6eda0c1bccea/php/class-coauthors-plus.php#L1022) (specifically the variables [$query_type and $field](https://github.com/Automattic/Co-Authors-Plus/blob/30602dbd59c6cd73bd4aa3ff8a3e6eda0c1bccea/php/class-coauthors-plus.php#L1050-L1052)) for other argument options.
+
 ## Logging
 This class logs to file in `UsersHelper.log`.
 

--- a/src/Logic/GuestContributorsHelper.php
+++ b/src/Logic/GuestContributorsHelper.php
@@ -8,7 +8,7 @@ use WP_User;
 use WP_Error;
 use WP_Role;
 
-class GuestContributorsHelper extends UsersHelper {
+class GuestContributorsHelper {
 
 	const ERROR_ATTEMPTS        = 'Might be in an infinite loop.';
 	const ERROR_CREATE_USER     = 'Could not create user.';
@@ -132,14 +132,23 @@ class GuestContributorsHelper extends UsersHelper {
 	 * @return bool|WP_Error True if successful, WP_Error if not.
 	 */
 	public static function assign_contributors_to_post( int $post_id, array $contributor_ids ): bool|WP_Error {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
 
-		// deprepcate this...what is the point of having to have both objects in a migrator?
-		// why even have this GuestContributors file???
-		// of just have this object extend the UsersHelper???
-		// UsersHelper assign_coauthors_to_post( int $post_id, array $coauthors, $append = false, $query_type = 'id' ): bool|WP_Error {
+		if ( ! is_plugin_active( 'co-authors-plus/co-authors-plus.php' ) ) {
+			return new WP_Error( 'ERROR_COAUTHORS_PLUS', 'Co-Authors Plus plugin not found. Install and activate it before using this code.' );
+		}
 
+		global $coauthors_plus;
 
+		// Assign ids to post.
+		$success = $coauthors_plus->add_coauthors( $post_id, $contributor_ids, false, 'id' );
+		if ( ! $success ) {
+			return new WP_Error( 'ERROR_ASSIGN_CONTRIBUTORS', 'Failed to set authors. The add_coauthors() function did not successfully add contributors to the post.' );
+		}
 
+		return true;
 	}
 
 	/**

--- a/src/Logic/GuestContributorsHelper.php
+++ b/src/Logic/GuestContributorsHelper.php
@@ -8,7 +8,7 @@ use WP_User;
 use WP_Error;
 use WP_Role;
 
-class GuestContributorsHelper {
+class GuestContributorsHelper extends UsersHelper {
 
 	const ERROR_ATTEMPTS        = 'Might be in an infinite loop.';
 	const ERROR_CREATE_USER     = 'Could not create user.';
@@ -132,23 +132,14 @@ class GuestContributorsHelper {
 	 * @return bool|WP_Error True if successful, WP_Error if not.
 	 */
 	public static function assign_contributors_to_post( int $post_id, array $contributor_ids ): bool|WP_Error {
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
 
-		if ( ! is_plugin_active( 'co-authors-plus/co-authors-plus.php' ) ) {
-			return new WP_Error( 'ERROR_COAUTHORS_PLUS', 'Co-Authors Plus plugin not found. Install and activate it before using this code.' );
-		}
+		// deprepcate this...what is the point of having to have both objects in a migrator?
+		// why even have this GuestContributors file???
+		// of just have this object extend the UsersHelper???
+		// UsersHelper assign_coauthors_to_post( int $post_id, array $coauthors, $append = false, $query_type = 'id' ): bool|WP_Error {
 
-		global $coauthors_plus;
 
-		// Assign ids to post.
-		$success = $coauthors_plus->add_coauthors( $post_id, $contributor_ids, false, 'id' );
-		if ( ! $success ) {
-			return new WP_Error( 'ERROR_ASSIGN_CONTRIBUTORS', 'Failed to set authors. The add_coauthors() function did not successfully add contributors to the post.' );
-		}
 
-		return true;
 	}
 
 	/**

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -19,7 +19,6 @@ use WP_User;
 class UsersHelper {
 
 	const MAX_USER_LOGIN_LENGTH = 60;
-	
 	/**
 	 * Meta key for the unique identifier for users.
 	 */

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -484,6 +484,7 @@ class UsersHelper {
 	 * Most likely you'll want to pass in an array of WP_User IDs as the $authors argument, so this requires the $query_type to be 'id'.
 	 * 
 	 * For other options, please see the underlying CoAuthors Plus function `add_coauthors` and $query_type ($field) options;
+	 * 
 	 * @link https://github.com/Automattic/Co-Authors-Plus/blob/30602dbd59c6cd73bd4aa3ff8a3e6eda0c1bccea/php/class-coauthors-plus.php#L1022
 	 * @link https://github.com/Automattic/Co-Authors-Plus/blob/30602dbd59c6cd73bd4aa3ff8a3e6eda0c1bccea/php/class-coauthors-plus.php#L1050-L1052
 	 *

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -19,6 +19,7 @@ use WP_User;
 class UsersHelper {
 
 	const MAX_USER_LOGIN_LENGTH = 60;
+
 	/**
 	 * Meta key for the unique identifier for users.
 	 */

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -19,11 +19,17 @@ use WP_User;
 class UsersHelper {
 
 	const MAX_USER_LOGIN_LENGTH = 60;
-
+	
 	/**
 	 * Meta key for the unique identifier for users.
 	 */
 	public const UNIQUE_IDENTIFIER_META_KEY = '_nmt_user_uniqid';
+
+	/**
+	 * WP_Error enum
+	 */
+	const ERROR_ASSIGN_CONTRIBUTORS = 'Failed to set authors. The underlying add_coauthors() function was not successful.';
+	const ERROR_COAUTHORS_PLUS      = 'Co-Authors Plus plugin not found. Install and activate it before using this function.';
 
 	/**
 	 * Get a user by its unique identifier.
@@ -466,5 +472,46 @@ class UsersHelper {
 	 */
 	public static function get_short_sha_from_array( array $data ): string {
 		return substr( sha1( wp_json_encode( $data ) ), 0, 10 );
+	}
+
+	/**
+	 * Assign Authors to a Post.
+	 * 
+	 * This function will create the related 'author' taxonomy database rows using CoAuthorsPlus (our preferred plugin for managing
+	 * "multiple authors per post"). CoAuthorsPlus will create the author taxonomy relationships and also update the post's `post_author`
+	 * database column too.
+	 * 
+	 * Most likely you'll want to pass in an array of WP_User IDs as the $authors argument, so this requires the $query_type to be 'id'.
+	 * 
+	 * For other options, please see the underlying CoAuthors Plus function `add_coauthors` and $query_type ($field) options;
+	 * @link https://github.com/Automattic/Co-Authors-Plus/blob/30602dbd59c6cd73bd4aa3ff8a3e6eda0c1bccea/php/class-coauthors-plus.php#L1022
+	 * @link https://github.com/Automattic/Co-Authors-Plus/blob/30602dbd59c6cd73bd4aa3ff8a3e6eda0c1bccea/php/class-coauthors-plus.php#L1050-L1052
+	 *
+	 * @param int    $post_id    Post ID.
+	 * @param array  $authors    WP_User ids (preferred), but see links above for other options.
+	 * @param bool   $append     Append to existing authors. (Default false - do not append, replace existing).
+	 * @param string $query_type 'id' (for WP_User ids), but see links above for other options.
+	 *
+	 * @return bool|WP_Error True if successful, WP_Error if not.
+	 */
+	public static function assign_authors_to_post( int $post_id, array $authors, $append = false, $query_type = 'id' ): bool|WP_Error {
+	
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		if ( ! is_plugin_active( 'co-authors-plus/co-authors-plus.php' ) ) {
+			return new WP_Error( 'ERROR_COAUTHORS_PLUS', self::ERROR_COAUTHORS_PLUS );
+		}
+
+		global $coauthors_plus;
+
+		// Assign ids to post.
+		$success = $coauthors_plus->add_coauthors( $post_id, $authors, $append, $query_type );
+		if ( ! $success ) {
+			return new WP_Error( 'ERROR_ASSIGN_CONTRIBUTORS', self::ERROR_ASSIGN_CONTRIBUTORS );
+		}
+
+		return true;
 	}
 }

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -507,7 +507,7 @@ class UsersHelper {
 
 		global $coauthors_plus;
 
-		// Assign ids to post.
+		// Assign authors to post.
 		$success = $coauthors_plus->add_coauthors( $post_id, $authors, $append, $query_type );
 		if ( ! $success ) {
 			return new WP_Error( 'ERROR_ASSIGN_CONTRIBUTORS', self::ERROR_ASSIGN_CONTRIBUTORS );

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -26,12 +26,6 @@ class UsersHelper {
 	public const UNIQUE_IDENTIFIER_META_KEY = '_nmt_user_uniqid';
 
 	/**
-	 * WP_Error enum
-	 */
-	const ERROR_ASSIGN_CONTRIBUTORS = 'Failed to set authors. The underlying add_coauthors() function was not successful.';
-	const ERROR_COAUTHORS_PLUS      = 'Co-Authors Plus plugin not found. Install and activate it before using this function.';
-
-	/**
 	 * Get a user by its unique identifier.
 	 *
 	 * The identifier was set when the user was created (if it was created by this class), so you probably know what it is.
@@ -495,14 +489,14 @@ class UsersHelper {
 	 *
 	 * @return bool|WP_Error True if successful, WP_Error if not.
 	 */
-	public static function assign_authors_to_post( int $post_id, array $authors, $append = false, $query_type = 'id' ): bool|WP_Error {
+	public static function assign_authors_to_post( int $post_id, array $authors, bool $append = false, string $query_type = 'id' ): bool|WP_Error {
 	
 		if ( ! function_exists( 'is_plugin_active' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
 		if ( ! is_plugin_active( 'co-authors-plus/co-authors-plus.php' ) ) {
-			return new WP_Error( 'ERROR_COAUTHORS_PLUS', self::ERROR_COAUTHORS_PLUS );
+			return new WP_Error( 'ERROR_COAUTHORS_PLUS', 'Co-Authors Plus plugin not found. Install and activate it before using this function.' );
 		}
 
 		global $coauthors_plus;
@@ -510,7 +504,7 @@ class UsersHelper {
 		// Assign authors to post.
 		$success = $coauthors_plus->add_coauthors( $post_id, $authors, $append, $query_type );
 		if ( ! $success ) {
-			return new WP_Error( 'ERROR_ASSIGN_CONTRIBUTORS', self::ERROR_ASSIGN_CONTRIBUTORS );
+			return new WP_Error( 'ERROR_ASSIGN_CONTRIBUTORS', 'Failed to set authors. The underlying add_coauthors() function was not successful.' );
 		}
 
 		return true;

--- a/tests/Logic/TestUsersHelper.php
+++ b/tests/Logic/TestUsersHelper.php
@@ -232,5 +232,9 @@ class TestUsersHelper extends WP_UnitTestCase {
 		
 		$success_mulitple = UsersHelper::assign_authors_to_post( $post_id, [ $user->ID, $this->peter_parker_id ] );
 		$this->assertTrue( $success_mulitple );
+
+		$failure_empty = UsersHelper::assign_authors_to_post( $post_id, [] );
+		$this->assertInstanceOf( \WP_Error::class, $failure_empty );
+		$this->assertEquals( 'ERROR_ASSIGN_CONTRIBUTORS', $failure_empty->get_error_code() );
 	}
 }

--- a/tests/Logic/TestUsersHelper.php
+++ b/tests/Logic/TestUsersHelper.php
@@ -216,15 +216,15 @@ class TestUsersHelper extends WP_UnitTestCase {
 
 		$post_id = wp_insert_post(
 			[
-				'post_title' => 'Test Post'
+				'post_title' => 'Test Post',
 			]
 		);
 
 		$user = UsersHelper::create_or_get_user(
 			[
-				'user_login' => 'test_user_login'
+				'user_login' => 'test_user_login',
 			],
-			rand()
+			wp_rand()
 		);
 
 		$success_single = UsersHelper::assign_authors_to_post( $post_id, [ $user->ID ] );
@@ -232,6 +232,5 @@ class TestUsersHelper extends WP_UnitTestCase {
 		
 		$success_mulitple = UsersHelper::assign_authors_to_post( $post_id, [ $user->ID, $this->peter_parker_id ] );
 		$this->assertTrue( $success_mulitple );
-
 	}
 }

--- a/tests/Logic/TestUsersHelper.php
+++ b/tests/Logic/TestUsersHelper.php
@@ -211,4 +211,27 @@ class TestUsersHelper extends WP_UnitTestCase {
 		$this->assertEquals( $user1->ID, $user5->ID );
 		$this->assertEquals( $user1->user_email, $user5->user_email ); // Should return original user, not create new one
 	}
+
+	public function test_assign_authors_to_post() {
+
+		$post_id = wp_insert_post(
+			[
+				'post_title' => 'Test Post'
+			]
+		);
+
+		$user = UsersHelper::create_or_get_user(
+			[
+				'user_login' => 'test_user_login'
+			],
+			rand()
+		);
+
+		$success_single = UsersHelper::assign_authors_to_post( $post_id, [ $user->ID ] );
+		$this->assertTrue( $success_single );
+		
+		$success_mulitple = UsersHelper::assign_authors_to_post( $post_id, [ $user->ID, $this->peter_parker_id ] );
+		$this->assertTrue( $success_mulitple );
+
+	}
 }


### PR DESCRIPTION
### Assigning Authors to a Post

The `assign_authors_to_post()` function can be used to assign author(s) to a post. 

```php

// Assign one author (single value array) to the post.
UsersHelper::assign_authors_to_post( 1, [ 1 ] );

// Assign multiple authors (multiple value array) to the post.
UsersHelper::assign_authors_to_post( 1, [ 1, 2, 3 ] );

```

View changed files to see: updated docs, new function (with docblock), and new test.
