### PR TITLE
Add release automation script and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The repository contains a set of WP commands to migrate different data to WordPr
 
 ## Requirements
 * WordPress
-* Minimum PHP version required is 8.1.
+* Minimum PHP version required is 8.3.
 * If you use the JsonIterator class, you must have `jq` installed on your system. See [download instructions](https://jqlang.github.io/jq/download/).
 
 ## Documentation
@@ -25,7 +25,7 @@ The repository contains a set of WP commands to migrate different data to WordPr
 * [GhostCMS](./docs/GhostCMS.md)
 * [Newspaper Theme](./docs/newspaper-theme.md)
 
-## Development
+## Using the library
 
 You can load this package in your PHP project as follows:
 
@@ -39,9 +39,11 @@ _composer.json_
     }
 ],
 "require": {
-    "automattic/newspack-migration-tools": "dev-trunk"
+    "automattic/newspack-migration-tools": "VERSION"
 }
 ```
+
+Where `VERSION` is a version constraint (e.g., `^0.1.3`), or `dev-trunk` for bleeding edge. See [available releases](https://github.com/Automattic/newspack-migration-tools/releases).
 
 You can either include the `newspack-migration-tools.php` file in your code, use the classes directly, or call `NMT:setup()`.
 
@@ -73,6 +75,8 @@ foreach ( $cli_commands as $command_class ) {
     }
 }
 ```
+## Creating a release of this library.
+To create a release, make sure you have the [gh cli tool](https://cli.github.com) installed. We do releases from trunk, so switch to the trunk branch and pull so you have the latest. Then run `composer release` and follow the steps on screen. The release script will create a tag, update the plugin file version number, and create a release on Github. 
 
 ## Tests
 To get started with tests, run `./bin/install-wp-tests.sh`. If you are using Local.app, then the args could look something like this: `./bin/install-wp-tests.sh local root root "localhost:/Users/<your-username>/Library/Application Support/Local/run/<some-id>/mysql/mysqld.sock"` You can find the part to put after "socket:" on the Database tab in the local app for the site.

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,10 @@
             "rm -rf release",
             "composer install --no-dev --optimize-autoloader",
             "composer archive --format=zip --dir=release --file=newspack-migration-tools"
+        ],
+        "gh-release": [
+            "@build-release",
+            "./release.sh"
         ]
     }
 }

--- a/newspack-migration-tools.php
+++ b/newspack-migration-tools.php
@@ -1,12 +1,11 @@
 <?php
 /**
- * Newspack Migration Tools.
- *
- * Version: 0.1.3
+ * Newspack Migration Tools
  *
  * This is a library to be included by plugins. See README.md for more information.
  *
- * Requires PHP 8.1 or later.
+ * Version:           1.0.0
+ * Requires at least: 8.3
  *
  * @package newspack-migration-tools
  */

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -e
+
+# Main plugin file where the version number lives.
+PLUGIN_FILE="newspack-migration-tools.php"
+
+# Make text red.
+print_red() {
+    echo -e "\033[31m$1\033[0m"
+}
+
+# Check prerequisites before creating a release.
+check_prerequisites() {
+    # Is gh installed?
+    if ! command -v gh &> /dev/null; then
+        print_red "The 'gh' CLI tool is not installed. Please install it from https://cli.github.com in order to use this release script."
+        exit 1
+    fi
+
+    # Are we on trunk?
+    local current_branch
+    current_branch=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$current_branch" != "trunk" ]; then
+        print_red "You must be on the 'trunk' branch to create a release. Current branch: $current_branch"
+        exit 1
+    fi
+
+    # Do we have uncommitted changes?
+    if [ -n "$(git status --porcelain)" ]; then
+        print_red "You have uncommitted changes. Please commit or stash them before creating a release."
+        exit 1
+    fi
+}
+
+# Extract the current version from the plugin file.
+get_current_version() {
+    local version
+    version=$(grep "Version:" "$PLUGIN_FILE" | sed -E 's/.*Version: +([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+
+    if [ -z "$version" ]; then
+        print_red "Error: Could not find version in $PLUGIN_FILE"
+        exit 1
+    fi
+
+    echo "$version"
+}
+
+# Update the version number in the plugin file.
+update_version() {
+    local new_version=$1
+
+    # Update the version in the plugin file
+    sed -i '' -E "s/(Version: +)[0-9]+\.[0-9]+\.[0-9]+/\1$new_version/" "$PLUGIN_FILE"
+
+    printf " * Updated version in %s to %s\n" "$PLUGIN_FILE" "$new_version"
+}
+
+# Main release workflow.
+main() {
+    check_prerequisites
+
+    # Pull latest changes from remote
+    echo "Pulling latest changes from origin/trunk..."
+    git fetch origin trunk
+    git pull origin trunk
+    printf " * Up to date with remote\n"
+    echo ""
+
+    # Get current version
+    local current_version
+    current_version=$(get_current_version)
+    echo "Current version is: $current_version"
+
+    # Ask for release type as a numeric choice
+    echo ""
+    echo "Select release type:"
+    echo "  1) patch"
+    echo "  2) minor"
+    echo "  3) major"
+    printf "Enter choice [1-3]: "
+    read -r choice
+
+    # Validate numeric choice
+    if ! [[ "$choice" =~ ^[1-3]$ ]]; then
+        echo "Invalid choice. Enter a number: 1 (patch), 2 (minor), or 3 (major)."
+        exit 1
+    fi
+
+    # Calculate new version
+    local major minor patch
+    IFS='.' read -r major minor patch <<< "$current_version"
+
+    if [ "$choice" -eq 1 ]; then
+        # patch
+        patch=$((patch + 1))
+    elif [ "$choice" -eq 2 ]; then
+        # minor
+        minor=$((minor + 1))
+        patch=0
+    else
+        # major
+        major=$((major + 1))
+        minor=0
+        patch=0
+    fi
+
+    local new_version="$major.$minor.$patch"
+
+    # Confirm with user
+    printf "\nNew version will be: \033[1m%s\033[0m Do you want to proceed with this version? [y/N]: " "$new_version"
+    read -r confirm
+
+    if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+        echo "Release cancelled."
+        exit 0
+    fi
+
+    # Create the release
+    echo ""
+    echo "-------------------------------------"
+    echo "Creating release..."
+    echo "-------------------------------------"
+
+    update_version "$new_version"
+
+    git add "$PLUGIN_FILE"
+    git commit -m "Bump version to $new_version"
+    printf " * Created commit\n"
+
+    git tag "v$new_version"
+    printf " * Created tag v%s\n" "$new_version"
+
+    gh release create "v$new_version" --generate-notes release/newspack-migration-tools.zip
+    printf " * Created GitHub release with zip file\n"
+
+    git push && git push --tags
+    printf " * Pushed changes and tags\n"
+
+    echo ""
+    echo "-------------------------------------"
+    echo "Release v$new_version created successfully!"
+    echo "-------------------------------------"
+}
+
+# Run main function
+main


### PR DESCRIPTION
Add a release script to avoid the pain that is remembering how to do releases. The script requires the user to have `gh` installed.