### PR TITLE
Replace Ghost custom syntax/embeds for audio and video with standard HTML5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "php": ">=8.1",
         "monolog/monolog": "^3.7",
         "bramus/monolog-colored-line-formatter": "^3.1",
-        "halaxa/json-machine": "^1.1.5"
+        "halaxa/json-machine": "^1.1.5",
+        "simplehtmldom/simplehtmldom": "2.0-RC2"
     },
     "require-dev": {
         "ext-libxml": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e212883d976af8716c11ca6ffc55269",
+    "content-hash": "fcf33d9b43d71c27cc6cb743774eee87",
     "packages": [
         {
             "name": "bramus/ansi-php",
@@ -316,6 +316,81 @@
                 "source": "https://github.com/php-fig/log/tree/2.0.0"
             },
             "time": "2021-07-14T16:41:46+00:00"
+        },
+        {
+            "name": "simplehtmldom/simplehtmldom",
+            "version": "2.0-RC2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/simplehtmldom/simplehtmldom.git",
+                "reference": "3c87726400e59d8e1bc4709cfe82353abeb0f4d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/simplehtmldom/simplehtmldom/zipball/3c87726400e59d8e1bc4709cfe82353abeb0f4d1",
+                "reference": "3c87726400e59d8e1bc4709cfe82353abeb0f4d1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6 || ^7"
+            },
+            "suggest": {
+                "ext-curl": "Needed to support cURL downloads in class HtmlWeb",
+                "ext-mbstring": "Allows better decoding for multi-byte documents",
+                "ext-openssl": "Allows loading HTTPS pages when using cURL"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "./"
+                ],
+                "exclude-from-classmap": [
+                    "/example/",
+                    "/manual/",
+                    "/testcase/",
+                    "/tests/",
+                    "simple_html_dom.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "S.C. Chen",
+                    "role": "Developer"
+                },
+                {
+                    "name": "John Schlick",
+                    "role": "Developer"
+                },
+                {
+                    "name": "logmanoriginal",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fast, simple and reliable HTML document parser for PHP.",
+            "homepage": "https://simplehtmldom.sourceforge.io/",
+            "keywords": [
+                "Simple",
+                "dom",
+                "html",
+                "parser",
+                "php",
+                "simplehtmldom"
+            ],
+            "support": {
+                "issues": "https://sourceforge.net/p/simplehtmldom/bugs/",
+                "rss": "https://sourceforge.net/p/simplehtmldom/news/feed.rss",
+                "source": "https://sourceforge.net/p/simplehtmldom/repository/",
+                "wiki": "https://simplehtmldom.sourceforge.io/docs/"
+            },
+            "time": "2019-11-09T15:42:50+00:00"
         }
     ],
     "packages-dev": [
@@ -4541,7 +4616,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "simplehtmldom/simplehtmldom": 5
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -4551,5 +4628,5 @@
         "ext-libxml": "*",
         "ext-dom": "*"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,6 +16,14 @@
         <exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_is_writable" />
         <exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink" />
 
+		<!-- Exclude deprecated sniffs for JS and CSS -->
+		<exclude name="WordPressVIPMinimum.JS.DangerouslySetInnerHTML" />
+		<exclude name="WordPressVIPMinimum.JS.InnerHTML" />
+		<exclude name="WordPressVIPMinimum.JS.StrippingTags" />
+		<exclude name="WordPressVIPMinimum.JS.StringConcat" />
+		<exclude name="WordPressVIPMinimum.JS.HTMLExecutingFunctions" />
+		<exclude name="WordPressVIPMinimum.JS.Window" />
+
         <!-- Only comment when neccessary -->
         <exclude name="Squiz.Commenting.FileComment.Missing" />
         <exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -19,6 +19,7 @@ use Newspack\MigrationTools\Util\Log\FileLog;
 use Newspack\MigrationTools\Util\Log\MultiLog;
 use Monolog\Level;
 use Psr\Log\LogLevel;
+use simplehtmldom\HtmlDocument;
 use UnhandledMatchError;
 use WP_Error;
 use WP_User;
@@ -208,10 +209,16 @@ class GhostCMSHelper {
 
 			}
 
+			// Post content processing.
+			$post_content = str_replace( '__GHOST_URL__', $this->ghost_url, $json_post->html );
+			// Replace video and audio embeds from Ghost's "Koenig editor" to classic HTML5 (Ghost's syntax won't work in WP frontend or Gutenberg).
+			$post_content = $this->replace_video_embeds( $post_content );
+			$post_content = $this->replace_audio_embeds( $post_content );
+
 			// Post.
 			$args = array(
 				'post_author'  => $default_user->ID,
-				'post_content' => str_replace( '__GHOST_URL__', $this->ghost_url, $json_post->html ),
+				'post_content' => $post_content,
 				'post_date'    => $json_post->published_at,
 				'post_excerpt' => $json_post->custom_excerpt ?? '',
 				'post_name'    => $json_post->slug,
@@ -922,5 +929,90 @@ class GhostCMSHelper {
 		}
 			
 		return null;
+	}
+
+	/**
+	 * Replace Ghost's "Koenig editor" video embeds with <video> elements.
+	 * 
+	 * The resulting <video> element(s):
+	 *   - are not Gutenberg blocks, because the input HTML is not in expected to be in blocks either,
+	 *   - are simple HTML5 video players with controls,
+	 *   - are given the `style="width: 100%%; height: auto;"` to ensure they are displayed correctly in WP.
+	 *
+	 * @param string $content Content to replace video embeds in.
+	 * @return string Processed content.
+	 */
+	public function replace_video_embeds( string $content ): string {
+		// Find all kg-video-container divs.
+		$doc              = new HtmlDocument( $content );
+		$video_containers = $doc->find( 'div.kg-video-container' );
+		if ( empty( $video_containers ) ) {
+			return $content;
+		}
+
+		foreach ( $video_containers as $container ) {
+			// Find the first video element within this container.
+			$video_element = $container->find( 'video', 0 );
+			if ( ! $video_element ) {
+				continue;
+			}
+
+			// Get the src attribute.
+			$src = $video_element->getAttribute( 'src' );
+			if ( empty( $src ) ) {
+				continue;
+			}
+
+			// Replace the entire kg-video-container with the simple video element.
+			$replacement          = sprintf(
+				'<video src="%s" controls style="width: 100%%; height: auto;"></video>',
+				esc_attr( $src )
+			);
+			$container->outertext = $replacement;
+		}
+
+		return (string) $doc;
+	}
+
+	/**
+	 * Replace Ghost's "Koenig editor" audio embeds with <audio> elements.
+	 * 
+	 * The resulting <audio> element(s):
+	 *   - are not Gutenberg blocks, because the input HTML is not expected to be in blocks either,
+	 *   - are simple HTML5 audio players with controls.
+	 *
+	 * @param string $content Content to replace audio embeds in.
+	 * @return string Processed content.
+	 */
+	public function replace_audio_embeds( string $content ): string {
+		// Find all kg-audio-card divs.
+		$doc              = new HtmlDocument( $content );
+		$audio_containers = $doc->find( 'div.kg-audio-card' );
+		if ( empty( $audio_containers ) ) {
+			return $content;
+		}
+
+		foreach ( $audio_containers as $container ) {
+			// Find the first audio element within this container.
+			$audio_element = $container->find( 'audio', 0 );
+			if ( ! $audio_element ) {
+				continue;
+			}
+
+			// Get the src attribute.
+			$src = $audio_element->getAttribute( 'src' );
+			if ( empty( $src ) ) {
+				continue;
+			}
+
+			// Replace the entire kg-audio-card with the simple audio element.
+			$replacement          = sprintf(
+				'<audio src="%s" controls></audio>',
+				esc_attr( $src )
+			);
+			$container->outertext = $replacement;
+		}
+
+		return (string) $doc;
 	}
 }

