### PR TITLE
Custom Ghost content checker

### DIFF
--- a/src/Command/GhostCMSMigrator.php
+++ b/src/Command/GhostCMSMigrator.php
@@ -124,18 +124,14 @@ class GhostCMSMigrator implements WpCliCommandInterface {
 
 	/**
 	 * Callable for the 'newspack-migration-tools ghostcms-check-imported-posts-for-custom-html-content' command.
+	 * 
+	 * @param array $pos_args The positional arguments.
+	 * @param array $assoc_args The associative arguments.
 	 */
 	public static function cmd_check_imported_posts_for_custom_html_content( array $pos_args, array $assoc_args ): void {
-		$log_slug = str_replace( __NAMESPACE__ . '\\', '', __CLASS__ ) . '_' . __FUNCTION__;
-		$logger   = MultiLog::get_logger( 
-			'multi-' . $log_slug,
-			[
-				CliLog::get_logger( $log_slug ),
-				FileLog::get_logger( $log_slug ),
-			]
-		);
-		
+		$logger = MultiLog::get_cli_and_file_logger( __FUNCTION__ );
 		$logger->info( 'Starting CLI - Scanning imported posts for custom HTML content...' );
+
 		$helper = new GhostCMSHelper();
 		$helper->cmd_check_imported_posts_for_custom_html_content( $pos_args, $assoc_args, $logger );
 	}

--- a/src/Command/GhostCMSMigrator.php
+++ b/src/Command/GhostCMSMigrator.php
@@ -129,10 +129,11 @@ class GhostCMSMigrator implements WpCliCommandInterface {
 	 * @param array $assoc_args The associative arguments.
 	 */
 	public static function cmd_check_imported_posts_for_custom_html_content( array $pos_args, array $assoc_args ): void {
-		$logger = MultiLog::get_cli_and_file_logger( __FUNCTION__ );
+		$logger_slug = __FUNCTION__;
+		$logger      = MultiLog::get_cli_and_file_logger( $logger_slug );
 		$logger->info( 'Starting CLI - Scanning imported posts for custom HTML content...' );
 
-		$helper = new GhostCMSHelper();
-		$helper->cmd_check_imported_posts_for_custom_html_content( $pos_args, $assoc_args, $logger );
+		$ghost = new GhostCMSHelper();
+		$ghost->check_imported_posts_for_custom_html_content( $logger_slug );
 	}
 }

--- a/src/Command/GhostCMSMigrator.php
+++ b/src/Command/GhostCMSMigrator.php
@@ -89,6 +89,13 @@ class GhostCMSMigrator implements WpCliCommandInterface {
 					),
 				],
 			],
+			[
+				'newspack-migration-tools ghostcms-check-imported-posts-for-custom-html-content',
+				[ __CLASS__, 'cmd_check_imported_posts_for_custom_html_content' ],
+				[
+					'shortdesc' => "After the content has been imported, run this command to check the imported posts for yet unvalidated/unsupported custom HTML content/syntax from the Ghost Koenig editor (such as different custom embeds, or Ghost's equivalents to Gutenberg blocks). This scans all HTML elements with kg-* classes.",
+				],
+			],
 		];
 	}
 	
@@ -113,5 +120,23 @@ class GhostCMSMigrator implements WpCliCommandInterface {
 		// Do helper.
 		$helper = new GhostCMSHelper();
 		$helper->ghostcms_import( $pos_args, $assoc_args, $log_slug );
+	}
+
+	/**
+	 * Callable for the 'newspack-migration-tools ghostcms-check-imported-posts-for-custom-html-content' command.
+	 */
+	public static function cmd_check_imported_posts_for_custom_html_content( array $pos_args, array $assoc_args ): void {
+		$log_slug = str_replace( __NAMESPACE__ . '\\', '', __CLASS__ ) . '_' . __FUNCTION__;
+		$logger   = MultiLog::get_logger( 
+			'multi-' . $log_slug,
+			[
+				CliLog::get_logger( $log_slug ),
+				FileLog::get_logger( $log_slug ),
+			]
+		);
+		
+		$logger->info( 'Starting CLI - Scanning imported posts for custom HTML content...' );
+		$helper = new GhostCMSHelper();
+		$helper->cmd_check_imported_posts_for_custom_html_content( $pos_args, $assoc_args, $logger );
 	}
 }

