### PR TITLE
Ghost user nicenames/slugs creation and rewriting

### DIFF
--- a/src/Command/GhostCMSMigrator.php
+++ b/src/Command/GhostCMSMigrator.php
@@ -96,6 +96,13 @@ class GhostCMSMigrator implements WpCliCommandInterface {
 					'shortdesc' => "After the content has been imported, run this command to check the imported posts for yet unvalidated/unsupported custom HTML content/syntax from the Ghost Koenig editor (such as different custom embeds, or Ghost's equivalents to Gutenberg blocks). This scans all HTML elements with kg-* classes.",
 				],
 			],
+			[
+				'newspack-migration-tools ghostcms-rewrite-author-urls',
+				[ __CLASS__, 'cmd_rewrite_ghost_author_urls' ],
+				[
+					'shortdesc' => 'Rewrite Ghost author URLs in imported post content. When users are imported from Ghost, their WordPress user_nicename (URL slug) may differ from the original Ghost slug if a collision occurred. This command finds all such users and rewrites author URLs in post content from the old Ghost slug to the new WordPress nicename.',
+				],
+			],
 		];
 	}
 	
@@ -135,5 +142,20 @@ class GhostCMSMigrator implements WpCliCommandInterface {
 
 		$ghost = new GhostCMSHelper();
 		$ghost->check_imported_posts_for_custom_html_content( $log_slug );
+	}
+
+	/**
+	 * Callable for the 'newspack-migration-tools ghostcms-rewrite-author-urls' command.
+	 * 
+	 * @param array $pos_args The positional arguments.
+	 * @param array $assoc_args The associative arguments.
+	 */
+	public static function cmd_rewrite_ghost_author_urls( array $pos_args, array $assoc_args ): void {
+		$log_slug = __FUNCTION__;
+		$logger   = MultiLog::get_cli_and_file_logger( $log_slug );
+		$logger->info( 'Starting CLI - Rewriting Ghost author URLs in post content...' );
+
+		$ghost = new GhostCMSHelper();
+		$ghost->rewrite_ghost_author_urls_in_content( $log_slug );
 	}
 }

--- a/src/Command/GhostCMSMigrator.php
+++ b/src/Command/GhostCMSMigrator.php
@@ -101,6 +101,15 @@ class GhostCMSMigrator implements WpCliCommandInterface {
 				[ __CLASS__, 'cmd_rewrite_ghost_author_urls' ],
 				[
 					'shortdesc' => 'Rewrite Ghost author URLs in imported post content. When users are imported from Ghost, their WordPress user_nicename (URL slug) may differ from the original Ghost slug if a collision occurred. This command finds all such users and rewrites author URLs in post content from the old Ghost slug to the new WordPress nicename.',
+					'synopsis'  => [
+						[
+							'type'        => 'assoc',
+							'name'        => 'ghost-url',
+							'description' => 'Public URL of the Ghost website (e.g., https://www.liveghost.com). This is the same URL used during import. The author URLs in post content will contain this hostname, and will be rewritten from the original Ghost slug to the new WP nicename.',
+							'optional'    => false,
+							'repeating'   => false,
+						],
+					],
 				],
 			],
 		];
