### PR TITLE
Deprecate the duplicate get_attachment_by_filename in favor of get_attachment_id_by_filename

### DIFF
--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -572,30 +572,6 @@ class Attachments {
 	}
 
 	/**
-	 * Find an attachment by its filename.
-	 *
-	 * @deprecated Use get_attachment_id_by_filename() instead, which has proper LIKE escaping and typed return.
-	 *
-	 * @param string $filename The filename.
-	 * @return int|null The attachment ID or null if not found.
-	 */
-	public static function get_attachment_by_filename( $filename ) {
-		global $wpdb;
-
-		$filename = esc_sql( $filename );
-		// phpcs:disable -- $filename is properly sanitized.
-		$attachment_id = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_wp_attached_file' AND meta_value LIKE '%s'",
-				'%' . $filename,
-			),
-		);
-		// phpcs:enable
-
-		return $attachment_id;
-	}
-
-	/**
 	 * This helper wraps the `wp_get_attachment_image_src()` function to bypass Jetpack's Photon.
 	 *
 	 * We don't want the CDN urls in migration data because they are harder to replace later.

--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -574,8 +574,10 @@ class Attachments {
 	/**
 	 * Find an attachment by its filename.
 	 *
+	 * @deprecated Use get_attachment_id_by_filename() instead, which has proper LIKE escaping and typed return.
+	 *
 	 * @param string $filename The filename.
-	 * @return int The attachment ID.
+	 * @return int|null The attachment ID or null if not found.
 	 */
 	public static function get_attachment_by_filename( $filename ) {
 		global $wpdb;


### PR DESCRIPTION
The newer method has proper LIKE escaping, strict return type (int), guaranteed non-null return (0 instead of null), and we should remove the older duplicate (I additionally updated the duplicate's docblock return type description because it was wrong).