--- a/src/Command/GhostCMSMigrator.php
+++ b/src/Command/GhostCMSMigrator.php
@@ -129,11 +129,11 @@ class GhostCMSMigrator implements WpCliCommandInterface {
 	 * @param array $assoc_args The associative arguments.
 	 */
 	public static function cmd_check_imported_posts_for_custom_html_content( array $pos_args, array $assoc_args ): void {
-		$logger_slug = __FUNCTION__;
-		$logger      = MultiLog::get_cli_and_file_logger( $logger_slug );
+		$log_slug = __FUNCTION__;
+		$logger   = MultiLog::get_cli_and_file_logger( $log_slug );
 		$logger->info( 'Starting CLI - Scanning imported posts for custom HTML content...' );
 
 		$ghost = new GhostCMSHelper();
-		$ghost->check_imported_posts_for_custom_html_content( $logger_slug );
+		$ghost->check_imported_posts_for_custom_html_content( $log_slug );
 	}
 }

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -290,18 +290,22 @@ class GhostCMSHelper {
 
 		}
 
-		$this->log( 'Done.' );
+		$this->log( 'Done importing posts from Ghost.', LogLevel::INFO );
+
+		// Run command to check for custom Ghost HTML content.
+		$this->check_imported_posts_for_custom_html_content( $this->log_slug );
 	}
 
 	/**
 	 * Check imported posts for custom Ghost Koenig editor HTML content, by scanning all HTML elements with kg-* classes.
 	 * 
-	 * @param array           $pos_args The positional arguments.
-	 * @param array           $assoc_args The associative arguments.
-	 * @param LoggerInterface $logger The logger.
+	 * @param string $logger_slug The logger slug.
 	 */