@@ -151,11 +160,19 @@ class GhostCMSMigrator implements WpCliCommandInterface {
 	 * @param array $assoc_args The associative arguments.
 	 */
 	public static function cmd_rewrite_ghost_author_urls( array $pos_args, array $assoc_args ): void {
+		// Logger.
 		$log_slug = __FUNCTION__;
 		$logger   = MultiLog::get_cli_and_file_logger( $log_slug );
 		$logger->info( 'Starting CLI - Rewriting Ghost author URLs in post content...' );
 
+		// Arguments.
+		if ( ! isset( $assoc_args['ghost-url'] ) || ! preg_match( '#^https?://[^/]+/?$#i', $assoc_args['ghost-url'] ) ) {
+			$logger->error( 'Ghost URL does not match regex: ^https?://[^/]+/?$' );
+			exit( 1 );
+		}
+		$ghost_url = $assoc_args['ghost-url'];
+
 		$ghost = new GhostCMSHelper();
-		$ghost->rewrite_ghost_author_urls_in_content( $log_slug );
+		$ghost->rewrite_ghost_author_urls_in_content( $log_slug, $ghost_url );
 	}
 }

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -557,10 +557,15 @@ class GhostCMSHelper {
 				$user_nicename                   = $user['user_nicename'];
 				$post_content_before_replacement = $post_content_updated;
 
-				// Replace all strings in content from `//{hostname}/author/{ghost_slug}"` to `//{hostname}/author/{user_nicename}"`.
+				// Replace author URL, with or without trailing slash.
 				$post_content_updated = str_replace(
 					sprintf( '//%s/author/%s"', $hostname, $ghost_slug ),
 					sprintf( '//%s/author/%s"', $hostname, $user_nicename ),
+					$post_content_updated
+				);
+				$post_content_updated = str_replace(
+					sprintf( '//%s/author/%s/"', $hostname, $ghost_slug ),
+					sprintf( '//%s/author/%s/"', $hostname, $user_nicename ),
 					$post_content_updated
 				);
 

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -344,6 +344,9 @@ class GhostCMSHelper {
 
 		$this->log( 'Done importing posts from Ghost.', LogLevel::INFO );
 
+		// Rewrite author URLs in content if any nicenames changed during import.
+		$this->rewrite_ghost_author_urls_in_content( $this->log_slug );
+
 		// Run command to check for custom Ghost HTML content.
 		$this->check_imported_posts_for_custom_html_content( $this->log_slug );
 	}
@@ -481,6 +484,104 @@ class GhostCMSHelper {
 			$this->log( sprintf( "No unfamiliar/unhandled 'kg-*' elements found in total %d posts.", count( $post_ids ) ), LogLevel::INFO );
 		}
 		$this->log( 'Done checking for custom Ghost HTML content.', LogLevel::INFO );
+	}
+
+	/**
+	 * Rewrite Ghost author URLs in imported post content.
+	 *
+	 * When users are imported from Ghost, we try to preserve their original Ghost slug in `user_nicename`,
+	 * but that specific `user_nicename` may already be taken during user insertion, and so the resulting nicename may 
+	 * still differ from the original Ghost slug.
+	 * 
+	 * This method finds all such users and rewrites author URLs in post content from the old Ghost slug to the new nicename.
+	 *
+	 * @param string $log_slug The logger slug.
+	 */
+	public function rewrite_ghost_author_urls_in_content( string $log_slug ): void {
+		global $wpdb;
+
+		// Init logger usage in this class.
+		$this->set_log_slug( $log_slug );
+
+		$hostname = wp_parse_url( home_url(), PHP_URL_HOST );
+		if ( empty( $hostname ) ) {
+			$this->log( 'Could not determine site hostname from home_url() -- no author URL rewrites have been done. Please attempt to run the self-standing command `wp newspack-migration-tools ghostcms-rewrite-author-urls` to check if author URLs are rewritten correctly.', LogLevel::ERROR );
+			return;
+		}
+
+		// Get Ghost users where user_nicename differs from their original Ghost slug.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+		$users_to_update = $wpdb->get_results(
+			"SELECT u.ID, um.meta_value AS ghost_slug, u.user_nicename
+			FROM $wpdb->users u
+			JOIN $wpdb->usermeta um ON u.ID = um.user_id
+			WHERE um.meta_key = 'newspack_ghostcms_slug'
+			AND u.user_nicename <> um.meta_value",
+			ARRAY_A
+		);
+		// phpcs:enable
+		if ( empty( $users_to_update ) ) {
+			$this->log( 'No users with changed nicenames found. No author URL rewrites needed.', LogLevel::INFO );
+			return;
+		}
+
+		$this->log( sprintf( 'Found %d users with nicenames different from their original Ghost slugs.', count( $users_to_update ) ), LogLevel::INFO );
+
+		// Get all posts imported from Ghost.
+		$post_ids = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			"SELECT DISTINCT p.ID FROM $wpdb->posts p
+			JOIN $wpdb->postmeta pm ON pm.post_id = p.ID
+			WHERE p.post_type = 'post' AND p.post_status = 'publish'
+			AND pm.meta_key = 'newspack_ghostcms_id'"
+		);
+		if ( empty( $post_ids ) ) {
+			$this->log( 'No Ghost posts found.', LogLevel::WARNING );
+			return;
+		}
+
+		$this->log( sprintf( 'Scanning %d Ghost posts for author URL rewrites...', count( $post_ids ) ), LogLevel::INFO );
+
+		// Rewrite author URLs in content.
+		foreach ( $post_ids as $post_id ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$post_content = $wpdb->get_var( $wpdb->prepare( "SELECT post_content FROM $wpdb->posts WHERE ID = %d", $post_id ) );
+			if ( empty( $post_content ) ) {
+				continue;
+			}
+
+			$replaced_user_nicenames = [];
+			$post_content_updated    = $post_content;
+
+			foreach ( $users_to_update as $user ) {
+				$ghost_slug                      = $user['ghost_slug'];
+				$user_nicename                   = $user['user_nicename'];
+				$post_content_before_replacement = $post_content_updated;
+
+				// Replace all strings in content from `//{hostname}/author/{ghost_slug}"` to `//{hostname}/author/{user_nicename}"`.
+				$post_content_updated = str_replace(
+					sprintf( '//%s/author/%s"', $hostname, $ghost_slug ),
+					sprintf( '//%s/author/%s"', $hostname, $user_nicename ),
+					$post_content_updated
+				);
+
+				// Note if a replacement was made.
+				if ( $post_content_before_replacement !== $post_content_updated ) {
+					$replaced_user_nicenames[] = $user_nicename;
+				}
+			}
+
+			if ( $post_content !== $post_content_updated ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->update(
+					$wpdb->posts,
+					[ 'post_content' => $post_content_updated ],
+					[ 'ID' => $post_id ]
+				);
+				$this->log( sprintf( 'Updated post ID %d with URLs to user_nicename(s): %s', $post_id, implode( ', ', $replaced_user_nicenames ) ), LogLevel::INFO );
+			}
+		}
+
+		wp_cache_flush();
 	}
 
 	/**

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -345,7 +345,7 @@ class GhostCMSHelper {
 		$this->log( 'Done importing posts from Ghost.', LogLevel::INFO );
 
 		// Rewrite author URLs in content if any nicenames changed during import.
-		$this->rewrite_ghost_author_urls_in_content( $this->log_slug );
+		$this->rewrite_ghost_author_urls_in_content( $this->log_slug, $this->ghost_url );
 
 		// Run command to check for custom Ghost HTML content.
 		$this->check_imported_posts_for_custom_html_content( $this->log_slug );
@@ -495,17 +495,18 @@ class GhostCMSHelper {
 	 * 
 	 * This method finds all such users and rewrites author URLs in post content from the old Ghost slug to the new nicename.
 	 *
-	 * @param string $log_slug The logger slug.
+	 * @param string $log_slug  The logger slug.
+	 * @param string $ghost_url The Ghost site URL (e.g., https://www.liveghost.com).
 	 */
