### PR TITLE
Ghost migrator addons

### DIFF
--- a/docs/GhostCMS.md
+++ b/docs/GhostCMS.md
@@ -61,6 +61,20 @@ Optional arguments:
 --created-after=<created-after>
 Datetime cut-off to only import posts AFTER this date. (Must be parseable by strtotime).
 
+--visibility-csv=<visibility-csv>
+Comma separated list of post visibility values to import. Default is 'public'.
+Ghost posts can have visibility values like: public, members, paid, tiers.
+
+Examples:
+- --visibility-csv=public (default, only public posts)
+- --visibility-csv=public,members (include both public and members-only posts)
+
+Important: The visibility check scans ALL posts in the JSON file before any other filters are applied. 
+When combined with --created-after, the visibility report will show all visibility values found in the 
+entire dataset, which may include values not present in the date-filtered posts that will actually be 
+imported. This behavior is intentional to help you understand your complete dataset and catch any 
+unexpected visibility values in your historical data.
+
 --json-data-path=<json-data-path>
 Standard `jq`-style path notation to node in JSON where posts (and other objects) are stored (e.g., --json-data-path=".db[0].data" or --json-data-path=".data").
 
@@ -84,7 +98,7 @@ For testing, you can use these test values (with the included `json` test file):
 
 Command (_be sure to replace your values_):
 ```
-wp newspack-migration-tools ghostcms-import --default-user-id=<default-user-id> --ghost-url=<ghost-url> --json-file=<json-file> [--created-after=<created-after>] [--json-data-path=<json-data-path>]
+wp newspack-migration-tools ghostcms-import --default-user-id=<default-user-id> --ghost-url=<ghost-url> --json-file=<json-file> [--created-after=<created-after>] [--visibility-csv=<visibility-csv>] [--json-data-path=<json-data-path>]
 ```
 
 If the migrator command is stopped mid-migration, it is OK to simply re-run the command.

