### PR TITLE
Fix: Prevent double file extensions when importing attachments

### DIFF
--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -306,10 +306,7 @@ class Attachments {
 
 		if ( ! empty( $desired_filename ) ) {
 			$file_array['name'] = $desired_filename;
-		} elseif (
-			! pathinfo( $path, PATHINFO_EXTENSION )
-			|| ( false === array_search( pathinfo( $path, PATHINFO_EXTENSION ), wp_get_mime_types() ) )
-		) {
+		} elseif ( ! self::has_valid_extension( $path ) ) {
 			// If the path does not have a file extension, let's try to find one for it.
 			// Without the extension, the upload will fail because WP will not allow that "file type".
 			$mimetype           = mime_content_type( $tmpfname );
@@ -326,6 +323,26 @@ class Attachments {
 		}
 
 		return $file_array;
+	}
+
+	/**
+	 * Check if a file path has a valid, recognized extension.
+	 *
+	 * @param string $path File path or URL.
+	 *
+	 * @return bool True if the extension is valid and recognized by WordPress.
+	 */
+	private static function has_valid_extension( string $path ): bool {
+		$extension = pathinfo( $path, PATHINFO_EXTENSION );
+
+		if ( empty( $extension ) ) {
+			return false;
+		}
+
+		// Use wp_check_filetype which properly checks extensions against allowed mime types.
+		$filetype = wp_check_filetype( '.' . $extension );
+
+		return ! empty( $filetype['ext'] );
 	}
 
 	/**

--- a/tests/Logic/TestAttachmentHelper.php
+++ b/tests/Logic/TestAttachmentHelper.php
@@ -97,4 +97,90 @@ class TestAttachmentHelper extends WP_UnitTestCase {
 		$this->assertFileExists( $file_path );
 		$this->assertStringEndsWith( $desired_file_name, $file_path );
 	}
+
+	/**
+	 * Test that files with valid extensions don't get double extensions.
+	 *
+	 * This is a regression test for a bug where the old extension validation logic
+	 * used array_search() on wp_get_mime_types() values instead of keys, causing
+	 * valid extensions like 'jpg' to not be recognized. This resulted in the code
+	 * appending another extension based on mime type detection, creating filenames
+	 * like 'image.jpg.jpg'.
+	 *
+	 * @return void
+	 */
+	public function test_download_file_does_not_create_double_extension(): void {
+		// Use a URL with a valid .jpg extension.
+		$url_with_extension = $this->dummy_image;
+
+		$file_array = Attachments::download_file( $url_with_extension );
+
+		$this->assertIsArray( $file_array, 'download_file should return an array' );
+		$this->assertArrayHasKey( 'name', $file_array, 'File array should have a name key' );
+
+		$filename = $file_array['name'];
+
+		// Count how many times common image extensions appear in the filename.
+		// A double extension bug would result in something like "image.jpg.jpg".
+		$extension_pattern = '/\.(jpg|jpeg|png|gif|webp)/i';
+		preg_match_all( $extension_pattern, $filename, $matches );
+
+		$this->assertCount(
+			1,
+			$matches[0],
+			sprintf(
+				'Filename "%s" should have exactly one image extension, but found %d. This indicates a double extension bug.',
+				$filename,
+				count( $matches[0] )
+			)
+		);
+
+		// Clean up the temp file.
+		if ( file_exists( $file_array['tmp_name'] ) ) {
+			unlink( $file_array['tmp_name'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		}
+	}
+
+	/**
+	 * Test that files without extensions get an extension added based on mime type.
+	 *
+	 * @return void
+	 */
+	public function test_download_file_adds_extension_when_missing(): void {
+		// Use a local test file without an extension.
+		$test_file_without_ext = sys_get_temp_dir() . '/test_image_no_ext_' . uniqid();
+
+		// Copy the fixture image to a file without extension.
+		$fixture_image = dirname( __DIR__ ) . '/fixtures/koi.jpg';
+		copy( $fixture_image, $test_file_without_ext );
+
+		$file_array = Attachments::download_file( $test_file_without_ext );
+
+		$this->assertIsArray( $file_array, 'download_file should return an array' );
+		$this->assertArrayHasKey( 'name', $file_array, 'File array should have a name key' );
+
+		$filename  = $file_array['name'];
+		$extension = pathinfo( $filename, PATHINFO_EXTENSION );
+
+		$this->assertNotEmpty(
+			$extension,
+			sprintf( 'Filename "%s" should have an extension added based on mime type detection.', $filename )
+		);
+
+		// The extension should be a valid image extension since we used an image file.
+		$valid_extensions = [ 'jpg', 'jpeg', 'png', 'gif', 'webp' ];
+		$this->assertContains(
+			strtolower( $extension ),
+			$valid_extensions,
+			sprintf( 'Extension "%s" should be a valid image extension.', $extension )
+		);
+
+		// Clean up.
+		if ( file_exists( $file_array['tmp_name'] ) ) {
+			unlink( $file_array['tmp_name'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		}
+		if ( file_exists( $test_file_without_ext ) ) {
+			unlink( $test_file_without_ext ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		}
+	}
 }


### PR DESCRIPTION
## Fix: Prevent double file extensions when importing attachments

### Description

This PR fixes a bug where files with valid extensions were incorrectly getting a duplicate extension appended during import (e.g., `image.jpg` becoming `image.jpg.jpg`).

### The Bug

In the `download_file()` method, the code was checking whether a file had a valid extension using:

```php
} elseif (
    ! pathinfo( $path, PATHINFO_EXTENSION )
    || ( false === array_search( pathinfo( $path, PATHINFO_EXTENSION ), wp_get_mime_types() ) )
) {
    // Add extension based on mime type...
    $file_array['name'] .= '.' . $probably_extension;
}
```

The problem is that `wp_get_mime_types()` returns an array structured like:

```php
[
    'jpg|jpeg|jpe' => 'image/jpeg',
    'png'          => 'image/png',
    // ...
]
```

The `array_search()` function searches in the **values** (the mime types), not the **keys** (the extensions). So `array_search('jpg', wp_get_mime_types())` would search for `'jpg'` in `['image/jpeg', 'image/png', ...]`, which **always returns `false`** because `'jpg'` never matches `'image/jpeg'`.

This caused the condition to be true for every file, even those with valid extensions, resulting in an extra extension being appended.

### The Fix

Extracted the extension validation logic into a new private method `has_valid_extension()` that uses `wp_check_filetype()`, which is the proper WordPress function for validating file extensions:

```php
private static function has_valid_extension( string $path ): bool {
    $extension = pathinfo( $path, PATHINFO_EXTENSION );

    if ( empty( $extension ) ) {
        return false;
    }

    // Use wp_check_filetype which properly checks extensions against allowed mime types.
    $filetype = wp_check_filetype( '.' . $extension );

    return ! empty( $filetype['ext'] );
}
```

### Testing

Two new unit tests were added to `tests/Logic/TestAttachmentHelper.php`:

1. **`test_download_file_does_not_create_double_extension`** - Regression test that verifies files with valid extensions (like `.jpg`) don't end up with double extensions (like `.jpg.jpg`)

2. **`test_download_file_adds_extension_when_missing`** - Verifies that files without extensions still correctly get an extension added based on mime type detection

### How to Test

```bash
# Run the new tests
./vendor/bin/phpunit --filter TestAttachmentHelper

# Or run just the regression test
./vendor/bin/phpunit --filter test_download_file_does_not_create_double_extension
```

### Checklist

- [x] Bug fix with regression test
- [x] No breaking changes
- [x] Tests pass locally
