### PR TITLE
Fix memory leak in throttled_posts_loop by unsetting posts array

### DIFF
--- a/src/Logic/Posts.php
+++ b/src/Logic/Posts.php
@@ -486,6 +486,8 @@ SQL;
 			$callback( $post );
 		}
 
+		unset( $posts );
+
 		sleep( $wait );
 
 		self::throttled_posts_loop( $query_args, $callback, $wait, $posts_per_batch, $batch + 1 );


### PR DESCRIPTION
## Problem                                                                                        
                                                                                                 
The throttled_posts_loop method uses recursion to paginate through batches of posts. Each recursive call keeps the previous batch's $posts array (containing up to 1000 WP_Post objects) on the call stack until the entire recursion unwinds.                                          
                                                                                                
For example, processing 27,000 posts at 1000 posts per batch results in ~27 nested recursive calls. Since PHP doesn't release local variables until a function returns, all 27,000 posts remain in memory until the final batch completes and the call stack unwinds.
                                                                                                 
This caused memory usage to grow from 265MB to 505MB when processing 27k posts on production.  
                                                                                                 
## Solution                                                                                       
                                                                                                 
Explicitly unset($posts) after processing each batch. This releases the memory held by the post objects before the next recursive call, keeping memory usage constant regardless of total post count.                                                                                        

```php                                                                                           
  foreach ( $posts as $post ) {                                                                  
      $callback( $post );                                                                        
  }                                                                                              
                                                                                                 
  unset( $posts );  // Free memory before recursive call                                         
                                                                                                 
  sleep( $wait );                                                                                
  self::throttled_posts_loop( ... );
```