### PR TITLE
Update post without modified date, plus save revision

### DIFF
--- a/src/Logic/Posts.php
+++ b/src/Logic/Posts.php
@@ -792,9 +792,11 @@ SQL;
 
 	/**
 	 * Shorthand for updating a post without touching the post_modified and post_modified_gmt fields,
-	 * but it saves a revision before the update.
+	 * but instead of wp_update_post only doing a revison after the update, this functions saves a
+	 * revision before the update too.
 	 *
-	 * Parameters are the same as for wp_update_post.
+	 * Parameters are the same as for wp_update_post. Even though wp_update_post allows $postarr to be
+	 * optional, it's required here so that we have a post ID for saving the revision.
 	 *
 	 * @static
 	 * @access public
@@ -802,12 +804,12 @@ SQL;
 	 * @uses \Newspack\MigrationTools\Hooks\PostUpdateHook
 	 * @see https://developer.wordpress.org/reference/functions/wp_update_post/
 	 *
-	 * @param array|object $postarr          Post data. Arrays are expected to be escaped, objects are not. Default array. ID key or property is required. @see wp_update_post().
+	 * @param array|object $postarr          Post data. Arrays are expected to be escaped, objects are not. ID key or property is required. @see wp_update_post().
 	 * @param bool         $wp_error         @see wp_update_post(). Optional. Whether to return a WP_Error on failure. Default false.
 	 * @param bool         $fire_after_hooks @see wp_update_post(). Optional. Whether to fire the after insert hooks. Default true.
 	 * @return int|WP_Error The post ID on success. The value 0 or WP_Error on failure.
 	 */
-	public static function update_post_without_modified_date_with_review( array|object $postarr, bool $wp_error = false, bool $fire_after_hooks = true ) {
+	public static function update_post_without_modified_date_with_pre_revision( array|object $postarr, bool $wp_error = false, bool $fire_after_hooks = true ) {
 		// Validate if $postarr ID key/property is set.
 		if ( is_array( $postarr ) ) {
 			$post_id = $postarr['ID'] ?? null;

--- a/src/Logic/Posts.php
+++ b/src/Logic/Posts.php
@@ -808,12 +808,16 @@ SQL;
 	 * @return int|WP_Error The post ID on success. The value 0 or WP_Error on failure.
 	 */
 	public static function update_post_without_modified_date_with_review( array|object $postarr, bool $wp_error = false, bool $fire_after_hooks = true ) {
-		// Validate $postarr['ID'] is set.
-		if ( ! isset( $postarr['ID'] ) ) {
+		// Validate if $postarr ID key/property is set.
+		if ( is_array( $postarr ) ) {
+			$post_id = $postarr['ID'] ?? null;
+		} else {
+			$post_id = $postarr->ID ?? null;
+		}
+		
+		if ( ! $post_id ) {
 			return new WP_Error( 'missing_post_id', 'Post ID is required.' );
 		}
-
-		$post_id = is_array( $postarr ) ? $postarr['ID'] : $postarr->ID;
 
 		// Save revision before update.
 		wp_save_post_revision( $post_id );

--- a/src/Logic/Posts.php
+++ b/src/Logic/Posts.php
@@ -789,4 +789,35 @@ SQL;
 
 		return $result;
 	}
+
+	/**
+	 * Shorthand for updating a post without touching the post_modified and post_modified_gmt fields,
+	 * but it saves a revision before the update.
+	 *
+	 * Parameters are the same as for wp_update_post.
+	 *
+	 * @static
+	 * @access public
+	 *
+	 * @uses \Newspack\MigrationTools\Hooks\PostUpdateHook
+	 * @see https://developer.wordpress.org/reference/functions/wp_update_post/
+	 *
+	 * @param array|object $postarr          Post data. Arrays are expected to be escaped, objects are not. Default array. ID key or property is required. @see wp_update_post().
+	 * @param bool         $wp_error         @see wp_update_post(). Optional. Whether to return a WP_Error on failure. Default false.
+	 * @param bool         $fire_after_hooks @see wp_update_post(). Optional. Whether to fire the after insert hooks. Default true.
+	 * @return int|WP_Error The post ID on success. The value 0 or WP_Error on failure.
+	 */
+	public static function update_post_without_modified_date_with_review( array|object $postarr, bool $wp_error = false, bool $fire_after_hooks = true ) {
+		// Validate $postarr['ID'] is set.
+		if ( ! isset( $postarr['ID'] ) ) {
+			return new WP_Error( 'missing_post_id', 'Post ID is required.' );
+		}
+
+		$post_id = is_array( $postarr ) ? $postarr['ID'] : $postarr->ID;
+
+		// Save revision before update.
+		wp_save_post_revision( $post_id );
+
+		return self::update_post_without_modified_date( $postarr, $wp_error, $fire_after_hooks );
+	}
 }


### PR DESCRIPTION
Method which updates a post without touching the modified date, but also saves a revision before.

It is @ronchambers idea 🙌 here putting it into a new method.