### PR TITLE
Add/ghost custom json data path ron

### DIFF
--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -52,13 +52,6 @@ class GhostCMSHelper {
 	private ?object $data = null;
 
 	/**
-	 * JSON from file
-	 *
-	 * @var object $json
-	 */
-	private object $json;
-
-	/**
 	 * Log slug.
 	 *
 	 * @var string $log_slug
@@ -86,18 +79,6 @@ class GhostCMSHelper {
 	 */
 	public function __construct() {
 		// Nothing for now.
-	}
-
-	/**
-	 * Set the JSON data object.
-	 *
-	 * Primarily used for unit testing to inject test data.
-	 *
-	 * @param object $json The JSON data object.
-	 * @return void
-	 */
-	public function set_json( object $json ): void {
-		$this->json = $json;
 	}
 
 	/**
@@ -168,16 +149,16 @@ class GhostCMSHelper {
 			$this->log( 'JSON file not found.', LogLevel::ERROR, true );
 		}
 
-		$this->json = json_decode( file_get_contents( $assoc_args['json-file'] ), null, 2147483647 );
+		$json = json_decode( file_get_contents( $assoc_args['json-file'] ), null, 2147483647 );
 
-		if ( 0 != json_last_error() || 'No error' != json_last_error_msg() ) {
+		if ( ! is_object( $json ) || 0 != json_last_error() || 'No error' != json_last_error_msg() ) {
 			$this->log( 'JSON file could not be parsed.', LogLevel::ERROR, true );
 		}
 
 		// --json-data-path (optional, defaults to .db[0].data).
 
 		$json_data_path = $assoc_args['json-data-path'] ?? '.db[0].data';
-		$this->data     = $this->get_json_data_from_path( $json_data_path );
+		$this->data     = $this->get_json_data_from_path( $json_data_path, $json );
 
 		if ( null === $this->data ) {
 			$this->log( sprintf( 'JSON data path "%s" could not be resolved.', $json_data_path ), LogLevel::ERROR, true );
@@ -598,18 +579,22 @@ class GhostCMSHelper {
 	 * Get JSON data node from a jq-style path.
 	 *
 	 * @param string $path jq-style path (e.g., ".db[0].data" or "data").
+	 * 
+	 * 
+	 * 
+	 * 
 	 * @return object|null The resolved data node or null if path is invalid.
 	 */
-	private function get_json_data_from_path( string $path ): ?object {
+	public function get_json_data_from_path( string $path, object $json ): ?object {
 		// Strip leading dot if present.
 		$path = ltrim( $path, '.' );
 
 		if ( empty( $path ) ) {
-			return is_object( $this->json ) ? $this->json : null;
+			return $json;
 		}
 
 		// $current is the current object we are working on, it's like a bookmark that tracks where we are as we walk through a nested JSON structure.
-		$current = $this->json;
+		$current = $json;
 
 		// Split jq-style path by dots: "db[0].data" becomes ["db[0]", "data"].
 		$tokens = explode( '.', $path );

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -165,7 +165,7 @@ class GhostCMSHelper {
 		}
 
 		if ( empty( $this->data->posts ) ) {
-			$this->log( 'JSON file contained no posts.', LogLevel::ERROR, true );
+			$this->log( sprintf( 'JSON file contained no posts at data path: %s', $json_data_path ), LogLevel::ERROR, true );
 		}
 
 		// Start processing.
@@ -579,9 +579,7 @@ class GhostCMSHelper {
 	 * Get JSON data node from a jq-style path.
 	 *
 	 * @param string $path jq-style path (e.g., ".db[0].data" or "data").
-	 * 
-	 * 
-	 * 
+	 * @param object $json JSON object.
 	 * 
 	 * @return object|null The resolved data node or null if path is invalid.
 	 */
@@ -590,6 +588,7 @@ class GhostCMSHelper {
 		$path = ltrim( $path, '.' );
 
 		if ( empty( $path ) ) {
+			// path was either blank or dot - which means the "root" object.
 			return $json;
 		}
 

--- a/tests/Logic/TestGhostCMSHelper.php
+++ b/tests/Logic/TestGhostCMSHelper.php
@@ -4,25 +4,9 @@ namespace Newspack\MigrationTools\Tests\Logic;
 
 use Newspack\Guest_Contributor_Role;
 use Newspack\MigrationTools\Logic\GhostCMSHelper;
-use ReflectionClass;
 use WP_UnitTestCase;
 
 class TestGhostCMSHelper extends WP_UnitTestCase {
-
-	/**
-	 * Helper to invoke the private get_json_data_from_path method.
-	 *
-	 * @param GhostCMSHelper $helper The helper instance with JSON set.
-	 * @param string         $path   The jq-style path to resolve.
-	 * @return object|null The resolved data node or null.
-	 */
-	private function invoke_get_json_data_from_path( GhostCMSHelper $helper, string $path ): ?object {
-		$reflection = new ReflectionClass( $helper );
-		$method     = $reflection->getMethod( 'get_json_data_from_path' );
-		$method->setAccessible( true );
-
-		return $method->invoke( $helper, $path );
-	}
 
 	/**
 	 * Test empty path returns the root JSON object.
@@ -33,9 +17,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"db": [{"data": {"posts": []}}]}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, '' );
+		$result = $helper->get_json_data_from_path( '', $json );
 
 		$this->assertSame( $json, $result );
 	}
@@ -49,9 +32,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"db": [{"data": {"posts": []}}]}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, '.db[0].data' );
+		$result = $helper->get_json_data_from_path( '.db[0].data', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertTrue( property_exists( $result, 'posts' ) );
@@ -66,9 +48,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"settings": {"theme": "dark"}}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'settings' );
+		$result = $helper->get_json_data_from_path( 'settings', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'dark', $result->theme );
@@ -83,9 +64,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"level1": {"level2": {"level3": {"value": "deep"}}}}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'level1.level2.level3' );
+		$result = $helper->get_json_data_from_path( 'level1.level2.level3', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'deep', $result->value );
@@ -100,20 +80,19 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"db": [{"name": "first"}, {"name": "second"}, {"name": "third"}]}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
 		// Access first element.
-		$result = $this->invoke_get_json_data_from_path( $helper, 'db[0]' );
+		$result = $helper->get_json_data_from_path( 'db[0]', $json );
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'first', $result->name );
 
 		// Access second element.
-		$result = $this->invoke_get_json_data_from_path( $helper, 'db[1]' );
+		$result = $helper->get_json_data_from_path( 'db[1]', $json );
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'second', $result->name );
 
 		// Access third element.
-		$result = $this->invoke_get_json_data_from_path( $helper, 'db[2]' );
+		$result = $helper->get_json_data_from_path( 'db[2]', $json );
 		$this->assertIsObject( $result );
 		$this->assertEquals( 'third', $result->name );
 	}
@@ -138,9 +117,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		);
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'db[0].data' );
+		$result = $helper->get_json_data_from_path( 'db[0].data', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertTrue( property_exists( $result, 'posts' ) );
@@ -165,9 +143,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		);
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'databases[0].tables[0]' );
+		$result = $helper->get_json_data_from_path( 'databases[0].tables[0]', $json );
 
 		$this->assertIsObject( $result );
 		$this->assertTrue( property_exists( $result, 'rows' ) );
@@ -182,9 +159,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"existing": {"value": 1}}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'nonexistent' );
+		$result = $helper->get_json_data_from_path( 'nonexistent', $json );
 
 		$this->assertNull( $result );
 	}
@@ -198,9 +174,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"level1": {"level2": {}}}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'level1.level2.level3' );
+		$result = $helper->get_json_data_from_path( 'level1.level2.level3', $json );
 
 		$this->assertNull( $result );
 	}
@@ -214,9 +189,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"items": [{"id": 1}, {"id": 2}]}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'items[99]' );
+		$result = $helper->get_json_data_from_path( 'items[99]', $json );
 
 		$this->assertNull( $result );
 	}
@@ -230,9 +204,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"notArray": {"key": "value"}}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'notArray[0]' );
+		$result = $helper->get_json_data_from_path( 'notArray[0]', $json );
 
 		$this->assertNull( $result );
 	}
@@ -246,9 +219,8 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"db": [{"data": {}}]}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
-		$result = $this->invoke_get_json_data_from_path( $helper, 'db[0].invalid.something' );
+		$result = $helper->get_json_data_from_path( 'db[0].invalid.something', $json );
 
 		$this->assertNull( $result );
 	}
@@ -264,10 +236,9 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$json = json_decode( '{"config": {"name": "test"}}' );
 
 		$helper = new GhostCMSHelper();
-		$helper->set_json( $json );
 
 		// "name" is a string, not an object.
-		$result = $this->invoke_get_json_data_from_path( $helper, 'config.name' );
+		$result = $helper->get_json_data_from_path( 'config.name', $json );
 
 		$this->assertNull( $result );
 	}


### PR DESCRIPTION
Option 1 for: https://github.com/Automattic/newspack-migration-tools/pull/143#pullrequestreview-3580029745


- Removes the `$json` property from the object now that `$this->data` is new class-wide property.
- Updates `get_json_data_from_path` with a secondary parameter for the local `$json` value so that `set_json` is not needed.  
- Also makes `get_json_data_from_path` public for easier testing.

