### PR TITLE
Guest Contributors Deprecate Assign

### DIFF
--- a/docs/guest-contributors.md
+++ b/docs/guest-contributors.md
@@ -104,28 +104,7 @@ if ( is_wp_error( $users ) ) WP_CLI::error( $users->get_error_message() );
 
 #### assign_contributors_to_post
 
-Assigns Guest Contributors to a Post using Co-Authors Plus.
-
-**Parameters:**
-
--   `$post_id` (int): Post ID.
--   `$contributor_ids` (array): Array of contributor IDs.
-
-**Returns:** `true|WP_Error` - True if successful, WP_Error if not.
-
-Example usage:
-
-```php
-use Newspack\MigrationTools\Logic\GuestContributorsHelper;
-
-$post_id = 123;
-$contributor_ids = [ 1, 2, 3 ];
-
-$result = GuestContributorsHelper::assign_contributors_to_post( $post_id, $contributor_ids );
-if ( is_wp_error( $result ) ) {
-    WP_CLI::error( $result->get_error_message() );
-}
-```
+Deprecated. Since guest contributors are just WP_Users, call [UsersHelper::assign_authors_to_post](https://github.com/Automattic/newspack-migration-tools/blob/trunk/docs/users-helper.md) directly instead.
 
 ### Error Handling
 

--- a/src/Logic/GuestContributorsHelper.php
+++ b/src/Logic/GuestContributorsHelper.php
@@ -126,29 +126,19 @@ class GuestContributorsHelper {
 	/**
 	 * Assigns Guest Contributors to the Post.
 	 *
+	 * @deprecated Call UsersHelper::assign_authors_to_post() directly instead.
+	 * 
 	 * @param int   $post_id                 Post IDs.
 	 * @param array $contributor_ids         Contributor IDs.
 	 *
 	 * @return bool|WP_Error True if successful, WP_Error if not.
 	 */
 	public static function assign_contributors_to_post( int $post_id, array $contributor_ids ): bool|WP_Error {
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
 
-		if ( ! is_plugin_active( 'co-authors-plus/co-authors-plus.php' ) ) {
-			return new WP_Error( 'ERROR_COAUTHORS_PLUS', 'Co-Authors Plus plugin not found. Install and activate it before using this code.' );
-		}
+		_deprecated_function( __METHOD__, '', 'UsersHelper::assign_authors_to_post()' );
+		
+		return UsersHelper::assign_authors_to_post( $post_id, $contributor_ids );
 
-		global $coauthors_plus;
-
-		// Assign ids to post.
-		$success = $coauthors_plus->add_coauthors( $post_id, $contributor_ids, false, 'id' );
-		if ( ! $success ) {
-			return new WP_Error( 'ERROR_ASSIGN_CONTRIBUTORS', 'Failed to set authors. The add_coauthors() function did not successfully add contributors to the post.' );
-		}
-
-		return true;
 	}
 
 	/**

--- a/src/Logic/GuestContributorsHelper.php
+++ b/src/Logic/GuestContributorsHelper.php
@@ -138,7 +138,6 @@ class GuestContributorsHelper {
 		_deprecated_function( __METHOD__, '', 'UsersHelper::assign_authors_to_post()' );
 		
 		return UsersHelper::assign_authors_to_post( $post_id, $contributor_ids );
-
 	}
 
 	/**


### PR DESCRIPTION
Now that we have `UsersHelper::assign_authors_to_post` [merged](https://github.com/Automattic/newspack-migration-tools/pull/116), we no longer need the assign function on Guest Contributors.

Zak had also asked: 

> Can we make `assign_contributors_to_posts` call `UsersHelper::assign_authors_to_post` instead of deprecating for convenience?  If it's not used anywhere, we can remove it. -- Zak (via https://github.com/Automattic/newspack-migration-tools/pull/116#issuecomment-3454957917 )

Yes.  This PR will show a deprecation warning but will also run the assign to post also so that nothing breaks.

Otherwise what we could do is just update NCCM at these spots ( [one](https://github.com/Automattic/newspack-custom-content-migrator/blob/5a62fa148eb40d346e69737964e2e55860d5fece/src/Command/General/Foundation/FoundationMigrator.php#L1313) and [two](https://github.com/Automattic/newspack-custom-content-migrator/blob/5a62fa148eb40d346e69737964e2e55860d5fece/src/Command/General/Foundation/FoundationMigrator.php#L1679) ) to change those to use the UsersHelper instead.

My preference is to just merge this PR as is.  There will be more Guest Contributors changes in the near future, so this is a small non-breaking change.
