### PR TITLE
Remove temp dir after tests complete

### DIFF
--- a/src/Util/CsvWriter.php
+++ b/src/Util/CsvWriter.php
@@ -27,7 +27,7 @@ class CsvWriter {
 		private string $filename
 	) {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-		$this->file_pointer = fopen( getcwd() . '/' . $this->filename, 'a+' );
+		$this->file_pointer = fopen( $this->filename, 'a+' );
 
 		if ( false === $this->file_pointer ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped

--- a/tests/Util/CsvWriterTest.php
+++ b/tests/Util/CsvWriterTest.php
@@ -31,6 +31,7 @@ class CsvWriterTest extends TestCase {
 	protected function tearDown(): void {
 		if ( file_exists( $this->test_file ) ) {
 			unlink( $this->test_file );
+			rmdir( dirname( $this->test_file ) );
 		}
 	}
 

--- a/tests/Util/CsvWriterTest.php
+++ b/tests/Util/CsvWriterTest.php
@@ -31,6 +31,7 @@ class CsvWriterTest extends TestCase {
 	protected function tearDown(): void {
 		if ( file_exists( $this->test_file ) ) {
 			unlink( $this->test_file );
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.directory_rmdir
 			rmdir( dirname( $this->test_file ) );
 		}
 	}

--- a/tests/Util/CsvWriterTest.php
+++ b/tests/Util/CsvWriterTest.php
@@ -20,9 +20,10 @@ class CsvWriterTest extends TestCase {
 
 		$random_dir_name = wp_unique_filename( $temp_dir, uniqid( time() ) );
 
-		wp_mkdir_p( $random_dir_name );
+		wp_mkdir_p( $temp_dir . $random_dir_name );
 
-		$this->test_file = $random_dir_name . '/test.csv';
+		$this->test_file = $temp_dir . $random_dir_name . '/test.csv';
+
 		if ( file_exists( $this->test_file ) ) {
 			unlink( $this->test_file );
 		}


### PR DESCRIPTION
## Summary

Removes the temporary directory being created when the CSVWriter tests are being executed.

## Related Issue

https://github.com/Automattic/newspack-migration-tools/issues/79