-	public function rewrite_ghost_author_urls_in_content( string $log_slug ): void {
+	public function rewrite_ghost_author_urls_in_content( string $log_slug, string $ghost_url ): void {
 		global $wpdb;
 
 		// Init logger usage in this class.
 		$this->set_log_slug( $log_slug );
 
-		$hostname = wp_parse_url( home_url(), PHP_URL_HOST );
+		$hostname = wp_parse_url( $ghost_url, PHP_URL_HOST );
 		if ( empty( $hostname ) ) {
-			$this->log( 'Could not determine site hostname from home_url() -- no author URL rewrites have been done. Please attempt to run the self-standing command `wp newspack-migration-tools ghostcms-rewrite-author-urls` to check if author URLs are rewritten correctly.', LogLevel::ERROR );
+			$this->log( 'Could not determine hostname from provided Ghost URL.', LogLevel::ERROR );
 			return;
 		}
 

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -671,9 +671,11 @@ class GhostCMSHelper {
 		}
 
 		// Create Guest Contributor.
-		$user_data = [
-			'display_name' => $display_name,
-			'user_login'   => $json_author_user->slug ?? sanitize_title( $display_name ),
+		$desired_slug = $json_author_user->slug ?? sanitize_title( $display_name );
+		$user_data    = [
+			'display_name'  => $display_name,
+			'user_login'    => $desired_slug,
+			'user_nicename' => $desired_slug, // Try and preserve same user slug for author URLs.
 		];
 		if ( ! empty( $json_author_user->email ) ) {
 			$user_data['user_email'] = $json_author_user->email;

--- a/tests/Logic/TestGhostCMSHelper.php
+++ b/tests/Logic/TestGhostCMSHelper.php
@@ -1056,4 +1056,42 @@ class TestGhostCMSHelper extends WP_UnitTestCase {
 		$this->assertIsObject( $category );
 		$this->assertEquals( 'news', $category->slug );
 	}
+
+	/**
+	 * Test that GhostCMS Helper will import from JSON file and rewrite author urls.
+	 *
+	 * @return void
+	 */
+	public function test_ghostcms_import_and_rewrite_author_urls(): void {
+
+		// Run test.
+		$test_ghostcms_helper = new GhostCMSHelper();
+		$test_ghostcms_helper->ghostcms_import( 
+			[], 
+			[
+				'json-file'       => 'tests/fixtures/ghostcms.json',
+				'ghost-url'       => 'https://newspack.com/',
+				'default-user-id' => 1,
+			],
+			''
+		);
+
+		// Posts.
+		$posts = get_posts(
+			[
+				'title'       => 'Author Slug Test',
+				'numberposts' => 1,
+			]
+		);
+		$this->assertIsArray( $posts );
+		$this->assertCount( 1, $posts );
+		$this->assertEquals( 'author-slug-test', $posts[0]->post_name );
+
+		
+		// Author url fixed.
+		$this->assertStringContainsString(
+			'/author/user-with-really-long-name-over-user_nicename-50-c">Click to see all my posts',
+			$posts[0]->post_content
+		);
+	}
 }

--- a/tests/fixtures/ghostcms.json
+++ b/tests/fixtures/ghostcms.json
@@ -30,13 +30,31 @@
                         "canonical_url": null,
                         "newsletter_id": "634d9d2778516800318062d9",
                         "show_title_and_feature_image": 1
+                    },
+                    {
+                        "id": "post-0000000000000000007",
+                        "uuid": "post0000-0000-0000-0000-000000000007",
+                        "title": "Author Slug Test",
+                        "slug": "author-slug-test",
+                        "html": "<a href=\"__GHOST_URL__/author/user-with-really-long-name-over-user_nicename-50-char-limit\">Click to see all my posts</a>",
+                        "type": "post",
+                        "status": "published",
+                        "visibility": "public",
+                        "created_at": "2024-04-07T23:11:41.000Z",
+                        "published_at": "2024-04-07T23:12:17.000Z"
                     }
-               ],
+                ],
                 "posts_authors": [
                     {
                         "id": "65ea49b97b6cf900014e6622",
                         "post_id": "65ea49ad7b6cf900014e661c",
                         "author_id": "6387a43e354f5f003ddbe55f",
+                        "sort_order": 0
+                    },
+                    {
+                        "id": "post-author-000000000002",
+                        "post_id": "post-0000000000000000007",
+                        "author_id": "user-0000000000000000002",
                         "sort_order": 0
                     }
                 ],
