### PR TITLE
Reassign post authorship from user A to user B

### DIFF
--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -546,15 +546,8 @@ class UsersHelper {
 	 *
 	 * @return bool|null|WP_Error True if reassignment was successful. Null if $from_user_id is not one of post's coauthors.
 	 *                            WP_Error no coauthors are found for post or assignment fails.
-	 *
-	 * @throws Exception If Co-Authors Plus plugin is not active.
 	 */
 	public static function reassign_author( int $post_id, int $from_user_id, int $to_user_id ): bool|null|WP_Error {
-		// Validate CAP is available.
-		if ( ! is_plugin_active( 'co-authors-plus/co-authors-plus.php' ) || ! function_exists( 'get_coauthors' ) ) {
-			throw new Exception( 'Co-Authors Plus plugin is not active.' );
-		}
-
 		// Get current authors for the post.
 		$current_authors = get_coauthors( $post_id );
 

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -536,4 +536,51 @@ class UsersHelper {
 
 		return true;
 	}
+
+	/**
+	 * Reassign authorship of post from one author to another. Makes sure that additional coauthors are preserved.
+	 *
+	 * @param int $post_id      Post ID.
+	 * @param int $from_user_id User ID to reassign from.
+	 * @param int $to_user_id   User ID to reassign to.
+	 *
+	 * @return bool|null|WP_Error True if reassignment was successful. Null if $from_user_id is not one of post's coauthors.
+	 *                            WP_Error no coauthors are found for post or assignment fails.
+	 *
+	 * @throws Exception If Co-Authors Plus plugin is not active.
+	 */
+	public static function reassign_author( int $post_id, int $from_user_id, int $to_user_id ): bool|null|WP_Error {
+		// Validate CAP is available.
+		if ( ! is_plugin_active( 'co-authors-plus/co-authors-plus.php' ) || ! function_exists( 'get_coauthors' ) ) {
+			throw new Exception( 'Co-Authors Plus plugin is not active.' );
+		}
+
+		// Get current authors for the post.
+		$current_authors = get_coauthors( $post_id );
+
+		// If no authors found (it might mean that author terms are missing on a legacy author setup, and that `wp co-authors-plus create-author-terms-for-posts` should be run first).
+		if ( empty( $current_authors ) ) {
+			return new WP_Error( 'ERROR_NO_AUTHORS', sprintf( 'No authors found for post ID %d.', $post_id ) );
+		}
+
+		// Get $new_author_ids.
+		$is_from_user_author = false;
+		$new_author_ids      = [];
+		foreach ( $current_authors as $author ) {
+			if ( $author->ID == $from_user_id ) {
+				$new_author_ids[]    = $to_user_id;
+				$is_from_user_author = true;
+			} else {
+				$new_author_ids[] = $author->ID;
+			}
+		}
+
+		// $from_user_id is not an author.
+		if ( false === $is_from_user_author ) {
+			return null;
+		}
+
+		// Assign new authors.
+		return self::assign_authors_to_post( $post_id, $new_author_ids );
+	}
 }


### PR DESCRIPTION
New method `reassign_author` in `UsersHelper` which reassigns post authorship from one user to another. It makes sure that other coauthors remain properly assigned, and just changes that one author from A to B.

Note for our Team -- in [this P2](https://newspackengineering.wordpress.com/2025/09/10/problems-when-instantiating-helpers-in-constructors/#comment-2207) we agreed to check if dependencies plugins are active in the constructor, but that doesn't seem to work if we use static methods for everything. That's why this checks if CAP is active in the new method directly.