### PR TITLE
Fix/users helper cap validation

### DIFF
--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -593,9 +593,9 @@ class UsersHelper {
 	
 		// Only run this function once, as long as argument(s) are the same.
 		static $validated = [];
-		$args_hash = wp_hash( serialize( func_get_args() ) );
-		if ( isset( $validated[$args_hash] ) ) {
-			return $validated[$args_hash];
+		$args_hash        = wp_hash( wp_json_encode( func_get_args() ) );
+		if ( isset( $validated[ $args_hash ] ) ) {
+			return $validated[ $args_hash ];
 		}
 
 		if ( ! function_exists( 'is_plugin_active' ) ) {
@@ -622,6 +622,8 @@ class UsersHelper {
 			return new WP_Error( 'ERROR_COAUTHORS_PLUS_GAS', 'Co-Authors Plus Guest Authors not set.' );
 		}
 
-		return ( $validated[$args_hash] = true );
+		$validated[ $args_hash ] = true;
+		
+		return $validated[ $args_hash ];
 	}
 }

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -593,7 +593,7 @@ class UsersHelper {
 	
 		// Only run this function once, as long as argument(s) are the same.
 		static $validated = [];
-		$args_key = $guest_authors ? '1' : '0';
+		$args_key         = $guest_authors ? '1' : '0';
 		if ( isset( $validated[ $args_key ] ) ) {
 			return $validated[ $args_key ];
 		}

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -518,12 +518,8 @@ class UsersHelper {
 	 */
 	public static function assign_authors_to_post( int $post_id, array $authors, bool $append = false, string $query_type = 'id' ): bool|WP_Error {
 	
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
-		if ( ! is_plugin_active( 'co-authors-plus/co-authors-plus.php' ) ) {
-			return new WP_Error( 'ERROR_COAUTHORS_PLUS', 'Co-Authors Plus plugin not found. Install and activate it before using this function.' );
+		if( true !== ( $validate_cap = self::validate_co_authors_plus() ) ) {
+			return $validate_cap;
 		}
 
 		global $coauthors_plus;
@@ -548,7 +544,12 @@ class UsersHelper {
 	 *                            WP_Error no coauthors are found for post or assignment fails.
 	 */
 	public static function reassign_author( int $post_id, int $from_user_id, int $to_user_id ): bool|null|WP_Error {
-		// Get current authors for the post.
+
+		if( true !== ( $validate_cap = self::validate_co_authors_plus() ) ) {
+			return $validate_cap;
+		}
+
+		// Get current authors for the post using Co-Authors Plus plugin's function.
 		$current_authors = get_coauthors( $post_id );
 
 		// If no authors found (it might mean that author terms are missing on a legacy author setup, and that `wp co-authors-plus create-author-terms-for-posts` should be run first).
@@ -575,5 +576,43 @@ class UsersHelper {
 
 		// Assign new authors.
 		return self::assign_authors_to_post( $post_id, $new_author_ids );
+	}
+
+	/**
+	 * Validate Co-Authors Plus.
+	 * 
+	 * For some functions of this UsersHelper class, we need to first verify Co-Authors Plus is installed and active.
+	 *
+	 * @param bool $guest_authors Is the Guest Authors feature of CAP required. Default is not required.
+	 * 
+	 * @return bool|WP_Error True if active, WP_Error if not.
+	 */
+	public static function validate_co_authors_plus( $guest_authors = false ): bool|WP_Error {
+	
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		if ( ! is_plugin_active( 'co-authors-plus/co-authors-plus.php' ) ) {
+			return new WP_Error( 'ERROR_COAUTHORS_PLUS', 'Co-Authors Plus plugin not found. Install and activate it before using this function.' );
+		}
+		
+		if ( ! isset( $GLOBALS['coauthors_plus'] ) ) {
+			return new WP_Error( 'ERROR_COAUTHORS_PLUS_OBJ', 'Co-Authors Plus global is not set.' );
+		}
+		
+		if( ! method_exists( $GLOBALS['coauthors_plus'], 'add_coauthors' ) ) {
+			return new WP_Error( 'ERROR_COAUTHORS_PLUS_ADD', 'Co-Authors Plus method add_coauthors does not exist.' );
+		}
+
+		if( ! function_exists( '\get_coauthors' ) ) {
+			return new WP_Error( 'ERROR_COAUTHORS_PLUS_GET', 'Co-Authors Plus function get_coauthors does not exist.' );
+		}
+
+		if ( $guest_authors && empty( $GLOBALS['coauthors_plus']->guest_authors ) ) {
+			return new WP_Error( 'ERROR_COAUTHORS_PLUS_GAS', 'Co-Authors Plus Guest Authors not set.' );
+		}
+
+		return true;		
 	}
 }

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -518,7 +518,8 @@ class UsersHelper {
 	 */
 	public static function assign_authors_to_post( int $post_id, array $authors, bool $append = false, string $query_type = 'id' ): bool|WP_Error {
 	
-		if( true !== ( $validate_cap = self::validate_co_authors_plus() ) ) {
+		$validate_cap = self::validate_co_authors_plus();
+		if ( true !== $validate_cap ) {
 			return $validate_cap;
 		}
 
@@ -545,7 +546,8 @@ class UsersHelper {
 	 */
 	public static function reassign_author( int $post_id, int $from_user_id, int $to_user_id ): bool|null|WP_Error {
 
-		if( true !== ( $validate_cap = self::validate_co_authors_plus() ) ) {
+		$validate_cap = self::validate_co_authors_plus();
+		if ( true !== $validate_cap ) {
 			return $validate_cap;
 		}
 
@@ -601,11 +603,11 @@ class UsersHelper {
 			return new WP_Error( 'ERROR_COAUTHORS_PLUS_OBJ', 'Co-Authors Plus global is not set.' );
 		}
 		
-		if( ! method_exists( $GLOBALS['coauthors_plus'], 'add_coauthors' ) ) {
+		if ( ! method_exists( $GLOBALS['coauthors_plus'], 'add_coauthors' ) ) {
 			return new WP_Error( 'ERROR_COAUTHORS_PLUS_ADD', 'Co-Authors Plus method add_coauthors does not exist.' );
 		}
 
-		if( ! function_exists( '\get_coauthors' ) ) {
+		if ( ! function_exists( '\get_coauthors' ) ) {
 			return new WP_Error( 'ERROR_COAUTHORS_PLUS_GET', 'Co-Authors Plus function get_coauthors does not exist.' );
 		}
 
@@ -613,6 +615,6 @@ class UsersHelper {
 			return new WP_Error( 'ERROR_COAUTHORS_PLUS_GAS', 'Co-Authors Plus Guest Authors not set.' );
 		}
 
-		return true;		
+		return true;        
 	}
 }

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -593,9 +593,9 @@ class UsersHelper {
 	
 		// Only run this function once, as long as argument(s) are the same.
 		static $validated = [];
-		$args_hash        = wp_hash( wp_json_encode( func_get_args() ) );
-		if ( isset( $validated[ $args_hash ] ) ) {
-			return $validated[ $args_hash ];
+		$args_key = $guest_authors ? '1' : '0';
+		if ( isset( $validated[ $args_key ] ) ) {
+			return $validated[ $args_key ];
 		}
 
 		if ( ! function_exists( 'is_plugin_active' ) ) {
@@ -622,8 +622,8 @@ class UsersHelper {
 			return new WP_Error( 'ERROR_COAUTHORS_PLUS_GAS', 'Co-Authors Plus Guest Authors not set.' );
 		}
 
-		$validated[ $args_hash ] = true;
+		$validated[ $args_key ] = true;
 		
-		return $validated[ $args_hash ];
+		return $validated[ $args_key ];
 	}
 }

--- a/src/Logic/UsersHelper.php
+++ b/src/Logic/UsersHelper.php
@@ -591,6 +591,13 @@ class UsersHelper {
 	 */
 	public static function validate_co_authors_plus( $guest_authors = false ): bool|WP_Error {
 	
+		// Only run this function once, as long as argument(s) are the same.
+		static $validated = [];
+		$args_hash = wp_hash( serialize( func_get_args() ) );
+		if ( isset( $validated[$args_hash] ) ) {
+			return $validated[$args_hash];
+		}
+
 		if ( ! function_exists( 'is_plugin_active' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
@@ -615,6 +622,6 @@ class UsersHelper {
 			return new WP_Error( 'ERROR_COAUTHORS_PLUS_GAS', 'Co-Authors Plus Guest Authors not set.' );
 		}
 
-		return true;        
+		return ( $validated[$args_hash] = true );
 	}
 }


### PR DESCRIPTION
This PR refactors the validation for Co-Authors Plus plugin (and it's functions) for use with some of our UsersHelper functions.

* Reinstates validation to `reassign_author` function since we need to check that CAP is active before calling it's function `get_coauthors` ( [re-instated](https://github.com/Automattic/newspack-migration-tools/pull/129/commits/502aa406636cfd485e9c534ed6c30cf470550310) concept from [PR](https://github.com/Automattic/newspack-migration-tools/pull/129) ) 
* Since our `CoAuthorsPlusHelper` will someday be fully deprecated/removed, all new functionality should be put into `UsersHelper`.  ( [old validation for reference](https://github.com/Automattic/newspack-migration-tools/blob/4df31617ea50caa59ffc09da2271f979cbd430f0/src/Logic/CoAuthorsPlusHelper.php#L47) ).
* It might be cool in the future to create some sort of trait or util that can be re-used to "validate helper dependencies".  For helpers that need to check if a plugin is installed or not, it would be cool to have a standard approach to this, but for now this PR puts the validation into a function in the same class.