--- a/src/Command/GhostCMSMigrator.php
+++ b/src/Command/GhostCMSMigrator.php
@@ -60,7 +60,9 @@ class GhostCMSMigrator implements WpCliCommandInterface {
 							'type'        => 'assoc',
 							'name'        => 'visibility-csv',
 							'description' => 'Comma separated list of post visibility (i.e. post status) values to import. ' .
-											'This command will scan for existing visibilities in the JSON data before importing any posts, and warn you if there are any multiple values besides the default `public`. ' .
+											'This command will scan for existing visibilities in ALL posts in the JSON data before applying any filters (like --created-after). ' .
+											'You will be warned if there are multiple visibility values besides the default `public`. ' .
+											'Note: The visibility scan in this command reports on the entire dataset, which may include visibility values not present in the filtered date range. ' .
 											'E.g. `--visibility-csv=public,members,paid,tiers`.',
 							'optional'    => true,
 							'repeating'   => false,

--- a/src/Command/GhostCMSMigrator.php
+++ b/src/Command/GhostCMSMigrator.php
@@ -58,6 +58,15 @@ class GhostCMSMigrator implements WpCliCommandInterface {
 						// optional:
 						array(
 							'type'        => 'assoc',
+							'name'        => 'visibility-csv',
+							'description' => 'Comma separated list of post visibility (i.e. post status) values to import. ' .
+											'This command will scan for existing visibilities in the JSON data before importing any posts, and warn you if there are any multiple values besides the default `public`. ' .
+											'E.g. `--visibility-csv=public,members,paid,tiers`.',
+							'optional'    => true,
+							'repeating'   => false,
+						),
+						array(
+							'type'        => 'assoc',
 							'name'        => 'created-after',
 							'description' => 'Datetime cut-off to only import posts AFTER this date. (Must be parseable by strtotime).',
 							'optional'    => true,

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -21,6 +21,7 @@ use Monolog\Level;
 use Psr\Log\LogLevel;
 use simplehtmldom\HtmlDocument;
 use UnhandledMatchError;
+use WP_CLI;
 use WP_Error;
 use WP_User;
 
@@ -111,6 +112,12 @@ class GhostCMSHelper {
 
 		// Argument parsing.
 
+		// --visibility-csv, default is 'public'.
+		$visibilities_to_import = [ 'public' ];
+		if ( isset( $assoc_args['visibility-csv'] ) ) {
+			$visibilities_to_import = explode( ',', $assoc_args['visibility-csv'] );
+		}
+
 		// --created-after.
 		$created_after = null;
 		if ( isset( $assoc_args['created-after'] ) ) {
@@ -180,7 +187,23 @@ class GhostCMSHelper {
 			// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 			$this->log( '--created-after: ' . date( 'Y-m-d H:i:s', $created_after ) );
 		}
-		
+
+		// Check if there are any additional post visibility values in JSON data, besides the ones which are selected for import.
+		$visibilities_existing         = $this->get_visibility_values( $this->data );
+		$are_all_visibilities_selected = empty( array_diff( $visibilities_existing, $visibilities_to_import ) );
+		if ( false === $are_all_visibilities_selected ) {
+			$this->log(
+				sprintf(
+					'There are %d existing `visibility` values found in JSON posts: %s. Only the posts with visibility value(s) %s will be imported.',
+					count( $visibilities_existing ),
+					'`' . implode( '`, `', $visibilities_existing ) . '`',
+					'`' . implode( '`, `', $visibilities_to_import ) . '`'
+				),
+				LogLevel::WARNING
+			);
+			WP_CLI::confirm( 'Continue with the import (y), or stop here (n) and set the `--visibility-csv` argument to the target values?' );
+		}
+
 		// Insert posts.
 		foreach ( $this->data->posts as $json_post ) {
 
@@ -197,7 +220,7 @@ class GhostCMSHelper {
 			}
 			
 			// Check for skips, log, and continue.
-			$skip_reason = $this->skip( $json_post );
+			$skip_reason = $this->skip( $json_post, $visibilities_to_import );
 			if ( ! empty( $skip_reason ) ) {
 			
 				$this->log( 'Skip JSON post (review by hand -skips.log): ' . $skip_reason, LogLevel::NOTICE );
@@ -872,10 +895,11 @@ class GhostCMSHelper {
 	/**
 	 * Check if need to skip this JSON post.
 	 *
-	 * @param object $json_post JSON post object.
+	 * @param object $json_post             JSON post object.
+	 * @param array  $visibilities_to_import Visibility values to import.
 	 * @return string|null
 	 */
-	private function skip( object $json_post ): ?string {
+	private function skip( object $json_post, array $visibilities_to_import ): ?string {
 
 		global $wpdb;
 
@@ -887,8 +911,8 @@ class GhostCMSHelper {
 		if ( 'published' != $json_post->status ) {
 			return 'not_published';
 		}
-		if ( 'public' != $json_post->visibility ) {
-			return 'not_public';
+		if ( ! in_array( $json_post->visibility, $visibilities_to_import, true ) ) {
+			return 'visibility_is_different';
 		}
 
 		// Empty properties.
@@ -1017,5 +1041,22 @@ class GhostCMSHelper {
 		}
 
 		return (string) $doc;
+	}
+
+	/**
+	 * Get all visibility values from JSON data.
+	 *
+	 * @param object $data JSON data.
+	 * @return array Visibility values.
+	 */
+	private function get_visibility_values( object $data ): array {
+		$visibilities = [];
+		foreach ( $data->posts as $json_post ) {
+			if ( ! in_array( $json_post->visibility, $visibilities, true ) ) {
+				$visibilities[] = $json_post->visibility;
+			}
+		}
+
+		return $visibilities;
 	}
 }

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -242,6 +242,9 @@ class GhostCMSHelper {
 			update_post_meta( $wp_post_id, 'newspack_ghostcms_id', $json_post->id );
 			update_post_meta( $wp_post_id, 'newspack_ghostcms_uuid', $json_post->uuid );
 			update_post_meta( $wp_post_id, 'newspack_ghostcms_slug', $json_post->slug );
+			if ( ! empty( $json_post->custom_excerpt ) ) {
+				update_post_meta( $wp_post_id, 'newspack_post_subtitle', $json_post->custom_excerpt );
+			}
 			
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 			update_post_meta( $wp_post_id, 'newspack_ghostcms_checksum', md5( json_encode( $json_post ) ) );            


### PR DESCRIPTION
### Migrate post `custom_excerpt` field to Newspack subititle
Added in [21aaac7](https://github.com/Automattic/newspack-migration-tools/pull/153/commits/21aaac7cd02cdb9e6158db41b97b77f84ebbe2a5).

Example post
- live Ghost post with subtitle -- https://www.theicegarden.com/seattle-torrent-break-record-arrive-with-purpose-in-their-first-home-game/
- original Ghost export record for this post: [ghost_id_692e2b5122ad6e00017d5407.json](https://github.com/user-attachments/files/24936648/ghost_id_692e2b5122ad6e00017d5407.json)

### Warn if there are additional custom post `visibility` values which are not being migrated
Added in [418aa86](https://github.com/Automattic/newspack-migration-tools/pull/153/commits/418aa86c5beb3bda61b7451e9ed134700a0c9da0).

I just noticed that a bunch of posts were not migrated for one Publisher, and was not aware of it. The logs do show `Skip JSON post (review by hand -skips.log): not_public` but that is not entirely true, as that Ghost site has multiple public statuses, not just `public`, but also `member`, `paid`, `tiers`.

This now:
- scans all the existing `visibility` values in posts before importing the posts
- if there are any additional statues which are not being migrated, it outputs a warning and prompts the user whether they wish to proceed
- uses a different skip status, instead of `not_public` it is now labeled `visibility_is_different`.

Example, there are multiple other values besides the default `public`, and the user is warned:
<img width="948" height="63" alt="Screenshot 2026-01-29 at 4 42 00 PM" src="https://github.com/user-attachments/assets/7471528a-1af9-4baf-851b-aa83ff4c9ebd" />

Example, `--visibility-csv=public,paid,members` was provided, but there's also `tiers`, so the user is warned and prompted whether they wish to proceed:
<img width="944" height="81" alt="Screenshot 2026-01-29 at 4 41 23 PM" src="https://github.com/user-attachments/assets/a4c64783-d304-447d-bd2b-ca02cc0af66f" />

No warning/confirmation is shown if `public` is the only visibility which exists.