### PR TITLE
Users Helper: capture core bug on insert

### DIFF
--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -415,10 +415,11 @@ class UsersHelper {
 			throw new Exception( sprintf( 'Could not create user: %s. Context data: %s', $user_id->get_error_message(), wp_json_encode( $data ) ) );
 		}
 		if ( ! ( $user_id > 0 ) ) {
-			// Core bug could result in "0" being returned: https://core.trac.wordpress.org/ticket/53109
-			// This happens if display_name is > 250 characters. A wp_error should be returned from wp_insert_user, but instead a 
-			// value of "0" is returned. We need to check for this case since get_user_by needs a $user_id > 0, otherwise $wp_user will equal "false".
-			throw new Exception( sprintf( 'Could not create user: %s. Context data: %s', 'core bug: return was not gt 0', wp_json_encode( $data ) ) );
+			// wp_insert_user could return integer 0. We need to capture this case.
+			// While a WP_Error should be returned from wp_insert_user, but instead a value of "0" is returned.
+			// We need to check for this case since get_user_by needs a $user_id > 0, otherwise $wp_user will equal "false".
+			// One example is this bug: https://core.trac.wordpress.org/ticket/53109
+			throw new Exception( sprintf( 'Could not create user: %s. Context data: %s', 'wp_insert_user return was not gt 0', wp_json_encode( $data ) ) );
 		}
 
 		$wp_user = get_user_by( 'ID', $user_id );

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -414,6 +414,13 @@ class UsersHelper {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new Exception( sprintf( 'Could not create user: %s. Context data: %s', $user_id->get_error_message(), wp_json_encode( $data ) ) );
 		}
+		if ( ! ( $user_id > 0 ) ) {
+			// Core bug could result in "0" being returned: https://core.trac.wordpress.org/ticket/53109
+			// This happens if display_name is > 250 characters. A wp_error should be returned from wp_insert_user, but instead a 
+			// value of "0" is returned. We need to check for this case since get_user_by needs a $user_id > 0, otherwise $wp_user will equal "false".
+			throw new Exception( sprintf( 'Could not create user: %s. Context data: %s', 'core bug: return was not gt 0', wp_json_encode( $data ) ) );
+		}
+
 		$wp_user = get_user_by( 'ID', $user_id );
 
 		FileLog::get_logger( 'UsersHelper' )->notice(

--- a/tests/Logic/TestUsersHelper.php
+++ b/tests/Logic/TestUsersHelper.php
@@ -94,6 +94,19 @@ class TestUsersHelper extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_create_user_core_bug() {
+
+		// Test core bug when display_name is longer then 250 chars.
+		$this->expectException( \Exception::class );
+		UsersHelper::create_or_get_user(
+			[
+				'display_name' => str_repeat( 'a', 251 ),
+			],
+			'bork'
+		);
+
+	}
+
 	/**
 	 * Test that when a user is created – the unique identifier is set.
 	 */

--- a/tests/Logic/TestUsersHelper.php
+++ b/tests/Logic/TestUsersHelper.php
@@ -96,15 +96,24 @@ class TestUsersHelper extends WP_UnitTestCase {
 
 	public function test_create_user_core_bug() {
 
-		// Test core bug when display_name is longer then 250 chars.
+		// Test that a display name of 250 chars is OK.
+		$user = UsersHelper::create_or_get_user(
+			[
+				'display_name' => str_repeat( 'a', 250 ),
+			],
+			wp_rand()
+		);
+		$this->assertInstanceOf( 'WP_User', $user );
+
+		// Now, test that a display name of 251 chars will fail with proper error handling.
 		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'core bug: return was not gt 0' );
 		UsersHelper::create_or_get_user(
 			[
 				'display_name' => str_repeat( 'a', 251 ),
 			],
-			'bork'
+			wp_rand()
 		);
-
 	}
 
 	/**

--- a/tests/Logic/TestUsersHelper.php
+++ b/tests/Logic/TestUsersHelper.php
@@ -94,6 +94,12 @@ class TestUsersHelper extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * We need to capture if wp_insert_user returns integer 0.
+	 * 
+	 * Once such example is when display_name is > 250 chars.
+	 * @link https://core.trac.wordpress.org/ticket/53109
+	 */
 	public function test_create_user_core_bug() {
 
 		// Test that a display name of 250 chars is OK.
@@ -107,7 +113,7 @@ class TestUsersHelper extends WP_UnitTestCase {
 
 		// Now, test that a display name of 251 chars will fail with proper error handling.
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'core bug: return was not gt 0' );
+		$this->expectExceptionMessage( 'wp_insert_user return was not gt 0' );
 		UsersHelper::create_or_get_user(
 			[
 				'display_name' => str_repeat( 'a', 251 ),

--- a/tests/Logic/TestUsersHelper.php
+++ b/tests/Logic/TestUsersHelper.php
@@ -98,6 +98,7 @@ class TestUsersHelper extends WP_UnitTestCase {
 	 * We need to capture if wp_insert_user returns integer 0.
 	 * 
 	 * Once such example is when display_name is > 250 chars.
+	 * 
 	 * @link https://core.trac.wordpress.org/ticket/53109
 	 */
 	public function test_create_user_core_bug() {


### PR DESCRIPTION
Additional error checking for when `wp_insert_user` returns integer 0 - which then causes `get_user_by( 'ID', $user_id )` to not be able to get a user.

This problem can happen in WP core on [these lines](https://github.com/WordPress/WordPress/blob/884b83238ef970816587d8f877adc9bf0fc5f55d/wp-includes/user.php#L2517-L2518).

`$wpdb->insert( $wpdb->users, $data );` may return `false` on error.  But instead of a `WP_Error` being returned, the next line is run `$user_id = (int) $wpdb->insert_id;` which causes `false` to become `0`.  Thus `wp_insert_user` will return `0` instead of a proper `WP_Error`.

One example of such case is this core bug [here](https://core.trac.wordpress.org/ticket/53109).

**It's important that whenever `wp_insert_user` is called, to not only check `is_wp_error( $user_id )` but also make sure the return value is an integer greater than 0.**

The odds of this bug happening are rare (like if `display_name` is over `250 characters`), but we should still capture it if it happens.