-	public function cmd_check_imported_posts_for_custom_html_content( array $pos_args, array $assoc_args, LoggerInterface $logger ): void {
+	public function check_imported_posts_for_custom_html_content( string $logger_slug ): void {
 		global $wpdb;
+
+		// Init logger usage in this class.
+		$this->log_slug = $logger_slug;
 		
 		// Prepare output file.
 		$output_file = 'ghost_kg_elements.jsonl';
@@ -312,7 +316,6 @@ class GhostCMSHelper {
 		/**
 		 * Check all published posts migrated from Ghost for custom Ghost editor HTML content -- HTML elements with "kg-*" classes.
 		 */
-		$logger->debug( sprintf( 'Checking %d posts imported from Ghost for custom Ghost editor HTML content...', count( $post_rows ) ) );
 		$post_rows = $wpdb->get_results( // phpcs:ignore -- WordPress.DB.DirectDatabaseQuery.DirectQuery WordPress.DB.DirectDatabaseQuery.NoCaching.
 			"select p.ID, p.post_content from {$wpdb->posts} p
 			join {$wpdb->postmeta} pm on p.ID = pm.post_id
@@ -323,6 +326,7 @@ class GhostCMSHelper {
 			order by p.ID desc",
 			ARRAY_A
 		);
+		$this->log( sprintf( 'Checking posts imported from Ghost for custom Ghost editor HTML content...', count( $post_rows ) ) );
 		$elements     = [];
 		$failed_posts = [];
 		foreach ( $post_rows as $post_row ) {
@@ -388,7 +392,7 @@ class GhostCMSHelper {
 				}
 			} catch ( \Exception $e ) {
 				$failed_posts[] = $post_id;
-				$logger->warning( sprintf( 'Failed to parse post ID %d: %s', $post_id, $e->getMessage() ) );
+				$this->log( sprintf( 'Failed to parse post ID %d: %s', $post_id, $e->getMessage() ), LogLevel::WARNING );
 			}
 		}
 
@@ -397,7 +401,7 @@ class GhostCMSHelper {
 		 */
 		$file_handle = fopen( $output_file, 'w' ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fopen.
 		if ( false === $file_handle ) {
-			$logger->error( sprintf( 'Failed to open file "%s" for writing.', $output_file ) );
+			$this->log( sprintf( 'Failed to open file "%s" for writing.', $output_file ), LogLevel::ERROR );
 		}
 		foreach ( $elements as $element_data ) {
 			$data = [
@@ -414,14 +418,14 @@ class GhostCMSHelper {
 		 * Log summary.
 		 */
 		if ( ! empty( $failed_posts ) ) {
-			$logger->error( sprintf( 'Failed to parse %d posts: %s', count( $failed_posts ), implode( ', ', $failed_posts ) ) );
+			$this->log( sprintf( 'Failed to parse %d posts: %s', count( $failed_posts ), implode( ', ', $failed_posts ) ), LogLevel::ERROR );
 		}
 		if ( ! empty( $elements ) ) {
-			$logger->warning( sprintf( "Found %d unfamiliar/unhandled 'kg-*' elements in total %d posts. Their tags and post IDs where they appear are saved to %s. Please QA these findings: if they display correctly/well enough in the WP frontend/backend, simply whitelist them in the GhostCMSHelper's constant; if they don't, write fixers/transformers for them.", count( $elements ), count( $post_rows ), $output_file ) );
+			$this->log( sprintf( "Found %d unfamiliar/unhandled 'kg-*' elements in total %d posts. Their tags and post IDs where they appear are saved to %s. Please QA these findings: if they display correctly/well enough in the WP frontend/backend, simply whitelist them in the GhostCMSHelper's constant; if they don't, write fixers/transformers for them.", count( $elements ), count( $post_rows ), $output_file ), LogLevel::WARNING );
 		} else {
-			$logger->info( sprintf( "No unfamiliar/unhandled 'kg-*' elements found in total %d posts.", count( $post_rows ) ) );
+			$this->log( sprintf( "No unfamiliar/unhandled 'kg-*' elements found in total %d posts.", count( $post_rows ) ), LogLevel::INFO );
 		}
-		$logger->info( 'Done' );
+		$this->log( 'Done checking for custom Ghost HTML content.', LogLevel::INFO );
 	}
 
 	/**
@@ -824,20 +828,13 @@ class GhostCMSHelper {
 	 * @param boolean $exit_on_error For error messages if desired.
 	 * @return void
 	 */
-	private function log( string $message, string $level = 'info', bool $exit_on_error = false ): void {
-		
-		$logger = MultiLog::get_logger( 
-			'multi-' . $this->log_slug,
-			[
-				CliLog::get_logger( $this->log_slug ),
-				FileLog::get_logger( $this->log_slug ),
-			]
-		);
+	private function log( string $message, string $level = 'debug', bool $exit_on_error = false ): void {
+		$logger = MultiLog::get_cli_and_file_logger( 'multi-' . $this->log_slug );
 
 		try {
 			$level = Level::fromName( $level );
 		} catch ( UnhandledMatchError $e ) {
-			$level = Level::fromName( 'info' );
+			$level = Level::fromName( 'debug' );
 		}
 		
 		$logger->log( $level, $message );

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -238,7 +238,6 @@ class GhostCMSHelper {
 			// Replace various syntax elements from Ghost's "Koenig editor" to compatible HTML.
 			$post_content = $this->replace_video_embeds( $post_content );
 			$post_content = $this->replace_audio_embeds( $post_content );
-			$post_content = $this->replace_blockquotes( $post_content );
 
 			// Post.
 			$args = array(
@@ -829,7 +828,7 @@ class GhostCMSHelper {
 	 * @return void
 	 */
 	private function log( string $message, string $level = 'debug', bool $exit_on_error = false ): void {
-		$logger = MultiLog::get_cli_and_file_logger( 'multi-' . $this->log_slug );
+		$logger = MultiLog::get_cli_and_file_logger( $this->log_slug );
 
 		try {
 			$level = Level::fromName( $level );

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -324,7 +324,7 @@ class GhostCMSHelper {
 			and p.post_status = 'publish'",
 			ARRAY_A
 		);
-		$this->log( sprintf( 'Checking posts imported from Ghost for custom Ghost editor HTML content...', count( $post_ids ) ) );
+		$this->log( sprintf( 'Checking %d posts imported from Ghost for custom Ghost editor HTML content...', count( $post_ids ) ) );
 		$elements     = [];
 		$failed_posts = [];
 		foreach ( $post_ids as $post_id ) {

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -399,17 +399,18 @@ class GhostCMSHelper {
 		$file_handle = fopen( $output_file, 'w' ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fopen.
 		if ( false === $file_handle ) {
 			$this->log( sprintf( 'Failed to open file "%s" for writing.', $output_file ), LogLevel::ERROR );
+		} else {
+			foreach ( $elements as $element_data ) {
+				$data = [
+					'html_element'           => $element_data['html_element'],
+					'kg_classes'             => $element_data['kg_classes'],
+					'first_example_full_tag' => $element_data['first_example_full_tag'],
+					'post_ids'               => $element_data['post_ids'],
+				];
+				fwrite( $file_handle, wp_json_encode( $data ) . PHP_EOL ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fwrite.
+			}
+			fclose( $file_handle ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fclose.
 		}
-		foreach ( $elements as $element_data ) {
-			$data = [
-				'html_element'           => $element_data['html_element'],
-				'kg_classes'             => $element_data['kg_classes'],
-				'first_example_full_tag' => $element_data['first_example_full_tag'],
-				'post_ids'               => $element_data['post_ids'],
-			];
-			fwrite( $file_handle, wp_json_encode( $data ) . PHP_EOL ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fwrite.
-		}
-		fclose( $file_handle ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fclose.
 
 		/**
 		 * Log summary.

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -298,13 +298,13 @@ class GhostCMSHelper {
 	/**
 	 * Check imported posts for custom Ghost Koenig editor HTML content, by scanning all HTML elements with kg-* classes.
 	 * 
-	 * @param string $logger_slug The logger slug.
+	 * @param string $log_slug The logger slug.
 	 */
-	public function check_imported_posts_for_custom_html_content( string $logger_slug ): void {
+	public function check_imported_posts_for_custom_html_content( string $log_slug ): void {
 		global $wpdb;
 
 		// Init logger usage in this class.
-		$this->log_slug = $logger_slug;
+		$this->log_slug = $log_slug;
 		
 		// Prepare output file.
 		$output_file = 'ghost_kg_elements.jsonl';

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -18,6 +18,7 @@ use Newspack\MigrationTools\Util\Log\CliLog;
 use Newspack\MigrationTools\Util\Log\FileLog;
 use Newspack\MigrationTools\Util\Log\MultiLog;
 use Monolog\Level;
+use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use simplehtmldom\HtmlDocument;
 use UnhandledMatchError;
@@ -289,6 +290,143 @@ class GhostCMSHelper {
 		}
 
 		$this->log( 'Done.' );
+	}
+
+	public function cmd_check_imported_posts_for_custom_html_content( array $pos_args, array $assoc_args, LoggerInterface $logger ): void {
+		global $wpdb;
+		
+		// Categorized custom Ghost Koenig editor content blocks with post IDs where they appear.
+		$output_file = 'ghost_kg_elements.jsonl';
+		if ( file_exists( $output_file ) ) {
+			unlink( $output_file ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink.
+		}
+
+		// Store located elements here.
+		$elements = [];
+
+		// Check all published posts migrated from Ghost, ordered by ID DESC.
+		$post_rows = $wpdb->get_results( // phpcs:ignore -- WordPress.DB.DirectDatabaseQuery.DirectQuery WordPress.DB.DirectDatabaseQuery.NoCaching.
+			"select p.ID, p.post_content from {$wpdb->posts} p
+			join {$wpdb->postmeta} pm on p.ID = pm.post_id
+			where pm.meta_key = 'newspack_ghostcms_id'
+			and pm.meta_value is not null
+			and p.post_type = 'post'
+			and p.post_status = 'publish' 
+			order by p.ID desc",
+			ARRAY_A
+		);
+		$logger->debug( sprintf( 'Checking %d posts imported from Ghost for custom Ghost editor HTML content...', count( $post_rows ) ) );
+		$failed_posts = [];
+		foreach ( $post_rows as $post_row ) {
+			$post_id      = (int) $post_row['ID'];
+			$post_content = $post_row['post_content'];
+			if ( empty( $post_content ) ) {
+				continue;
+			}
+
+			try {
+				$doc = new HtmlDocument( $post_content );
+
+				// Process all elements.
+				$all_elements = $doc->find( '*' );
+				foreach ( $all_elements as $element ) {
+					$class_attr = $element->getAttribute( 'class' );
+					if ( empty( $class_attr ) ) {
+						continue;
+					}
+
+					// Extract kg-* classes.
+					$classes    = explode( ' ', $class_attr );
+					$kg_classes = [];
+					foreach ( $classes as $class ) {
+						$class = trim( $class );
+						if ( str_starts_with( $class, 'kg-' ) ) {
+							$kg_classes[] = $class;
+						}
+					}
+
+					// Continue if no kg-* classes found.
+					if ( empty( $kg_classes ) ) {
+						continue;
+					}
+
+					// Extract full opening tag for example.
+					$outertext           = $element->outertext;
+					$closing_bracket_pos = strpos( $outertext, '>' );
+					// If there's no closing bracket, use the whole outertext.
+					if ( false === $closing_bracket_pos ) {
+						$full_opening_tag = $outertext;
+					} else {
+						// From start to the first closing bracket inclusive.
+						$full_opening_tag = substr( $outertext, 0, $closing_bracket_pos + 1 );
+					}
+
+					// Create normalized element key (tag + class only, ignoring other attributes).
+					$tag_name    = $element->tag;
+					$element_key = sprintf( '<%s class="%s">', $tag_name, $class_attr );
+
+					// Initialize element if first time categorizing it.
+					if ( ! isset( $elements[ $element_key ] ) ) {
+						$elements[ $element_key ] = [
+							'kg_classes'       => $kg_classes,
+							'post_ids'         => [],
+							'example_full_tag' => $full_opening_tag, // Store first full example.
+						];
+					}
+
+					// Add this post ID to the element's list if not already there.
+					if ( ! in_array( $post_id, $elements[ $element_key ]['post_ids'], true ) ) {
+						$elements[ $element_key ]['post_ids'][] = $post_id;
+					}
+				}
+			} catch ( \Exception $e ) {
+				// Log error.
+				$failed_posts[] = $post_id;
+				$logger->warning( sprintf( 'Failed to parse post ID %d: %s', $post_id, $e->getMessage() ) );
+			}
+		}
+
+		// Write results to JSONL file.
+		$file_handle = fopen( $output_file, 'w' ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fopen.
+		if ( false === $file_handle ) {
+			$logger->error( sprintf( 'Failed to open file "%s" for writing.', $output_file ) );
+		}
+		foreach ( $elements as $element_key => $element_data ) {
+			$data = [
+				'html_element'     => $element_key,
+				'kg_classes'       => $element_data['kg_classes'],
+				'example_full_tag' => $element_data['example_full_tag'],
+				'post_ids'         => $element_data['post_ids'],
+			];
+			fwrite( $file_handle, wp_json_encode( $data ) . PHP_EOL ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fwrite.
+		}
+		fclose( $file_handle ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fclose.
+
+		// Log errors summary.
+		$logger->warning( sprintf( 'Found %d unique kg-* elements.', count( $elements ) ) );
+		if ( ! empty( $failed_posts ) ) {
+			$logger->warning( sprintf( 'Failed to parse %d posts: %s', count( $failed_posts ), implode( ', ', $failed_posts ) ) );
+		}
+		// Log results.
+		$logger->info( 'Found elements:' );
+		foreach ( $elements as $element_key => $element_data ) {
+			$count_ids  = count( $element_data['post_ids'] );
+			$sample_ids = array_slice( $element_data['post_ids'], 0, 10 );
+
+			$logger->debug( sprintf( 'Element: %s', $element_key ) );
+			$logger->debug( sprintf( '  kg-* classes: %s', implode( ', ', $element_data['kg_classes'] ) ) );
+			$logger->debug( sprintf( '  Example: %s', $element_data['example_full_tag'] ) );
+			$logger->debug( sprintf( '  Posts: %d', $count_ids ) );
+			$logger->debug( sprintf( '  Sample IDs: %s', implode( ', ', $sample_ids ) ) );
+		}
+		$logger->info(
+			sprintf(
+				'Done, found %d unique kg-* elements in %d posts. Results saved to "%s".',
+				count( $elements ),
+				count( $post_rows ),
+				$output_file
+			)
+		);
 	}
 
 	/**

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -315,22 +315,20 @@ class GhostCMSHelper {
 		/**
 		 * Check all published posts migrated from Ghost for custom Ghost editor HTML content -- HTML elements with "kg-*" classes.
 		 */
-		$post_rows = $wpdb->get_results( // phpcs:ignore -- WordPress.DB.DirectDatabaseQuery.DirectQuery WordPress.DB.DirectDatabaseQuery.NoCaching.
-			"select p.ID, p.post_content from {$wpdb->posts} p
+		$post_ids = $wpdb->get_col( // phpcs:ignore -- WordPress.DB.DirectDatabaseQuery.DirectQuery WordPress.DB.DirectDatabaseQuery.NoCaching.
+			"select p.ID from {$wpdb->posts} p
 			join {$wpdb->postmeta} pm on p.ID = pm.post_id
 			where pm.meta_key = 'newspack_ghostcms_id'
 			and pm.meta_value is not null
 			and p.post_type = 'post'
-			and p.post_status = 'publish' 
-			order by p.ID desc",
+			and p.post_status = 'publish'",
 			ARRAY_A
 		);
-		$this->log( sprintf( 'Checking posts imported from Ghost for custom Ghost editor HTML content...', count( $post_rows ) ) );
+		$this->log( sprintf( 'Checking posts imported from Ghost for custom Ghost editor HTML content...', count( $post_ids ) ) );
 		$elements     = [];
 		$failed_posts = [];
-		foreach ( $post_rows as $post_row ) {
-			$post_id      = (int) $post_row['ID'];
-			$post_content = $post_row['post_content'];
+		foreach ( $post_ids as $post_id ) {
+			$post_content = $wpdb->get_var( $wpdb->prepare( "SELECT post_content FROM {$wpdb->posts} WHERE ID = %d", $post_id ) ); // phpcs:ignore -- WordPress.DB.DirectDatabaseQuery.DirectQuery WordPress.DB.DirectDatabaseQuery.NoCaching.
 			if ( empty( $post_content ) ) {
 				continue;
 			}
@@ -420,9 +418,9 @@ class GhostCMSHelper {
 			$this->log( sprintf( 'Failed to parse %d posts: %s', count( $failed_posts ), implode( ', ', $failed_posts ) ), LogLevel::ERROR );
 		}
 		if ( ! empty( $elements ) ) {
-			$this->log( sprintf( "Found %d unfamiliar/unhandled 'kg-*' elements in total %d posts. Their tags and post IDs where they appear are saved to %s. Please QA these findings: if they display correctly/well enough in the WP frontend/backend, simply whitelist them in the GhostCMSHelper's constant; if they don't, write fixers/transformers for them.", count( $elements ), count( $post_rows ), $output_file ), LogLevel::WARNING );
+			$this->log( sprintf( "Found %d unfamiliar/unhandled 'kg-*' elements in total %d posts. Their tags and post IDs where they appear are saved to %s. Please QA these findings: if they display correctly/well enough in the WP frontend/backend, simply whitelist them in the GhostCMSHelper's constant; if they don't, write fixers/transformers for them.", count( $elements ), count( $post_ids ), $output_file ), LogLevel::WARNING );
 		} else {
-			$this->log( sprintf( "No unfamiliar/unhandled 'kg-*' elements found in total %d posts.", count( $post_rows ) ), LogLevel::INFO );
+			$this->log( sprintf( "No unfamiliar/unhandled 'kg-*' elements found in total %d posts.", count( $post_ids ) ), LogLevel::INFO );
 		}
 		$this->log( 'Done checking for custom Ghost HTML content.', LogLevel::INFO );
 	}

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -235,9 +235,10 @@ class GhostCMSHelper {
 
 			// Post content processing.
 			$post_content = str_replace( '__GHOST_URL__', $this->ghost_url, $json_post->html );
-			// Replace video and audio embeds from Ghost's "Koenig editor" to classic HTML5 (Ghost's syntax won't work in WP frontend or Gutenberg).
+			// Replace various syntax elements from Ghost's "Koenig editor" to compatible HTML.
 			$post_content = $this->replace_video_embeds( $post_content );
 			$post_content = $this->replace_audio_embeds( $post_content );
+			$post_content = $this->replace_blockquotes( $post_content );
 
 			// Post.
 			$args = array(
@@ -292,19 +293,26 @@ class GhostCMSHelper {
 		$this->log( 'Done.' );
 	}
 
+	/**
+	 * Check imported posts for custom Ghost Koenig editor HTML content, by scanning all HTML elements with kg-* classes.
+	 * 
+	 * @param array           $pos_args The positional arguments.
+	 * @param array           $assoc_args The associative arguments.
+	 * @param LoggerInterface $logger The logger.
+	 */
 	public function cmd_check_imported_posts_for_custom_html_content( array $pos_args, array $assoc_args, LoggerInterface $logger ): void {
 		global $wpdb;
 		
-		// Categorized custom Ghost Koenig editor content blocks with post IDs where they appear.
+		// Prepare output file.
 		$output_file = 'ghost_kg_elements.jsonl';
 		if ( file_exists( $output_file ) ) {
 			unlink( $output_file ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink.
 		}
 
-		// Store located elements here.
-		$elements = [];
-
-		// Check all published posts migrated from Ghost, ordered by ID DESC.
+		/**
+		 * Check all published posts migrated from Ghost for custom Ghost editor HTML content -- HTML elements with "kg-*" classes.
+		 */
+		$logger->debug( sprintf( 'Checking %d posts imported from Ghost for custom Ghost editor HTML content...', count( $post_rows ) ) );
 		$post_rows = $wpdb->get_results( // phpcs:ignore -- WordPress.DB.DirectDatabaseQuery.DirectQuery WordPress.DB.DirectDatabaseQuery.NoCaching.
 			"select p.ID, p.post_content from {$wpdb->posts} p
 			join {$wpdb->postmeta} pm on p.ID = pm.post_id
@@ -315,7 +323,7 @@ class GhostCMSHelper {
 			order by p.ID desc",
 			ARRAY_A
 		);
-		$logger->debug( sprintf( 'Checking %d posts imported from Ghost for custom Ghost editor HTML content...', count( $post_rows ) ) );
+		$elements     = [];
 		$failed_posts = [];
 		foreach ( $post_rows as $post_row ) {
 			$post_id      = (int) $post_row['ID'];
@@ -325,9 +333,8 @@ class GhostCMSHelper {
 			}
 
 			try {
-				$doc = new HtmlDocument( $post_content );
-
-				// Process all elements.
+				// Parse all elements.
+				$doc          = new HtmlDocument( $post_content );
 				$all_elements = $doc->find( '*' );
 				foreach ( $all_elements as $element ) {
 					$class_attr = $element->getAttribute( 'class' );
@@ -344,89 +351,77 @@ class GhostCMSHelper {
 							$kg_classes[] = $class;
 						}
 					}
-
-					// Continue if no kg-* classes found.
 					if ( empty( $kg_classes ) ) {
 						continue;
 					}
 
-					// Extract full opening tag for example.
+					// Get full opening tag for example.
 					$outertext           = $element->outertext;
 					$closing_bracket_pos = strpos( $outertext, '>' );
-					// If there's no closing bracket, use the whole outertext.
+					// If there's no closing bracket, use the whole outertext (e.g. malformed `<img src="broken`).
 					if ( false === $closing_bracket_pos ) {
 						$full_opening_tag = $outertext;
 					} else {
-						// From start to the first closing bracket inclusive.
+						// From start to the first closing bracket inclusive (e.g. `<img src="x" class="kg-image">` from `<img ...>content</img>`).
 						$full_opening_tag = substr( $outertext, 0, $closing_bracket_pos + 1 );
 					}
 
-					// Create normalized element key (tag + class only, ignoring other attributes).
-					$tag_name    = $element->tag;
-					$element_key = sprintf( '<%s class="%s">', $tag_name, $class_attr );
+					// Group elements by keys = tag name + sorted kg-classes.
+					$tag_name = $element->tag;
+					sort( $kg_classes );
+					$grouping_key = $tag_name . '|' . implode( ',', $kg_classes );
 
-					// Initialize element if first time categorizing it.
-					if ( ! isset( $elements[ $element_key ] ) ) {
-						$elements[ $element_key ] = [
-							'kg_classes'       => $kg_classes,
-							'post_ids'         => [],
-							'example_full_tag' => $full_opening_tag, // Store first full example.
+					// Initialize array element if first time adding it.
+					if ( ! isset( $elements[ $grouping_key ] ) ) {
+						$elements[ $grouping_key ] = [
+							'html_element'           => $tag_name,
+							'kg_classes'             => $kg_classes,
+							'post_ids'               => [],
+							'first_example_full_tag' => $full_opening_tag, // Store first full example for convenience.
 						];
 					}
 
-					// Add this post ID to the element's list if not already there.
-					if ( ! in_array( $post_id, $elements[ $element_key ]['post_ids'], true ) ) {
-						$elements[ $element_key ]['post_ids'][] = $post_id;
+					// Add this post ID where the element appears.
+					if ( ! in_array( $post_id, $elements[ $grouping_key ]['post_ids'], true ) ) {
+						$elements[ $grouping_key ]['post_ids'][] = $post_id;
 					}
 				}
 			} catch ( \Exception $e ) {
-				// Log error.
 				$failed_posts[] = $post_id;
 				$logger->warning( sprintf( 'Failed to parse post ID %d: %s', $post_id, $e->getMessage() ) );
 			}
 		}
 
-		// Write results to JSONL file.
+		/**
+		 * Write results to JSONL file.
+		 */
 		$file_handle = fopen( $output_file, 'w' ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fopen.
 		if ( false === $file_handle ) {
 			$logger->error( sprintf( 'Failed to open file "%s" for writing.', $output_file ) );
 		}
-		foreach ( $elements as $element_key => $element_data ) {
+		foreach ( $elements as $element_data ) {
 			$data = [
-				'html_element'     => $element_key,
-				'kg_classes'       => $element_data['kg_classes'],
-				'example_full_tag' => $element_data['example_full_tag'],
-				'post_ids'         => $element_data['post_ids'],
+				'html_element'           => $element_data['html_element'],
+				'kg_classes'             => $element_data['kg_classes'],
+				'first_example_full_tag' => $element_data['first_example_full_tag'],
+				'post_ids'               => $element_data['post_ids'],
 			];
 			fwrite( $file_handle, wp_json_encode( $data ) . PHP_EOL ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fwrite.
 		}
 		fclose( $file_handle ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fclose.
 
-		// Log errors summary.
-		$logger->warning( sprintf( 'Found %d unique kg-* elements.', count( $elements ) ) );
+		/**
+		 * Log summary.
+		 */
 		if ( ! empty( $failed_posts ) ) {
-			$logger->warning( sprintf( 'Failed to parse %d posts: %s', count( $failed_posts ), implode( ', ', $failed_posts ) ) );
+			$logger->error( sprintf( 'Failed to parse %d posts: %s', count( $failed_posts ), implode( ', ', $failed_posts ) ) );
 		}
-		// Log results.
-		$logger->info( 'Found elements:' );
-		foreach ( $elements as $element_key => $element_data ) {
-			$count_ids  = count( $element_data['post_ids'] );
-			$sample_ids = array_slice( $element_data['post_ids'], 0, 10 );
-
-			$logger->debug( sprintf( 'Element: %s', $element_key ) );
-			$logger->debug( sprintf( '  kg-* classes: %s', implode( ', ', $element_data['kg_classes'] ) ) );
-			$logger->debug( sprintf( '  Example: %s', $element_data['example_full_tag'] ) );
-			$logger->debug( sprintf( '  Posts: %d', $count_ids ) );
-			$logger->debug( sprintf( '  Sample IDs: %s', implode( ', ', $sample_ids ) ) );
+		if ( ! empty( $elements ) ) {
+			$logger->warning( sprintf( "Found %d unfamiliar/unhandled 'kg-*' elements in total %d posts. Their tags and post IDs where they appear are saved to %s. Please QA these findings: if they display correctly/well enough in the WP frontend/backend, simply whitelist them in the GhostCMSHelper's constant; if they don't, write fixers/transformers for them.", count( $elements ), count( $post_rows ), $output_file ) );
+		} else {
+			$logger->info( sprintf( "No unfamiliar/unhandled 'kg-*' elements found in total %d posts.", count( $post_rows ) ) );
 		}
-		$logger->info(
-			sprintf(
-				'Done, found %d unique kg-* elements in %d posts. Results saved to "%s".',
-				count( $elements ),
-				count( $post_rows ),
-				$output_file
-			)
-		);
+		$logger->info( 'Done' );
 	}
 
 	/**
@@ -1180,6 +1175,8 @@ class GhostCMSHelper {
 
 		return (string) $doc;
 	}
+
+	
 
 	/**
 	 * Get all visibility values from JSON data.

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -321,8 +321,7 @@ class GhostCMSHelper {
 			where pm.meta_key = 'newspack_ghostcms_id'
 			and pm.meta_value is not null
 			and p.post_type = 'post'
-			and p.post_status = 'publish'",
-			ARRAY_A
+			and p.post_status = 'publish'"
 		);
 		$this->log( sprintf( 'Checking %d posts imported from Ghost for custom Ghost editor HTML content...', count( $post_ids ) ) );
 		$elements     = [];


### PR DESCRIPTION
### Standalone helper command

The `ghostcms-check-imported-posts-for-custom-html-content` command scans all posts imported from Ghost for HTML elements which have a class with the "kg-" prefix, comes from Ghost Koenig editor.  

Those might be things such as nested custom syntax embeds which depend on Ghost styling/processing, and won't display correctly (or well enough) in WP frontend or backend, or it could be just extra styling annotation and nesting to prettify certain elements some more. Some of these "custom Ghost content" might be displayed correctly, or well enough (evaluated on a migration in progress, with TAM's additional QA and confirmation), in which case these elements get whitelisted in code (the next PR introduces that -- please allow that the ending log message mentions "whitelist them", it's coming in the next PR) and won't get reported (in the next PR, this one will report them all), while other elements need to be transformed. An additional PR following this one brings a series of such fixers, and will show how to implements fixers/replacers and how to whitelist them from this command.

This command scans any such HTML elements, groups them according to element type and class(es), and outputs a comprehensive list in a JSONL file (which seemed to me safer than CSV because HTML elements are output and needed escaping) with info about those particular elements:
- `html_element`, HTML element type/tag
- `kg_classes`, kg- classes used by that particular element
- `first_example_full_tag`, full HTML of first such element found
- `post_ids`, where this HTML appears

A single JSONL entry is a grouped by HTML element type/tag + kg_classes it has. Seeing how there could be multiple similar entries, e.g.
```
<img class"kg-image" ...>
<img class"kg-image custom things" ...>
```
purely for convenience the `first_example_full_tag` is listed in JSONL, while `post_ids` will contain all located "flavors" of this element.

Attached here is an actual JSONL file produced on an ongoing migration I'm working on (extra .txt suffix was appended because GH PR won't accept JSONLs).

[ghost_kg_elements.jsonl.txt](https://github.com/user-attachments/files/25097649/ghost_kg_elements.jsonl.txt)

### Integrated into the main import command

I first made this into a standalone command, which I believe is handy to be able to run on any Ghost imported site. in any stage of migration.

I also added it to execute after the Ghost import is completed -- during the import, all known syntax will get converted to WP-friendly HTML, and after the import any remaining unfamiliar "kg-" content gets checked, with a notice and a detailed JSONL file with all found custom content elements.

### Other code changes

- switched the default logging level from 'info' as default. Green should be only to highlight success messages, otherwise if everything is green it loses its purpose and makes things less readable
- removed "multi-" prefix hardcoded and additionally appended to logger slug by the log method since it made it difficult for different methods to use the same logger, and it actually seems more complicated that the slug is actually defined in multiple places, while presently we use no really custom logging config

_Also see Copilot's review summary down below._