@@ -143,6 +161,13 @@
                         "milestone_notifications": 1,
                         "donation_notifications": 1,
                         "recommendation_notifications": 1
+                    },
+                    {
+                        "id": "user-0000000000000000002",
+                        "name": "User with really long name over user_nicename 50 char limit",
+                        "slug": "user-with-really-long-name-over-user_nicename-50-char-limit",
+                        "email": "user-0000000000000000002@example.com",
+                        "visibility": "public"
                     }
                ]
             },


### PR DESCRIPTION
### Preserving same user slugs

Ghost users presently get inserted to WP with potentially different slugs than their original Ghost data -- WP User creation is done by `UsersHelper::create_or_get_user`, but nicename/slug is not specified, and ends up being created from a sanitized display name. Sometimes these slugs are different, and if there are author references in post content, e.g. `Read more by <a href="https://example.com/author/john">John<\a>` might need rewriting to new slug, e.g. "john-doe" (based on display name).

The first one-line change in this PR attempts to reuse the same existing Ghost user slug as new WP User nicename, which would leave default author URLs the same, and no need for rewriting. Added in [d872d8c](https://github.com/Automattic/newspack-migration-tools/pull/160/commits/d872d8c3d9bb65111c62135b13f4e856f7379ee1).

### Rewriting user URLs

However the nicename might already be taken at the point of user insertion, in which case the `UsersHelper::create_or_get_user` will safely call `get_unused_nicename()` and come up with a different user_nicename.

That's why the following rewriting command was added in remaining commits (other than that one above 👆).

This rewriting command is quite simple:
- it gets Ghost user slugs which are different from the created WP user nicenames
- replaces literal strings in post content, and this is made simple -- it will address `src`s and `href`s which have a closing `"` which is suffixed to the from/to strings:
    - from `//{HOST}/author/{GHOST_SLUG}"`
    - to `//{HOST}/author/{USER_NICENAME}"`
The suffix `"` will also avoid wrongly overwriting similar but not same author URLs like original `john`, target `john-doe` or `john-doeman`.

To test, insert a link in a test post, and see if the slug gets updated, e.g.
```
<p>Read more from <a href="https://example.com/author/old_slug/">Old author</a>
```