### PR TITLE
Optional command argument for path to data in JSON file

### DIFF
--- a/docs/GhostCMS.md
+++ b/docs/GhostCMS.md
@@ -65,7 +65,7 @@ Standard `jq`-style path notation to node in JSON where posts (and other objects
 
 Default value path (to posts and other data) is `.db[0].data`.
 To test for path, you can use `jq` from CLI like:
-- count posts: `jq '.db[0].data.posts' | length export.json`
+- count posts: `jq '.db[0].data.posts | length' export.json`
 - list posts:  `jq '.db[0].data.posts' export.json`
 ```
 

--- a/docs/GhostCMS.md
+++ b/docs/GhostCMS.md
@@ -59,6 +59,14 @@ Optional arguments:
 ```
 --created-after=<created-after>
 Datetime cut-off to only import posts AFTER this date. (Must be parseable by strtotime).
+
+--json-data-path=<json-data-path>
+Standard `jq`-style path notation to node in JSON where posts (and other objects) are stored (e.g., --json-data-path=".db[0].data" or --json-data-path=".data").
+
+Default value path (to posts and other data) is `.db[0].data`.
+To test for path, you can use `jq` from CLI like:
+- count posts: `jq '.db[0].data.posts' | length export.json`
+- list posts:  `jq '.db[0].data.posts' export.json`
 ```
 
 ### Step 4: Run a test
@@ -75,7 +83,7 @@ For testing, you can use these test values (with the included `json` test file):
 
 Command (_be sure to replace your values_):
 ```
-wp newspack-migration-tools ghostcms-import --default-user-id=<default-user-id> --ghost-url=<ghost-url> --json-file=<json-file> [--created-after=<created-after>]
+wp newspack-migration-tools ghostcms-import --default-user-id=<default-user-id> --ghost-url=<ghost-url> --json-file=<json-file> [--created-after=<created-after>] [--json-data-path=<json-data-path>]
 ```
 
 If the migrator command is stopped mid-migration, it is OK to simply re-run the command.

--- a/src/Command/GhostCMSMigrator.php
+++ b/src/Command/GhostCMSMigrator.php
@@ -69,7 +69,7 @@ class GhostCMSMigrator implements WpCliCommandInterface {
 							'description' => 'Standard jq-style path notation to node in JSON where posts (and other objects) are stored (e.g., `.db[0].data` or `.data`). ' . 
 											'To test for path, use jq commands like: ' .
 											" - list posts:  `jq '.db[0].data.posts' export.json` " .
-											" - count posts: `jq '.db[0].data.posts' | length export.json` " .
+											" - count posts: `jq '.db[0].data.posts | length' export.json` " .
 											'Default value (path to posts) is `.db[0].data`.',
 							'optional'    => true,
 							'repeating'   => false,

--- a/src/Command/GhostCMSMigrator.php
+++ b/src/Command/GhostCMSMigrator.php
@@ -63,6 +63,17 @@ class GhostCMSMigrator implements WpCliCommandInterface {
 							'optional'    => true,
 							'repeating'   => false,
 						),
+						array(
+							'type'        => 'assoc',
+							'name'        => 'json-data-path',
+							'description' => 'Standard jq-style path notation to node in JSON where posts (and other objects) are stored (e.g., `.db[0].data` or `.data`). ' . 
+											'To test for path, use jq commands like: ' .
+											" - list posts:  `jq '.db[0].data.posts' export.json` " .
+											" - count posts: `jq '.db[0].data.posts' | length export.json` " .
+											'Default value (path to posts) is `.db[0].data`.',
+							'optional'    => true,
+							'repeating'   => false,
+						),
 
 					),
 				],

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -583,7 +583,7 @@ class GhostCMSHelper {
 	 * 
 	 * @return object|null The resolved data node or null if path is invalid.
 	 */
-	public function get_json_data_from_path( string $path, object $json ): ?object {
+	private function get_json_data_from_path( string $path, object $json ): ?object {
 		// Strip leading dot if present.
 		$path = ltrim( $path, '.' );
 

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -89,6 +89,18 @@ class GhostCMSHelper {
 	}
 
 	/**
+	 * Set the JSON data object.
+	 *
+	 * Primarily used for unit testing to inject test data.
+	 *
+	 * @param object $json The JSON data object.
+	 * @return void
+	 */
+	public function set_json( object $json ): void {
+		$this->json = $json;
+	}
+
+	/**
 	 * Import GhostCMS Content from JSON file.
 	 * 
 	 * @param array  $pos_args Positional arguments.
@@ -342,7 +354,7 @@ class GhostCMSHelper {
 	 * @param int    $post_id Post ID (optional).
 	 * @return int|WP_Error $attachment_id
 	 */
-	private function get_or_import_url( string $path, string $title, string $caption = null, string $description = null, string $alt = null, int $post_id = 0 ): int|WP_Error {
+	private function get_or_import_url( string $path, string $title, ?string $caption = null, ?string $description = null, ?string $alt = null, int $post_id = 0 ): int|WP_Error {
 
 		global $wpdb;
 

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -52,13 +52,6 @@ class GhostCMSHelper {
 	private ?object $data = null;
 
 	/**
-	 * JSON from file
-	 *
-	 * @var object $json
-	 */
-	private object $json;
-
-	/**
 	 * Log slug.
 	 *
 	 * @var string $log_slug
@@ -86,18 +79,6 @@ class GhostCMSHelper {
 	 */
 	public function __construct() {
 		// Nothing for now.
-	}
-
-	/**
-	 * Set the JSON data object.
-	 *
-	 * Primarily used for unit testing to inject test data.
-	 *
-	 * @param object $json The JSON data object.
-	 * @return void
-	 */
-	public function set_json( object $json ): void {
-		$this->json = $json;
 	}
 
 	/**
@@ -168,16 +149,16 @@ class GhostCMSHelper {
 			$this->log( 'JSON file not found.', LogLevel::ERROR, true );
 		}
 
-		$this->json = json_decode( file_get_contents( $assoc_args['json-file'] ), null, 2147483647 );
+		$json = json_decode( file_get_contents( $assoc_args['json-file'] ), null, 2147483647 );
 
-		if ( 0 != json_last_error() || 'No error' != json_last_error_msg() ) {
+		if ( ! is_object( $json ) || 0 != json_last_error() || 'No error' != json_last_error_msg() ) {
 			$this->log( 'JSON file could not be parsed.', LogLevel::ERROR, true );
 		}
 
 		// --json-data-path (optional, defaults to .db[0].data).
 
 		$json_data_path = $assoc_args['json-data-path'] ?? '.db[0].data';
-		$this->data     = $this->get_json_data_from_path( $json_data_path );
+		$this->data     = $this->get_json_data_from_path( $json_data_path, $json );
 
 		if ( null === $this->data ) {
 			$this->log( sprintf( 'JSON data path "%s" could not be resolved.', $json_data_path ), LogLevel::ERROR, true );
@@ -598,18 +579,22 @@ class GhostCMSHelper {
 	 * Get JSON data node from a jq-style path.
 	 *
 	 * @param string $path jq-style path (e.g., ".db[0].data" or "data").
+	 * 
+	 * 
+	 * 
+	 * 
 	 * @return object|null The resolved data node or null if path is invalid.
 	 */
-	private function get_json_data_from_path( string $path ): ?object {
+	public function get_json_data_from_path( string $path, object $json ): ?object {
 		// Strip leading dot if present.
 		$path = ltrim( $path, '.' );
 
 		if ( empty( $path ) ) {
-			return is_object( $this->json ) ? $this->json : null;
+			return $json;
 		}
 
 		// $current is the current object we are working on, it's like a bookmark that tracks where we are as we walk through a nested JSON structure.
-		$current = $this->json;
+		$current = $json;
 
 		// Split jq-style path by dots: "db[0].data" becomes ["db[0]", "data"].
 		$tokens = explode( '.', $path );

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -596,11 +596,11 @@ class GhostCMSHelper {
 			return is_object( $this->json ) ? $this->json : null;
 		}
 
-		// Parse jq-style path: split by dots and brackets.
-		// e.g., "db[0].data" becomes ["db", "[0]", "data"].
-		$tokens  = preg_split( '/\.(?![^\[]*\])/', $path );
+		// $current is the current object we are working on, it's like a bookmark that tracks where we are as we walk through a nested JSON structure.
 		$current = $this->json;
 
+		// Split jq-style path by dots: "db[0].data" becomes ["db[0]", "data"].
+		$tokens = explode( '.', $path );
 		foreach ( $tokens as $token ) {
 			if ( empty( $token ) ) {
 				continue;

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -165,7 +165,7 @@ class GhostCMSHelper {
 		}
 
 		if ( empty( $this->data->posts ) ) {
-			$this->log( 'JSON file contained no posts.', LogLevel::ERROR, true );
+			$this->log( sprintf( 'JSON file contained no posts at data path: %s', $json_data_path ), LogLevel::ERROR, true );
 		}
 
 		// Start processing.
@@ -579,9 +579,7 @@ class GhostCMSHelper {
 	 * Get JSON data node from a jq-style path.
 	 *
 	 * @param string $path jq-style path (e.g., ".db[0].data" or "data").
-	 * 
-	 * 
-	 * 
+	 * @param object $json JSON object.
 	 * 
 	 * @return object|null The resolved data node or null if path is invalid.
 	 */
@@ -590,6 +588,7 @@ class GhostCMSHelper {
 		$path = ltrim( $path, '.' );
 
 		if ( empty( $path ) ) {
+			// path was either blank or dot - which means the "root" object.
 			return $json;
 		}
 

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -45,6 +45,13 @@ class GhostCMSHelper {
 	private string $ghost_url;
 
 	/**
+	 * JSON data node (resolved from json-data-path).
+	 *
+	 * @var object $data
+	 */
+	private ?object $data = null;
+
+	/**
 	 * JSON from file
 	 *
 	 * @var object $json
@@ -150,18 +157,28 @@ class GhostCMSHelper {
 		}
 
 		$this->json = json_decode( file_get_contents( $assoc_args['json-file'] ), null, 2147483647 );
-		
+
 		if ( 0 != json_last_error() || 'No error' != json_last_error_msg() ) {
 			$this->log( 'JSON file could not be parsed.', LogLevel::ERROR, true );
 		}
-		
-		if ( empty( $this->json->db[0]->data->posts ) ) {
+
+		// --json-data-path (optional, defaults to .db[0].data).
+
+		$json_data_path = $assoc_args['json-data-path'] ?? '.db[0].data';
+		$this->data     = $this->get_json_data_from_path( $json_data_path );
+
+		if ( null === $this->data ) {
+			$this->log( sprintf( 'JSON data path "%s" could not be resolved.', $json_data_path ), LogLevel::ERROR, true );
+		}
+
+		if ( empty( $this->data->posts ) ) {
 			$this->log( 'JSON file contained no posts.', LogLevel::ERROR, true );
 		}
 
 		// Start processing.
 		$this->log( 'Doing migration.' );
 		$this->log( '--json-file: ' . $assoc_args['json-file'] );
+		$this->log( '--json-data-path: ' . $json_data_path );
 		$this->log( '--ghost-url: ' . $this->ghost_url );
 		$this->log( '--default-user-id: ' . $default_user->ID );
 		
@@ -171,7 +188,7 @@ class GhostCMSHelper {
 		}
 		
 		// Insert posts.
-		foreach ( $this->json->db[0]->data->posts as $json_post ) {
+		foreach ( $this->data->posts as $json_post ) {
 
 			$this->log( '---- json id: ' . $json_post->id );
 			$this->log( 'Title/Slug: ' . $json_post->title . ' / ' . $json_post->slug );
@@ -256,11 +273,11 @@ class GhostCMSHelper {
 	 */
 	private function get_json_author_user_by_id( string $json_author_user_id ): ?object {
 
-		if ( empty( $this->json->db[0]->data->users ) ) {
+		if ( empty( $this->data->users ) ) {
 			return null;
 		}
 
-		foreach ( $this->json->db[0]->data->users as $json_author_user ) {
+		foreach ( $this->data->users as $json_author_user ) {
 
 			if ( $json_author_user->id == $json_author_user_id ) {
 				return $json_author_user;
@@ -278,11 +295,11 @@ class GhostCMSHelper {
 	 */
 	private function get_json_post_meta( string $json_post_id ): ?object {
 
-		if ( empty( $this->json->db[0]->data->posts_meta ) ) {
+		if ( empty( $this->data->posts_meta ) ) {
 			return null;
 		}
 
-		foreach ( $this->json->db[0]->data->posts_meta as $json_post_meta ) {
+		foreach ( $this->data->posts_meta as $json_post_meta ) {
 
 			if ( $json_post_meta->post_id == $json_post_id ) {
 				return $json_post_meta;
@@ -300,11 +317,11 @@ class GhostCMSHelper {
 	 */
 	private function get_json_tag_by_id( string $json_tag_id ): ?object {
 
-		if ( empty( $this->json->db[0]->data->tags ) ) {
+		if ( empty( $this->data->tags ) ) {
 			return null;
 		}
 
-		foreach ( $this->json->db[0]->data->tags as $json_tag ) {
+		foreach ( $this->data->tags as $json_tag ) {
 
 			if ( $json_tag->id == $json_tag_id ) {
 				return $json_tag;
@@ -566,6 +583,78 @@ class GhostCMSHelper {
 	}
 
 	/**
+	 * Get JSON data node from a jq-style path.
+	 *
+	 * @param string $path jq-style path (e.g., ".db[0].data" or "data").
+	 * @return object|null The resolved data node or null if path is invalid.
+	 */
+	private function get_json_data_from_path( string $path ): ?object {
+		// Strip leading dot if present.
+		$path = ltrim( $path, '.' );
+
+		if ( empty( $path ) ) {
+			return is_object( $this->json ) ? $this->json : null;
+		}
+
+		// Parse jq-style path: split by dots and brackets.
+		// e.g., "db[0].data" becomes ["db", "[0]", "data"].
+		$tokens  = preg_split( '/\.(?![^\[]*\])/', $path );
+		$current = $this->json;
+
+		foreach ( $tokens as $token ) {
+			if ( empty( $token ) ) {
+				continue;
+			}
+
+			/**
+			 * Pattern to match bracket notation: property[index] or just [index].
+			 *
+			 * ^           - Start of string
+			 * ([^\[]*)    - Capture group 1 -- zero or more characters that are NOT "[".
+			 *              This captures the property name (e.g., "db" in "db[0]").
+			 *              Can be empty for standalone indices like "[0]".
+			 * \[          - Literal "["
+			 * (\d+)       - Capture group 2 -- one or more digits (the array index)
+			 * \]          - Literal "]"
+			 * $           - End of string
+			 *
+			 * Examples:
+			 *   "db[0]"  => matches, $matches[1] = "db",  $matches[2] = "0"
+			 *   "[0]"    => matches, $matches[1] = "",    $matches[2] = "0"
+			 *   "data"   => no match (no brackets)
+			 */
+			$pattern = '/^([^\[]*)\[(\d+)\]$/';
+			if ( preg_match( $pattern, $token, $matches ) ) {
+				$property = $matches[1];
+				$index    = (int) $matches[2];
+
+				// Access property first if present.
+				if ( ! empty( $property ) ) {
+					if ( is_object( $current ) && isset( $current->{$property} ) ) {
+						$current = $current->{$property};
+					} else {
+						return null;
+					}
+				}
+
+				// Then access array index.
+				if ( is_array( $current ) && isset( $current[ $index ] ) ) {
+					$current = $current[ $index ];
+				} else {
+					return null;
+				}
+			} elseif ( is_object( $current ) && isset( $current->{$token} ) ) {
+				// Simple property access.
+				$current = $current->{$token};
+			} else {
+				return null;
+			}
+		}
+
+		return is_object( $current ) ? $current : null;
+	}
+
+	/**
 	 * Log wrapper function incase logging needs to be updated in future it can be changed here.
 	 *
 	 * @param string  $message The message to log.
@@ -605,7 +694,7 @@ class GhostCMSHelper {
 	 */
 	private function set_post_authors( int $wp_post_id, string $json_post_id ): void {
 
-		if ( empty( $this->json->db[0]->data->posts_authors ) ) {
+		if ( empty( $this->data->posts_authors ) ) {
 			$this->log( 'JSON has no post author relationships.', LogLevel::WARNING );
 			return;
 		}
@@ -613,7 +702,7 @@ class GhostCMSHelper {
 		$wp_user_ids = [];
 
 		// Each posts_authors relationship.
-		foreach ( $this->json->db[0]->data->posts_authors as $json_post_author ) {
+		foreach ( $this->data->posts_authors as $json_post_author ) {
 			// Skip if post id does not match relationship.
 			if ( $json_post_author->post_id != $json_post_id ) {
 				continue;
@@ -713,7 +802,7 @@ class GhostCMSHelper {
 	 */
 	private function set_post_tags_to_categories( int $wp_post_id, string $json_post_id ): void {
 
-		if ( empty( $this->json->db[0]->data->posts_tags ) ) {
+		if ( empty( $this->data->posts_tags ) ) {
 			
 			$this->log( 'JSON has no post tags (category) relationships.', LogLevel::WARNING );
 
@@ -724,7 +813,7 @@ class GhostCMSHelper {
 		$category_ids = [];
 
 		// Each posts_tags relationship.
-		foreach ( $this->json->db[0]->data->posts_tags as $json_post_tag ) {
+		foreach ( $this->data->posts_tags as $json_post_tag ) {
 			
 			// Skip if post id does not match relationship.
 			if ( $json_post_tag->post_id != $json_post_id ) {

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -56,7 +56,7 @@ class GhostCMSHelper {
 	 *
 	 * @var object $json
 	 */
-	private object $json;
+	private ?object $json = null;
 
 	/**
 	 * Log slug.
@@ -170,7 +170,7 @@ class GhostCMSHelper {
 
 		$this->json = json_decode( file_get_contents( $assoc_args['json-file'] ), null, 2147483647 );
 
-		if ( 0 != json_last_error() || 'No error' != json_last_error_msg() ) {
+		if ( ! is_object( $this->json ) || 0 != json_last_error() || 'No error' != json_last_error_msg() ) {
 			$this->log( 'JSON file could not be parsed.', LogLevel::ERROR, true );
 		}
 

--- a/tests/Logic/TestGhostCMSHelper.php
+++ b/tests/Logic/TestGhostCMSHelper.php
@@ -4,9 +4,273 @@ namespace Newspack\MigrationTools\Tests\Logic;
 
 use Newspack\Guest_Contributor_Role;
 use Newspack\MigrationTools\Logic\GhostCMSHelper;
+use ReflectionClass;
 use WP_UnitTestCase;
 
 class TestGhostCMSHelper extends WP_UnitTestCase {
+
+	/**
+	 * Helper to invoke the private get_json_data_from_path method.
+	 *
+	 * @param GhostCMSHelper $helper The helper instance with JSON set.
+	 * @param string         $path   The jq-style path to resolve.
+	 * @return object|null The resolved data node or null.
+	 */
+	private function invoke_get_json_data_from_path( GhostCMSHelper $helper, string $path ): ?object {
+		$reflection = new ReflectionClass( $helper );
+		$method     = $reflection->getMethod( 'get_json_data_from_path' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $helper, $path );
+	}
+
+	/**
+	 * Test empty path returns the root JSON object.
+	 *
+	 * @return void
+	 */
+	public function test_get_json_data_from_path_empty_path_returns_root(): void {
+		$json = json_decode( '{"db": [{"data": {"posts": []}}]}' );
+
+		$helper = new GhostCMSHelper();
+		$helper->set_json( $json );
+
+		$result = $this->invoke_get_json_data_from_path( $helper, '' );
+
+		$this->assertSame( $json, $result );
+	}
+
+	/**
+	 * Test path with leading dot is stripped and works correctly.
+	 *
+	 * @return void
+	 */
+	public function test_get_json_data_from_path_strips_leading_dot(): void {
+		$json = json_decode( '{"db": [{"data": {"posts": []}}]}' );
+
+		$helper = new GhostCMSHelper();
+		$helper->set_json( $json );
+
+		$result = $this->invoke_get_json_data_from_path( $helper, '.db[0].data' );
+
+		$this->assertIsObject( $result );
+		$this->assertTrue( property_exists( $result, 'posts' ) );
+	}
+
+	/**
+	 * Test simple property access.
+	 *
+	 * @return void
+	 */
+	public function test_get_json_data_from_path_simple_property(): void {
+		$json = json_decode( '{"settings": {"theme": "dark"}}' );
+
+		$helper = new GhostCMSHelper();
+		$helper->set_json( $json );
+
+		$result = $this->invoke_get_json_data_from_path( $helper, 'settings' );
+
+		$this->assertIsObject( $result );
+		$this->assertEquals( 'dark', $result->theme );
+	}
+
+	/**
+	 * Test nested property access with dots.
+	 *
+	 * @return void
+	 */
+	public function test_get_json_data_from_path_nested_properties(): void {
+		$json = json_decode( '{"level1": {"level2": {"level3": {"value": "deep"}}}}' );
+
+		$helper = new GhostCMSHelper();
+		$helper->set_json( $json );
+
+		$result = $this->invoke_get_json_data_from_path( $helper, 'level1.level2.level3' );
+
+		$this->assertIsObject( $result );
+		$this->assertEquals( 'deep', $result->value );
+	}
+
+	/**
+	 * Test array index access with property.
+	 *
+	 * @return void
+	 */
+	public function test_get_json_data_from_path_array_index_with_property(): void {
+		$json = json_decode( '{"db": [{"name": "first"}, {"name": "second"}, {"name": "third"}]}' );
+
+		$helper = new GhostCMSHelper();
+		$helper->set_json( $json );
+
+		// Access first element.
+		$result = $this->invoke_get_json_data_from_path( $helper, 'db[0]' );
+		$this->assertIsObject( $result );
+		$this->assertEquals( 'first', $result->name );
+
+		// Access second element.
+		$result = $this->invoke_get_json_data_from_path( $helper, 'db[1]' );
+		$this->assertIsObject( $result );
+		$this->assertEquals( 'second', $result->name );
+
+		// Access third element.
+		$result = $this->invoke_get_json_data_from_path( $helper, 'db[2]' );
+		$this->assertIsObject( $result );
+		$this->assertEquals( 'third', $result->name );
+	}
+
+	/**
+	 * Test typical Ghost CMS path: db[0].data
+	 *
+	 * @return void
+	 */
+	public function test_get_json_data_from_path_ghost_cms_typical_path(): void {
+		$json = json_decode(
+			'{
+			"db": [{
+				"meta": {"version": "5.0"},
+				"data": {
+					"posts": [{"title": "Hello"}],
+					"tags": [{"name": "News"}],
+					"users": [{"name": "Author"}]
+				}
+			}]
+		}' 
+		);
+
+		$helper = new GhostCMSHelper();
+		$helper->set_json( $json );
+
+		$result = $this->invoke_get_json_data_from_path( $helper, 'db[0].data' );
+
+		$this->assertIsObject( $result );
+		$this->assertTrue( property_exists( $result, 'posts' ) );
+		$this->assertTrue( property_exists( $result, 'tags' ) );
+		$this->assertTrue( property_exists( $result, 'users' ) );
+	}
+
+	/**
+	 * Test deeply nested path with multiple array indices.
+	 *
+	 * @return void
+	 */
+	public function test_get_json_data_from_path_multiple_array_indices(): void {
+		$json = json_decode(
+			'{
+			"databases": [{
+				"tables": [{
+					"rows": [{"id": 1}, {"id": 2}]
+				}]
+			}]
+		}' 
+		);
+
+		$helper = new GhostCMSHelper();
+		$helper->set_json( $json );
+
+		$result = $this->invoke_get_json_data_from_path( $helper, 'databases[0].tables[0]' );
+
+		$this->assertIsObject( $result );
+		$this->assertTrue( property_exists( $result, 'rows' ) );
+	}
+
+	/**
+	 * Test non-existent property returns null.
+	 *
+	 * @return void
+	 */
+	public function test_get_json_data_from_path_nonexistent_property_returns_null(): void {
+		$json = json_decode( '{"existing": {"value": 1}}' );
+
+		$helper = new GhostCMSHelper();
+		$helper->set_json( $json );
+
+		$result = $this->invoke_get_json_data_from_path( $helper, 'nonexistent' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test non-existent nested property returns null.
+	 *
+	 * @return void
+	 */
+	public function test_get_json_data_from_path_nonexistent_nested_property_returns_null(): void {
+		$json = json_decode( '{"level1": {"level2": {}}}' );
+
+		$helper = new GhostCMSHelper();
+		$helper->set_json( $json );
+
+		$result = $this->invoke_get_json_data_from_path( $helper, 'level1.level2.level3' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test array index out of bounds returns null.
+	 *
+	 * @return void
+	 */
+	public function test_get_json_data_from_path_index_out_of_bounds_returns_null(): void {
+		$json = json_decode( '{"items": [{"id": 1}, {"id": 2}]}' );
+
+		$helper = new GhostCMSHelper();
+		$helper->set_json( $json );
+
+		$result = $this->invoke_get_json_data_from_path( $helper, 'items[99]' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test accessing array index on non-array returns null.
+	 *
+	 * @return void
+	 */
+	public function test_get_json_data_from_path_index_on_non_array_returns_null(): void {
+		$json = json_decode( '{"notArray": {"key": "value"}}' );
+
+		$helper = new GhostCMSHelper();
+		$helper->set_json( $json );
+
+		$result = $this->invoke_get_json_data_from_path( $helper, 'notArray[0]' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test accessing property on non-existent intermediate path returns null.
+	 *
+	 * @return void
+	 */
+	public function test_get_json_data_from_path_invalid_intermediate_path_returns_null(): void {
+		$json = json_decode( '{"db": [{"data": {}}]}' );
+
+		$helper = new GhostCMSHelper();
+		$helper->set_json( $json );
+
+		$result = $this->invoke_get_json_data_from_path( $helper, 'db[0].invalid.something' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test path that resolves to non-object returns null.
+	 *
+	 * The method explicitly returns null if the final result is not an object.
+	 *
+	 * @return void
+	 */
+	public function test_get_json_data_from_path_non_object_result_returns_null(): void {
+		$json = json_decode( '{"config": {"name": "test"}}' );
+
+		$helper = new GhostCMSHelper();
+		$helper->set_json( $json );
+
+		// "name" is a string, not an object.
+		$result = $this->invoke_get_json_data_from_path( $helper, 'config.name' );
+
+		$this->assertNull( $result );
+	}
 
 	/**
 	 * Test that GhostCMS Helper will import from JSON file.

--- a/tests/Logic/TestGhostCMSHelper.php
+++ b/tests/Logic/TestGhostCMSHelper.php
@@ -4,9 +4,26 @@ namespace Newspack\MigrationTools\Tests\Logic;
 
 use Newspack\Guest_Contributor_Role;
 use Newspack\MigrationTools\Logic\GhostCMSHelper;
+use ReflectionClass;
 use WP_UnitTestCase;
 
 class TestGhostCMSHelper extends WP_UnitTestCase {
+
+	/**
+	 * Helper to invoke the private get_json_data_from_path method.
+	 *
+	 * @param GhostCMSHelper $helper The helper instance with JSON set.
+	 * @param string         $path   The jq-style path to resolve.
+	 * @param object         $json   The JSON object.
+	 * @return object|null The resolved data node or null.
+	 */
+	private function invoke_get_json_data_from_path( GhostCMSHelper $helper, string $path, object $json ): ?object {
+		$reflection = new ReflectionClass( $helper );
+		$method     = $reflection->getMethod( 'get_json_data_from_path' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $helper, $path, $json );
+	}
 
 	/**
 	 * Test empty path returns the root JSON object.
@@ -18,7 +35,7 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 
 		$helper = new GhostCMSHelper();
 
-		$result = $helper->get_json_data_from_path( '', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, '', $json );
 
 		$this->assertSame( $json, $result );
 	}
@@ -33,7 +50,7 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 
 		$helper = new GhostCMSHelper();
 
-		$result = $helper->get_json_data_from_path( '.db[0].data', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, '.db[0].data', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertTrue( property_exists( $result, 'posts' ) );
@@ -49,7 +66,7 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 
 		$helper = new GhostCMSHelper();
 
-		$result = $helper->get_json_data_from_path( 'settings', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, 'settings', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'dark', $result->theme );
@@ -65,7 +82,7 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 
 		$helper = new GhostCMSHelper();
 
-		$result = $helper->get_json_data_from_path( 'level1.level2.level3', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, 'level1.level2.level3', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'deep', $result->value );
@@ -82,17 +99,17 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$helper = new GhostCMSHelper();
 
 		// Access first element.
-		$result = $helper->get_json_data_from_path( 'db[0]', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, 'db[0]', $json );
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'first', $result->name );
 
 		// Access second element.
-		$result = $helper->get_json_data_from_path( 'db[1]', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, 'db[1]', $json );
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'second', $result->name );
 
 		// Access third element.
-		$result = $helper->get_json_data_from_path( 'db[2]', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, 'db[2]', $json );
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'third', $result->name );
 	}
@@ -118,7 +135,7 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 
 		$helper = new GhostCMSHelper();
 
-		$result = $helper->get_json_data_from_path( 'db[0].data', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, 'db[0].data', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertTrue( property_exists( $result, 'posts' ) );
@@ -144,7 +161,7 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 
 		$helper = new GhostCMSHelper();
 
-		$result = $helper->get_json_data_from_path( 'databases[0].tables[0]', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, 'databases[0].tables[0]', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertTrue( property_exists( $result, 'rows' ) );
@@ -160,7 +177,7 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 
 		$helper = new GhostCMSHelper();
 
-		$result = $helper->get_json_data_from_path( 'nonexistent', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, 'nonexistent', $json );
 
 		$this->assertNull( $result );
 	}
@@ -175,7 +192,7 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 
 		$helper = new GhostCMSHelper();
 
-		$result = $helper->get_json_data_from_path( 'level1.level2.level3', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, 'level1.level2.level3', $json );
 
 		$this->assertNull( $result );
 	}
@@ -190,7 +207,7 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 
 		$helper = new GhostCMSHelper();
 
-		$result = $helper->get_json_data_from_path( 'items[99]', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, 'items[99]', $json );
 
 		$this->assertNull( $result );
 	}
@@ -205,7 +222,7 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 
 		$helper = new GhostCMSHelper();
 
-		$result = $helper->get_json_data_from_path( 'notArray[0]', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, 'notArray[0]', $json );
 
 		$this->assertNull( $result );
 	}
@@ -220,7 +237,7 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 
 		$helper = new GhostCMSHelper();
 
-		$result = $helper->get_json_data_from_path( 'db[0].invalid.something', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, 'db[0].invalid.something', $json );
 
 		$this->assertNull( $result );
 	}
@@ -238,7 +255,7 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$helper = new GhostCMSHelper();
 
 		// "name" is a string, not an object.
-		$result = $helper->get_json_data_from_path( 'config.name', $json );
+		$result = $this->invoke_get_json_data_from_path( $helper, 'config.name', $json );
 
 		$this->assertNull( $result );
 	}

--- a/tests/Logic/TestGhostCMSHelper.php
+++ b/tests/Logic/TestGhostCMSHelper.php
@@ -4,25 +4,9 @@ namespace Newspack\MigrationTools\Tests\Logic;
 
 use Newspack\Guest_Contributor_Role;
 use Newspack\MigrationTools\Logic\GhostCMSHelper;
-use ReflectionClass;
 use WP_UnitTestCase;
 
 class TestGhostCMSHelper extends WP_UnitTestCase {
-
-	/**
-	 * Helper to invoke the private get_json_data_from_path method.
-	 *
-	 * @param GhostCMSHelper $helper The helper instance with JSON set.
-	 * @param string         $path   The jq-style path to resolve.
-	 * @return object|null The resolved data node or null.
-	 */
-	private function invoke_get_json_data_from_path( GhostCMSHelper $helper, string $path ): ?object {
-		$reflection = new ReflectionClass( $helper );
-		$method     = $reflection->getMethod( 'get_json_data_from_path' );
-		$method->setAccessible( true );
-
-		return $method->invoke( $helper, $path );
-	}
 
 	/**
 	 * Test empty path returns the root JSON object.
@@ -33,9 +17,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"db": [{"data": {"posts": []}}]}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, '' );
+		$result = $helper->get_json_data_from_path( '', $json );
 
 		$this->assertSame( $json, $result );
 	}
@@ -49,9 +32,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"db": [{"data": {"posts": []}}]}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, '.db[0].data' );
+		$result = $helper->get_json_data_from_path( '.db[0].data', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertTrue( property_exists( $result, 'posts' ) );
@@ -66,9 +48,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"settings": {"theme": "dark"}}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'settings' );
+		$result = $helper->get_json_data_from_path( 'settings', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'dark', $result->theme );
@@ -83,9 +64,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"level1": {"level2": {"level3": {"value": "deep"}}}}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'level1.level2.level3' );
+		$result = $helper->get_json_data_from_path( 'level1.level2.level3', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'deep', $result->value );
@@ -100,20 +80,19 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"db": [{"name": "first"}, {"name": "second"}, {"name": "third"}]}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
 		// Access first element.
-		$result = $this->invoke_get_json_data_from_path( $helper, 'db[0]' );
+		$result = $helper->get_json_data_from_path( 'db[0]', $json );
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'first', $result->name );
 
 		// Access second element.
-		$result = $this->invoke_get_json_data_from_path( $helper, 'db[1]' );
+		$result = $helper->get_json_data_from_path( 'db[1]', $json );
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'second', $result->name );
 
 		// Access third element.
-		$result = $this->invoke_get_json_data_from_path( $helper, 'db[2]' );
+		$result = $helper->get_json_data_from_path( 'db[2]', $json );
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'third', $result->name );
 	}
@@ -138,9 +117,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		);
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'db[0].data' );
+		$result = $helper->get_json_data_from_path( 'db[0].data', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertTrue( property_exists( $result, 'posts' ) );
@@ -165,9 +143,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		);
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'databases[0].tables[0]' );
+		$result = $helper->get_json_data_from_path( 'databases[0].tables[0]', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertTrue( property_exists( $result, 'rows' ) );
@@ -182,9 +159,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"existing": {"value": 1}}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'nonexistent' );
+		$result = $helper->get_json_data_from_path( 'nonexistent', $json );
 
 		$this->assertNull( $result );
 	}
@@ -198,9 +174,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"level1": {"level2": {}}}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'level1.level2.level3' );
+		$result = $helper->get_json_data_from_path( 'level1.level2.level3', $json );
 
 		$this->assertNull( $result );
 	}
@@ -214,9 +189,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"items": [{"id": 1}, {"id": 2}]}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'items[99]' );
+		$result = $helper->get_json_data_from_path( 'items[99]', $json );
 
 		$this->assertNull( $result );
 	}
@@ -230,9 +204,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"notArray": {"key": "value"}}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'notArray[0]' );
+		$result = $helper->get_json_data_from_path( 'notArray[0]', $json );
 
 		$this->assertNull( $result );
 	}
@@ -246,9 +219,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"db": [{"data": {}}]}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'db[0].invalid.something' );
+		$result = $helper->get_json_data_from_path( 'db[0].invalid.something', $json );
 
 		$this->assertNull( $result );
 	}
@@ -264,10 +236,9 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"config": {"name": "test"}}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
 		// "name" is a string, not an object.
-		$result = $this->invoke_get_json_data_from_path( $helper, 'config.name' );
+		$result = $helper->get_json_data_from_path( 'config.name', $json );
 
 		$this->assertNull( $result );
 	}


### PR DESCRIPTION
Turns out The Philly Download has a slightly different path to posts (and other data) in their Ghost export JSON file:
- our migrator expected to find posts at `.db[0].data.posts`
- but this one has posts at just `.data.posts`

This PR adds an optional `--json-data-path` param, which takes standard `jq` JSON path notation to posts and other data:
- default value (to posts and other data) remains `.db[0].data` if nothing is provided
- but I was able to import The Philly Download using just `--json-data-path=".data"`

The new argument `--json-data-path` also has examples in command argument description on how one can use `jq` from CLI to check and determine the path.