--- a/src/Util/CsvIterator.php
+++ b/src/Util/CsvIterator.php
@@ -27,7 +27,8 @@ class CsvIterator {
 		$csv_file    = fopen( $csv_path, 'r' );
 		$csv_headers = [];
 		$line_number = 0;
-		while ( false !== ( $line = fgetcsv( $csv_file, null, $separator ) ) ) {
+		// fgetcsv escape='' for RFC 4180 compliance (@see https://php.net/fgetcsv).
+		while ( false !== ( $line = fgetcsv( $csv_file, null, $separator, '"', '' ) ) ) {
 			++$line_number;
 			if ( 1 === $line_number ) {
 				$csv_headers = array_map( fn( $value ) => trim( $value ?? '' ), $line );
@@ -59,7 +60,8 @@ class CsvIterator {
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen -- We're reading a CSV file outside WP.
 		$csv_file = fopen( $csv_path, 'r' );
-		while ( false !== ( $line = fgetcsv( $csv_file, null, $separator ) ) ) {
+		// fgetcsv escape='' for RFC 4180 compliance (@see https://php.net/fgetcsv).
+		while ( false !== ( $line = fgetcsv( $csv_file, null, $separator, '"', '' ) ) ) {
 			$trimmed_line = array_map( fn( $value ) => trim( $value ?? '' ), $line );
 
 			// Skip empty rows (rows where all fields are empty)

--- a/src/Util/CsvWriter.php
+++ b/src/Util/CsvWriter.php
@@ -58,8 +58,8 @@ class CsvWriter {
 	 * @throws Exception If the row cannot be written to the file.
 	 */
 	public function put( array $row ): void {
-		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
-		if ( false === fputcsv( $this->file_pointer, $row ) ) {
+		// fputcsv escape='' for RFC 4180 compliance (@see https://www.php.net/manual/en/function.fputcsv.php).
+		if ( false === fputcsv( $this->file_pointer, $row, ',', '"', '' ) ) { // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new Exception( "Could not write to file: {$this->filename}" );
 		}

--- a/src/Util/JsonIterator.php
+++ b/src/Util/JsonIterator.php
@@ -30,7 +30,7 @@ class JsonIterator {
 	 *
 	 * @param FileLog|null $file_logger Optional File logger instance.
 	 */
-	public function __construct( FileLog $file_logger = null ) {
+	public function __construct( ?FileLog $file_logger = null ) {
 		if ( ! $file_logger ) {
 			$file_logger = FileLog::get_logger( 'JsonIterator', 'json-iterator.log' );
 		}

--- a/tests/Logic/TestGhostCMSHelper.php
+++ b/tests/Logic/TestGhostCMSHelper.php
@@ -261,6 +261,250 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test basic video embed replacement.
+	 *
+	 * @return void
+	 */
+	public function test_replace_video_embeds_basic_replacement(): void {
+		$helper = new GhostCMSHelper();
+
+		$input    = 'Before txt <div class="kg-video-container"><video src="https://example.com/video.mp4"></video></div> After txt';
+		$expected = 'Before txt <video src="https://example.com/video.mp4" controls style="width: 100%; height: auto;"></video> After txt';
+
+		$result = $helper->replace_video_embeds( $input );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test multiple video containers are all replaced.
+	 *
+	 * @return void
+	 */
+	public function test_replace_video_embeds_multiple_containers(): void {
+		$helper = new GhostCMSHelper();
+
+		$input    = 'First <div class="kg-video-container"><video src="https://example.com/video1.mp4"></video></div> Middle <div class="kg-video-container"><video src="https://example.com/video2.mp4"></video></div> Last';
+		$expected = 'First <video src="https://example.com/video1.mp4" controls style="width: 100%; height: auto;"></video> Middle <video src="https://example.com/video2.mp4" controls style="width: 100%; height: auto;"></video> Last';
+
+		$result = $helper->replace_video_embeds( $input );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test content without video containers returns unchanged.
+	 *
+	 * @return void
+	 */
+	public function test_replace_video_embeds_no_containers_returns_unchanged(): void {
+		$helper = new GhostCMSHelper();
+
+		$input = 'Before txt <p>Some paragraph</p> After txt';
+
+		$result = $helper->replace_video_embeds( $input );
+
+		$this->assertSame( $input, $result );
+	}
+
+	/**
+	 * Test video container without video element is skipped.
+	 *
+	 * @return void
+	 */
+	public function test_replace_video_embeds_container_without_video_element(): void {
+		$helper = new GhostCMSHelper();
+
+		$input = 'Before txt <div class="kg-video-container"><p>No video here</p></div> After txt';
+
+		$result = $helper->replace_video_embeds( $input );
+
+		$this->assertSame( $input, $result );
+	}
+
+	/**
+	 * Test video element without src attribute is skipped.
+	 *
+	 * @return void
+	 */
+	public function test_replace_video_embeds_video_without_src(): void {
+		$helper = new GhostCMSHelper();
+
+		$input = 'Before txt <div class="kg-video-container"><video></video></div> After txt';
+
+		$result = $helper->replace_video_embeds( $input );
+
+		$this->assertSame( $input, $result );
+	}
+
+	/**
+	 * Test video embed replacement works with both compact and formatted HTML.
+	 *
+	 * @return void
+	 */
+	public function test_replace_video_embeds_whitespace_agnostic(): void {
+		$helper = new GhostCMSHelper();
+
+		$compact   = 'Text <div class="kg-video-container"><video src="https://example.com/video.mp4"></video></div> More';
+		$formatted = 'Text <div class="kg-video-container">
+			<video src="https://example.com/video.mp4"></video>
+		</div> More';
+		$expected  = 'Text <video src="https://example.com/video.mp4" controls style="width: 100%; height: auto;"></video> More';
+
+		$result_compact   = $helper->replace_video_embeds( $compact );
+		$result_formatted = $helper->replace_video_embeds( $formatted );
+
+		$this->assertSame( $expected, $result_compact );
+		$this->assertSame( $expected, $result_formatted );
+	}
+
+	/**
+	 * Test video replacement preserves surrounding paragraph content.
+	 *
+	 * @return void
+	 */
+	public function test_replace_video_embeds_preserves_surrounding_content(): void {
+		$helper = new GhostCMSHelper();
+
+		$input = '<p>Before paragraph</p> <div class="kg-video-container"><video src="https://example.com/video.mp4"></video></div> <p>After paragraph</p>';
+		// Note: HTML parser normalizes whitespace between block elements - this is expected behavior.
+		$expected = '<p>Before paragraph</p><video src="https://example.com/video.mp4" controls style="width: 100%; height: auto;"></video><p>After paragraph</p>';
+
+		$result = $helper->replace_video_embeds( $input );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test basic audio embed replacement.
+	 *
+	 * @return void
+	 */
+	public function test_replace_audio_embeds_basic_replacement(): void {
+		$helper = new GhostCMSHelper();
+
+		$input    = 'Before txt <div class="kg-audio-card"><audio src="https://example.com/audio.mp3"></audio></div> After txt';
+		$expected = 'Before txt <audio src="https://example.com/audio.mp3" controls></audio> After txt';
+
+		$result = $helper->replace_audio_embeds( $input );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test multiple audio cards are all replaced.
+	 *
+	 * @return void
+	 */
+	public function test_replace_audio_embeds_multiple_cards(): void {
+		$helper = new GhostCMSHelper();
+
+		$input    = 'First <div class="kg-audio-card"><audio src="https://example.com/audio1.mp3"></audio></div> Middle <div class="kg-audio-card"><audio src="https://example.com/audio2.mp3"></audio></div> Last';
+		$expected = 'First <audio src="https://example.com/audio1.mp3" controls></audio> Middle <audio src="https://example.com/audio2.mp3" controls></audio> Last';
+
+		$result = $helper->replace_audio_embeds( $input );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test content without audio cards returns unchanged.
+	 *
+	 * @return void
+	 */
+	public function test_replace_audio_embeds_no_cards_returns_unchanged(): void {
+		$helper = new GhostCMSHelper();
+
+		$input = 'Before txt <p>Some paragraph</p> After txt';
+
+		$result = $helper->replace_audio_embeds( $input );
+
+		$this->assertSame( $input, $result );
+	}
+
+	/**
+	 * Test audio card without audio element is skipped.
+	 *
+	 * @return void
+	 */
+	public function test_replace_audio_embeds_card_without_audio_element(): void {
+		$helper = new GhostCMSHelper();
+
+		$input = 'Before txt <div class="kg-audio-card"><p>No audio here</p></div> After txt';
+
+		$result = $helper->replace_audio_embeds( $input );
+
+		$this->assertSame( $input, $result );
+	}
+
+	/**
+	 * Test audio element without src attribute is skipped.
+	 *
+	 * @return void
+	 */
+	public function test_replace_audio_embeds_audio_without_src(): void {
+		$helper = new GhostCMSHelper();
+
+		$input = 'Before txt <div class="kg-audio-card"><audio></audio></div> After txt';
+
+		$result = $helper->replace_audio_embeds( $input );
+
+		$this->assertSame( $input, $result );
+	}
+
+	/**
+	 * Test audio replacement preserves surrounding content.
+	 *
+	 * @return void
+	 */
+	public function test_replace_audio_embeds_preserves_surrounding_content(): void {
+		$helper = new GhostCMSHelper();
+
+		$input = '<p>Before paragraph</p> <div class="kg-audio-card"><audio src="https://example.com/audio.mp3"></audio></div> <p>After paragraph</p>';
+		// Note: HTML parser normalizes whitespace between block elements - this is expected behavior.
+		$expected = '<p>Before paragraph</p><audio src="https://example.com/audio.mp3" controls></audio><p>After paragraph</p>';
+
+		$result = $helper->replace_audio_embeds( $input );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test mixed video and audio embeds in same content.
+	 *
+	 * @return void
+	 */
+	public function test_replace_embeds_mixed_video_and_audio(): void {
+		$helper = new GhostCMSHelper();
+
+		$input    = 'Start <div class="kg-video-container"><video src="https://example.com/video.mp4"></video></div> Middle <div class="kg-audio-card"><audio src="https://example.com/audio.mp3"></audio></div> End';
+		$expected = 'Start <video src="https://example.com/video.mp4" controls style="width: 100%; height: auto;"></video> Middle <audio src="https://example.com/audio.mp3" controls></audio> End';
+
+		// Apply both replacements as they would be in the import process.
+		$result = $helper->replace_video_embeds( $input );
+		$result = $helper->replace_audio_embeds( $result );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test video/audio embeds nested in other markup.
+	 *
+	 * @return void
+	 */
+	public function test_replace_embeds_nested_in_other_markup(): void {
+		$helper = new GhostCMSHelper();
+
+		$input    = '<div><p>Text</p><div class="kg-video-container"><video src="https://example.com/video.mp4"></video></div><ul><li><div class="kg-audio-card"><audio src="https://example.com/audio.mp3"></audio></div></li></ul></div>';
+		$expected = '<div><p>Text</p><video src="https://example.com/video.mp4" controls style="width: 100%; height: auto;"></video><ul><li><audio src="https://example.com/audio.mp3" controls></audio></li></ul></div>';
+
+		$result = $helper->replace_video_embeds( $input );
+		$result = $helper->replace_audio_embeds( $result );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
 	 * Test that GhostCMS Helper will import from JSON file.
 	 *
 	 * @return void


### PR DESCRIPTION
### Changes

Ghost's "Koenig editor" embeds audio and video files with more elaborate custom HTML nested structure which doesn't work by default in WP frontend or backend. 

Here is the HTML syntax examples of these embeds:
- [video.html](https://github.com/user-attachments/files/24914417/video.html)
- [audio.html](https://github.com/user-attachments/files/24914421/audio.html)

This PR:
- replaces those embeds with standard HTML `<video>` and `<audio>` elements
- adds new tests for coverage of this new functionality

### Bonus Changes

See [Copilot's review](https://github.com/Automattic/newspack-migration-tools/pull/152#pullrequestreview-3717745533) down below > click "Show summary per file" for details:

- the PHPCS sniffing rules use some outdated and now deprecated sniffs/rules which output warnings to CLI. This excludes those specific deprecated rules
- fixes fgetcsv and fputcsv usage deprecation warnings for implicit escape strings
- fixes one more deprecated warning about implicitly marked argument as nullable

These were all done as cleanups to address the many warnings of several different types which were output during phpunit tests:

<img width="3600" height="1982" alt="image" src="https://github.com/user-attachments/assets/3e229058-07dd-43e1-a38f-17ba5e8c0cc9" />
