### PR TITLE
feat: init commit of CommandSupervisor

### DIFF
--- a/src/Command/CommandSupervisor.php
+++ b/src/Command/CommandSupervisor.php
@@ -2,6 +2,7 @@
 
 namespace Newspack\MigrationTools\Command;
 
+use Newspack\MigrationTools\NMT;
 use Newspack\MigrationTools\Util\Log\MultiLog;
 use Psr\Log\LoggerInterface;
 use WP_CLI;
@@ -73,13 +74,13 @@ class CommandSupervisor implements WpCliCommandInterface {
 						[
 							'type'        => 'flag',
 							'name'        => 'restart-on-success',
-							'description' => 'Also restart the command after a successful exit (exit code 0). Useful for batch-processing commands that need to run multiple passes. Requires --completion-criteria or --max-success-retries.',
+							'description' => 'Also restart the command after a successful exit (exit code 0). The supervised command can signal completion by exiting with code 2 (EXIT_DONE). Optionally use --completion-criteria or --max-success-retries as alternative stop conditions.',
 							'optional'    => true,
 						],
 						[
 							'type'        => 'assoc',
 							'name'        => 'completion-criteria',
-							'description' => 'A string to look for in the command output that indicates processing is complete and the supervisor should stop restarting. When set, --max-success-retries is ignored.',
+							'description' => 'A string to look for in the command output that indicates processing is complete. Fallback for commands that cannot use exit code 2 (EXIT_DONE) to signal completion. When set, --max-success-retries is ignored.',
 							'optional'    => true,
 						],
 						[
@@ -92,7 +93,7 @@ class CommandSupervisor implements WpCliCommandInterface {
 						[
 							'type'        => 'assoc',
 							'name'        => 'active-plugins',
-							'description' => 'Comma-separated list of additional plugin slugs to keep active. Plugins that depend on newspack-migration-tools are automatically kept active. All other plugins are skipped via --skip-plugins for memory optimization.',
+							'description' => 'Comma-separated list of additional plugin slugs to keep active. Co-Authors Plus, Simple Local Avatars, Yoast, and Newspack are kept active by default, along with any plugin that depends on newspack-migration-tools. All other plugins are skipped via --skip-plugins for memory optimization.',
 							'optional'    => true,
 						],
 						[
@@ -154,9 +155,16 @@ class CommandSupervisor implements WpCliCommandInterface {
 
 			$this->logger->info( sprintf( '========== Attempt #%d ==========', $attempt ) );
 
-			$process         = $this->execute_command( $command );
-			$final_exit_code = $process->return_code;
-			$success         = ( 0 === $process->return_code );
+			$process = $this->execute_command( $command );
+			// If return code is 2 (EXIT_DONE) is received, the command has fully completed its task.
+			$done = ( NMT::EXIT_DONE === $process->return_code );
+			// Want to know if the command has succeeded or not. A return code of 1 (EXIT_ERROR) means an error occurred.
+			// A return code of 1 is ignored if EXIT_DONE is received.
+			$success = ( 0 === $process->return_code || $done );
+			// If EXIT_DONE is received, we convert the final exit code to 0, indicating success. Otherwise, fallback to whatever the final exit code is.
+			$final_exit_code = $done ? 0 : $process->return_code;
+			// Track the success/failure status for the current and previous attempts.
+			// This is used to determine consecutive successes or failures.
 			if ( null !== $operation_status_stack[0] ) {
 				$operation_status_stack[1] = $operation_status_stack[0];
 			}
@@ -169,6 +177,12 @@ class CommandSupervisor implements WpCliCommandInterface {
 			if ( $success ) {
 				++$total_success_count;
 				$consecutive_fail_count = 0;
+
+				if ( $done ) {
+					$this->logger->info( sprintf( 'Command signaled completion (exit code %d) on attempt #%d. Stopping.', NMT::EXIT_DONE, $attempt ) );
+					break;
+				}
+
 				$this->logger->info( sprintf( 'Command succeeded on attempt #%d (exit code 0).', $attempt ) );
 
 				if ( ! $restart_on_success ) {
@@ -251,7 +265,7 @@ class CommandSupervisor implements WpCliCommandInterface {
 	 * @param string $command WP-CLI command without the "wp" prefix.
 	 * @return object{stdout: string, stderr: string, return_code: int} Process result.
 	 */
-	private function execute_command( string $command ): object {
+	protected function execute_command( string $command ): object {
 		return WP_CLI::runcommand(
 			$command,
 			[
@@ -319,12 +333,13 @@ class CommandSupervisor implements WpCliCommandInterface {
 		// Build the whitelist: host plugin(s) + default active plugins + caller-specified plugins.
 		$whitelist = $this->get_host_plugin_slugs( $all_active );
 
-		// Allow default active plugins to be configured via constant or filter.
-		$default_active_plugins = [];
-		if ( defined( 'NMT_DEFAULT_ACTIVE_PLUGINS' ) ) {
-			$default_active_plugins = array_map( 'trim', explode( ',', NMT_DEFAULT_ACTIVE_PLUGINS ) );
-		}
-		$default_active_plugins = apply_filters( 'newspack_migration_tools_default_active_plugins', $default_active_plugins );
+		// Plugins commonly used during migrations that should remain active by default.
+		$default_active_plugins = [
+			'co-authors-plus',
+			'simple-local-avatars',
+			'wordpress-seo',
+			'newspack-plugin',
+		];
 		$whitelist              = array_merge( $whitelist, $default_active_plugins );
 
 		if ( ! empty( $active_plugins_arg ) ) {

--- a/src/Command/CommandSupervisor.php
+++ b/src/Command/CommandSupervisor.php
@@ -283,15 +283,11 @@ class CommandSupervisor implements WpCliCommandInterface {
 
 		$flags = [];
 
-		if ( $has_skip_themes ) {
-			$this->logger->info( '--skip-themes already present in command; skipping.' );
-		} else {
+		if ( ! $has_skip_themes ) {
 			$flags[] = '--skip-themes';
 		}
 
-		if ( $has_skip_plugins ) {
-			$this->logger->info( '--skip-plugins already present in command; skipping.' );
-		} else {
+		if ( ! $has_skip_plugins ) {
 			$skip_plugins_list = $this->get_plugins_to_skip( $active_plugins_arg );
 			if ( ! empty( $skip_plugins_list ) ) {
 				$flags[] = '--skip-plugins=' . implode( ',', $skip_plugins_list );

--- a/src/Command/CommandSupervisor.php
+++ b/src/Command/CommandSupervisor.php
@@ -316,8 +316,17 @@ class CommandSupervisor implements WpCliCommandInterface {
 	private function get_plugins_to_skip( string $active_plugins_arg ): array {
 		$all_active = get_option( 'active_plugins', [] );
 
-		// Build the whitelist: host plugin(s) + caller-specified plugins.
+		// Build the whitelist: host plugin(s) + default active plugins + caller-specified plugins.
 		$whitelist = $this->get_host_plugin_slugs( $all_active );
+
+		// Allow default active plugins to be configured via constant or filter.
+		$default_active_plugins = [];
+		if ( defined( 'NMT_DEFAULT_ACTIVE_PLUGINS' ) ) {
+			$default_active_plugins = array_map( 'trim', explode( ',', NMT_DEFAULT_ACTIVE_PLUGINS ) );
+		}
+		$default_active_plugins = apply_filters( 'newspack_migration_tools_default_active_plugins', $default_active_plugins );
+		$whitelist              = array_merge( $whitelist, $default_active_plugins );
+
 		if ( ! empty( $active_plugins_arg ) ) {
 			$whitelist = array_merge(
 				$whitelist,

--- a/src/Command/CommandSupervisor.php
+++ b/src/Command/CommandSupervisor.php
@@ -168,6 +168,7 @@ class CommandSupervisor implements WpCliCommandInterface {
 
 			if ( $success ) {
 				++$total_success_count;
+				$consecutive_fail_count = 0;
 				$this->logger->info( sprintf( 'Command succeeded on attempt #%d (exit code 0).', $attempt ) );
 
 				if ( ! $restart_on_success ) {
@@ -210,6 +211,11 @@ class CommandSupervisor implements WpCliCommandInterface {
 					$this->logger->warning( sprintf( 'Max fail retries (%d) reached. Stopping.', $max_fail_retries ) );
 					break;
 				}
+
+				if ( $consecutive_fail_count >= $max_consecutive_fail_retries ) {
+					$this->logger->warning( sprintf( 'Max consecutive fail retries (%d) reached. Stopping.', $max_consecutive_fail_retries ) );
+					break;
+				}
 			}
 
 			$this->logger->info( sprintf( 'Retrying in %d seconds...', $retry_delay ) );
@@ -228,9 +234,7 @@ class CommandSupervisor implements WpCliCommandInterface {
 			}
 		}
 
-		if ( $total_success_count >= $max_success_retries ) {
-			$this->logger->info( 'Command succeeded after max success retries.' );
-		} elseif ( $consecutive_fail_count >= $max_consecutive_fail_retries || $total_fail_count >= $max_fail_retries ) {
+		if ( $consecutive_fail_count >= $max_consecutive_fail_retries || $total_fail_count >= $max_fail_retries ) {
 			$this->logger->error( 'Command failed after max consecutive failures or max fail retries.' );
 			WP_CLI::halt( 1 );
 		}

--- a/src/Command/CommandSupervisor.php
+++ b/src/Command/CommandSupervisor.php
@@ -117,10 +117,10 @@ class CommandSupervisor implements WpCliCommandInterface {
 	 */
 	public function cmd_supervise( array $args, array $assoc_args ): void {
 		$command              = $assoc_args['command'];
-		$max_fail_retries     = intval( $assoc_args['max-fail-retries'] ?? 3 );
-		$max_consecutive_fail_retries = intval( $assoc_args['max-consecutive-fail-retries'] ?? 2 );
-		$max_success_retries  = intval( $assoc_args['max-success-retries'] ?? 10 );
-		$retry_delay          = intval( $assoc_args['retry-delay'] ?? 5 );
+		$max_fail_retries     = abs( intval( $assoc_args['max-fail-retries'] ?? 3 ) );
+		$max_consecutive_fail_retries = abs( intval( $assoc_args['max-consecutive-fail-retries'] ?? 2 ) );
+		$max_success_retries  = abs( intval( $assoc_args['max-success-retries'] ?? 10 ) );
+		$retry_delay          = abs( intval( $assoc_args['retry-delay'] ?? 5 ) );
 		$restart_on_success   = isset( $assoc_args['restart-on-success'] );
 		$completion_criteria  = $assoc_args['completion-criteria'] ?? null;
 		$active_plugins_arg   = $assoc_args['active-plugins'] ?? '';

--- a/src/Command/CommandSupervisor.php
+++ b/src/Command/CommandSupervisor.php
@@ -1,0 +1,345 @@
+<?php
+
+namespace Newspack\MigrationTools\Command;
+
+use Newspack\MigrationTools\Util\Log\MultiLog;
+use Psr\Log\LoggerInterface;
+use WP_CLI;
+use WP_CLI\ExitException;
+
+/**
+ * Class CommandSupervisor.
+ *
+ * Supervises the execution of a shell command with automatic restart on failure.
+ * Designed for long-running migration scripts that may crash, timeout, or get OOM-killed.
+ */
+class CommandSupervisor implements WpCliCommandInterface {
+
+	use WpCliCommandTrait;
+
+	/**
+	 * Logger instance that writes to both CLI and file.
+	 *
+	 * @var LoggerInterface
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * Get CLI commands for the class.
+	 *
+	 * The array should contain an array of arrays. Each entry is a command.
+	 * Each command should have 2 or 3 elements that are the same as you would
+	 * pass to WP_CLI::add_command().
+	 * See https://make.wordpress.org/cli/handbook/references/internal-api/wp-cli-add-command/
+	 *
+	 * @return array
+	 */
+	public static function get_cli_commands(): array {
+		return [
+			[
+				'newspack-content-migrator command-supervisor',
+				self::get_command_closure( 'cmd_supervise' ),
+				[
+					'shortdesc' => 'Supervises and manages command execution with automatic restart.',
+					'longdesc'  => 'Runs a given shell command and automatically restarts it on failure. Useful for long-running migration scripts that may crash, timeout, or get OOM-killed. The supervisor will keep retrying until the command exits successfully (exit code 0) or the maximum number of retries is reached.',
+					'synopsis'  => [
+						[
+							'type'        => 'assoc',
+							'name'        => 'command',
+							'description' => 'The WP-CLI command to supervise, without the "wp" prefix (e.g. "newspack-content-migrator some-command --batch-size=100").',
+							'optional'    => false,
+						],
+						[
+							'type'        => 'assoc',
+							'name'        => 'max-fail-retries',
+							'description' => 'Maximum number of consecutive or total failed attempts before giving up. Successful runs do not count toward this limit.',
+							'optional'    => true,
+							'default'     => 3,
+						],
+						[
+							'type'        => 'assoc',
+							'name'        => 'retry-delay',
+							'description' => 'Seconds to wait between retries.',
+							'optional'    => true,
+							'default'     => 5,
+						],
+						[
+							'type'        => 'flag',
+							'name'        => 'restart-on-success',
+							'description' => 'Also restart the command after a successful exit (exit code 0). Useful for batch-processing commands that need to run multiple passes. Requires --completion-criteria or --max-success-retries.',
+							'optional'    => true,
+						],
+						[
+							'type'        => 'assoc',
+							'name'        => 'completion-criteria',
+							'description' => 'A string to look for in the command output that indicates processing is complete and the supervisor should stop restarting. When set, --max-success-retries is ignored.',
+							'optional'    => true,
+						],
+						[
+							'type'        => 'assoc',
+							'name'        => 'max-success-retries',
+							'description' => 'Maximum number of successful runs before stopping. Only used with --restart-on-success when --completion-criteria is not set.',
+							'optional'    => true,
+							'default'     => 10,
+						],
+						[
+							'type'        => 'assoc',
+							'name'        => 'active-plugins',
+							'description' => 'Comma-separated list of additional plugin slugs to keep active. newspack-custom-content-migrator is always kept active. All other plugins are skipped via --skip-plugins for memory optimization.',
+							'optional'    => true,
+						],
+						[
+							'type'        => 'assoc',
+							'name'        => 'notify-email',
+							'description' => 'Email address to notify when supervision ends (either final success or max retries exhausted).',
+							'optional'    => true,
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Supervises a command, restarting it on failure until it succeeds or max retries is hit.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 *
+	 * @throws ExitException If an error occurs during command execution.
+	 */
+	public function cmd_supervise( array $args, array $assoc_args ): void {
+		$command              = $assoc_args['command'];
+		$max_fail_retries     = intval( $assoc_args['max-fail-retries'] ?? 3 );
+		$max_success_retries  = intval( $assoc_args['max-success-retries'] ?? 10 );
+		$retry_delay          = intval( $assoc_args['retry-delay'] ?? 5 );
+		$restart_on_success   = isset( $assoc_args['restart-on-success'] );
+		$completion_criteria  = $assoc_args['completion-criteria'] ?? null;
+		$active_plugins_arg   = $assoc_args['active-plugins'] ?? '';
+		$notify_email         = $assoc_args['notify-email'] ?? null;
+
+		$this->logger = MultiLog::get_cli_and_file_logger( 'CommandSupervisor' );
+
+		// Strip the "wp" prefix if the caller included it.
+		$command = preg_replace( '/^\S*wp\s+/', '', $command );
+		$command = $this->inject_wp_cli_global_flags( $command, $active_plugins_arg );
+
+		$this->logger->info( "Starting supervision of: {$command}" );
+		$this->logger->info(
+			sprintf(
+				'Config: max-fail-retries=%d, retry-delay=%ds, restart-on-success=%s',
+				$max_fail_retries,
+				$retry_delay,
+				$restart_on_success ? 'yes' : 'no'
+			)
+		);
+
+		$attempt         = 0;
+		$fail_count      = 0;
+		$success_count   = 0;
+		$final_exit_code = null;
+
+		while ( true ) {
+			++$attempt;
+
+			$this->logger->info( "========== Attempt #{$attempt} ==========" );
+
+			$process         = $this->execute_command( $command );
+			$final_exit_code = $process->return_code;
+			$success         = ( 0 === $process->return_code );
+
+			if ( ! empty( $process->stdout ) ) {
+				$this->logger->info( $process->stdout );
+			}
+
+			if ( $success ) {
+				++$success_count;
+				$this->logger->info( "Command succeeded on attempt #{$attempt} (exit code 0)." );
+
+				if ( ! $restart_on_success ) {
+					break;
+				}
+
+				if ( ! empty( $completion_criteria ) ) {
+					// Check if the output contains the completion criteria string.
+					$output = ( $process->stdout ?? '' ) . ( $process->stderr ?? '' );
+					if ( false !== strpos( $output, $completion_criteria ) ) {
+						$this->logger->info( "Completion criteria \"{$completion_criteria}\" found in output. Stopping." );
+						break;
+					}
+				} elseif ( $success_count >= $max_success_retries ) {
+					$this->logger->info( "Max success retries ({$max_success_retries}) reached. Stopping." );
+					break;
+				}
+
+				$this->logger->info( "--restart-on-success is set; will restart after delay (success {$success_count}" . ( empty( $completion_criteria ) ? "/{$max_success_retries})." : ').' ) );
+			} else {
+				++$fail_count;
+
+				if ( ! empty( $process->stderr ) ) {
+					$this->logger->error( $process->stderr );
+				}
+				$this->logger->warning( "Command failed with exit code {$process->return_code} on attempt #{$attempt} (failure {$fail_count}/{$max_fail_retries})." );
+
+				// Check whether we've exhausted failure retries.
+				if ( $fail_count >= $max_fail_retries ) {
+					$this->logger->warning( "Max fail retries ({$max_fail_retries}) reached. Stopping." );
+					break;
+				}
+			}
+
+			$this->logger->info( "Retrying in {$retry_delay} seconds..." );
+			sleep( $retry_delay );
+		}
+
+		// Final summary.
+		$this->logger->info( '========== Supervision Complete ==========' );
+		$this->logger->info( sprintf( 'Finished after %d attempt(s), %d failure(s). Final exit code: %d.', $attempt, $fail_count, $final_exit_code ) );
+
+		if ( $notify_email ) {
+			$this->send_notification( $notify_email, $final_exit_code, $command, $attempt );
+		}
+
+		if ( 0 !== $final_exit_code ) {
+			$this->logger->error( sprintf( 'Command did not complete successfully after %d failure(s).', $fail_count ) );
+			WP_CLI::halt( 1 );
+		}
+	}
+
+	/**
+	 * Executes a WP-CLI command as a subprocess and returns the process result.
+	 *
+	 * Uses WP_CLI::runcommand() with launch=true so it spawns a new process using the
+	 * same PHP binary, avoiding "env: php: No such file or directory" issues.
+	 *
+	 * @param string $command WP-CLI command without the "wp" prefix.
+	 * @return object{stdout: string, stderr: string, return_code: int} Process result.
+	 */
+	private function execute_command( string $command ): object {
+		return WP_CLI::runcommand(
+			$command,
+			[
+				'launch'     => true,
+				'return'     => 'all',
+				'exit_error' => false,
+			]
+		);
+	}
+
+	/**
+	 * Injects --skip-themes and --skip-plugins global flags into a WP-CLI command for memory optimization.
+	 *
+	 * Flags are prepended to the command string so they appear before the subcommand, e.g.:
+	 *   --skip-themes --skip-plugins=foo,bar newspack-content-migrator some-command
+	 *
+	 * If the caller already included --skip-themes or --skip-plugins in the command,
+	 * those flags are respected and not overridden.
+	 *
+	 * @param string $command            The WP-CLI command (without "wp" prefix) to modify.
+	 * @param string $active_plugins_arg Comma-separated list of additional plugin slugs to keep active.
+	 *
+	 * @return string The command with WP-CLI global flags prepended.
+	 */
+	private function inject_wp_cli_global_flags( string $command, string $active_plugins_arg ): string {
+		// Check if the caller already included --skip-* flags in the command.
+		$has_skip_themes  = (bool) preg_match( '/--skip-themes\b/', $command );
+		$has_skip_plugins = (bool) preg_match( '/--skip-plugins\b/', $command );
+
+		$flags = [];
+
+		if ( $has_skip_themes ) {
+			$this->logger->info( '--skip-themes already present in command; skipping.' );
+		} else {
+			$flags[] = '--skip-themes';
+		}
+
+		if ( $has_skip_plugins ) {
+			$this->logger->info( '--skip-plugins already present in command; skipping.' );
+		} else {
+			$skip_plugins_list = $this->get_plugins_to_skip( $active_plugins_arg );
+			if ( ! empty( $skip_plugins_list ) ) {
+				$flags[] = '--skip-plugins=' . implode( ',', $skip_plugins_list );
+			}
+		}
+
+		if ( empty( $flags ) ) {
+			return $command;
+		}
+
+		$this->logger->info( 'Injected WP-CLI global flags: ' . implode( ' ', $flags ) );
+
+		return implode( ' ', $flags ) . ' ' . $command;
+	}
+
+	/**
+	 * Builds the list of plugin slugs to skip.
+	 *
+	 * All active plugins are included except newspack-custom-content-migrator and any additional
+	 * plugins specified by the caller.
+	 *
+	 * @param string $active_plugins_arg Comma-separated list of additional plugin slugs to keep active.
+	 *
+	 * @return string[] Plugin slugs to pass to --skip-plugins.
+	 */
+	private function get_plugins_to_skip( string $active_plugins_arg ): array {
+		// Build the whitelist of plugins that should remain active.
+		$whitelist = [ 'newspack-custom-content-migrator' ];
+		if ( ! empty( $active_plugins_arg ) ) {
+			$whitelist = array_merge(
+				$whitelist,
+				array_map( 'trim', explode( ',', $active_plugins_arg ) )
+			);
+		}
+		$whitelist = array_unique( $whitelist );
+
+		// Determine which active plugins to skip.
+		$all_active   = get_option( 'active_plugins', [] );
+		$skip_plugins = [];
+
+		foreach ( $all_active as $plugin_path ) {
+			$plugin_slug = dirname( $plugin_path );
+
+			// Single-file plugins have no directory, so dirname returns '.'.
+			if ( '.' === $plugin_slug ) {
+				$plugin_slug = basename( $plugin_path, '.php' );
+			}
+
+			if ( ! in_array( $plugin_slug, $whitelist, true ) ) {
+				$skip_plugins[] = $plugin_slug;
+			}
+		}
+
+		return $skip_plugins;
+	}
+
+	/**
+	 * Sends an email notification about the supervision outcome.
+	 *
+	 * @param string $email     Recipient email address.
+	 * @param int    $exit_code Final exit code of the supervised command.
+	 * @param string $command   The supervised command string.
+	 * @param int    $attempts  Total number of attempts made.
+	 */
+	private function send_notification( string $email, int $exit_code, string $command, int $attempts ): void {
+		$status  = ( 0 === $exit_code ) ? 'succeeded' : 'failed';
+		$subject = sprintf( '[CommandSupervisor] Command %s after %d attempt(s)', $status, $attempts );
+		$body    = implode(
+			"\n",
+			[
+				"Command:  {$command}",
+				"Status:   {$status}",
+				"Exit code: {$exit_code}",
+				"Attempts: {$attempts}",
+				'Time:     ' . gmdate( 'Y-m-d H:i:s' ),
+			]
+		);
+
+		$sent = wp_mail( $email, $subject, $body );
+
+		if ( $sent ) {
+			$this->logger->info( "Notification sent to {$email}." );
+		} else {
+			$this->logger->warning( "Failed to send notification to {$email}." );
+		}
+	}
+}

--- a/src/Command/CommandSupervisor.php
+++ b/src/Command/CommandSupervisor.php
@@ -92,7 +92,7 @@ class CommandSupervisor implements WpCliCommandInterface {
 						[
 							'type'        => 'assoc',
 							'name'        => 'active-plugins',
-							'description' => 'Comma-separated list of additional plugin slugs to keep active. newspack-custom-content-migrator is always kept active. All other plugins are skipped via --skip-plugins for memory optimization.',
+							'description' => 'Comma-separated list of additional plugin slugs to keep active. Plugins that depend on newspack-migration-tools are automatically kept active. All other plugins are skipped via --skip-plugins for memory optimization.',
 							'optional'    => true,
 						],
 						[
@@ -306,16 +306,18 @@ class CommandSupervisor implements WpCliCommandInterface {
 	/**
 	 * Builds the list of plugin slugs to skip.
 	 *
-	 * All active plugins are included except newspack-custom-content-migrator and any additional
-	 * plugins specified by the caller.
+	 * All active plugins are skipped except the host plugin(s) that depend on
+	 * newspack-migration-tools and any additional plugins specified by the caller.
 	 *
 	 * @param string $active_plugins_arg Comma-separated list of additional plugin slugs to keep active.
 	 *
 	 * @return string[] Plugin slugs to pass to --skip-plugins.
 	 */
 	private function get_plugins_to_skip( string $active_plugins_arg ): array {
-		// Build the whitelist of plugins that should remain active.
-		$whitelist = [ 'newspack-custom-content-migrator' ];
+		$all_active = get_option( 'active_plugins', [] );
+
+		// Build the whitelist: host plugin(s) + caller-specified plugins.
+		$whitelist = $this->get_host_plugin_slugs( $all_active );
 		if ( ! empty( $active_plugins_arg ) ) {
 			$whitelist = array_merge(
 				$whitelist,
@@ -325,7 +327,6 @@ class CommandSupervisor implements WpCliCommandInterface {
 		$whitelist = array_unique( $whitelist );
 
 		// Determine which active plugins to skip.
-		$all_active   = get_option( 'active_plugins', [] );
 		$skip_plugins = [];
 
 		foreach ( $all_active as $plugin_path ) {
@@ -342,6 +343,52 @@ class CommandSupervisor implements WpCliCommandInterface {
 		}
 
 		return $skip_plugins;
+	}
+
+	/**
+	 * Detects which active plugins depend on newspack-migration-tools.
+	 *
+	 * Checks each plugin's composer.json for the automattic/newspack-migration-tools
+	 * dependency. These plugins must remain active for the supervised command to work.
+	 *
+	 * @param string[] $active_plugins Active plugin paths from the active_plugins option.
+	 *
+	 * @return string[] Plugin slugs that depend on newspack-migration-tools.
+	 */
+	private function get_host_plugin_slugs( array $active_plugins ): array {
+		$host_plugins = [];
+
+		foreach ( $active_plugins as $plugin_path ) {
+			$plugin_slug = dirname( $plugin_path );
+
+			// Single-file plugins won't have a composer.json.
+			if ( '.' === $plugin_slug ) {
+				continue;
+			}
+
+			$composer_file = WP_PLUGIN_DIR . '/' . $plugin_slug . '/composer.json';
+			if ( ! file_exists( $composer_file ) ) {
+				continue;
+			}
+
+			$composer_json = file_get_contents( $composer_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$composer      = json_decode( $composer_json, true );
+			if ( ! is_array( $composer ) ) {
+				continue;
+			}
+
+			if ( isset( $composer['require']['automattic/newspack-migration-tools'] ) ) {
+				$host_plugins[] = $plugin_slug;
+			}
+		}
+
+		if ( empty( $host_plugins ) ) {
+			$this->logger->warning( 'Could not detect host plugin for newspack-migration-tools. No plugins will be whitelisted automatically.' );
+		} else {
+			$this->logger->info( sprintf( 'Detected host plugin(s): %s', implode( ', ', $host_plugins ) ) );
+		}
+
+		return $host_plugins;
 	}
 
 	/**

--- a/src/Command/CommandSupervisor.php
+++ b/src/Command/CommandSupervisor.php
@@ -52,9 +52,16 @@ class CommandSupervisor implements WpCliCommandInterface {
 						[
 							'type'        => 'assoc',
 							'name'        => 'max-fail-retries',
-							'description' => 'Maximum number of consecutive or total failed attempts before giving up. Successful runs do not count toward this limit.',
+							'description' => 'Maximum number of failed attempts before giving up. Successful runs do not count toward this limit.',
 							'optional'    => true,
 							'default'     => 3,
+						],
+						[
+							'type'        => 'assoc',
+							'name'        => 'max-consecutive-fail-retries',
+							'description' => 'Maximum number of consecutive failed attempts before giving up. Successful runs do not count toward this limit.',
+							'optional'    => true,
+							'default'     => 2,
 						],
 						[
 							'type'        => 'assoc',
@@ -106,11 +113,12 @@ class CommandSupervisor implements WpCliCommandInterface {
 	 * @param array $args Positional arguments.
 	 * @param array $assoc_args Associative arguments.
 	 *
-	 * @throws ExitException If an error occurs during command execution.
+	 * @throws ExitException Thrown if the command fails beyond or equal to the maximum number of retries.
 	 */
 	public function cmd_supervise( array $args, array $assoc_args ): void {
 		$command              = $assoc_args['command'];
 		$max_fail_retries     = intval( $assoc_args['max-fail-retries'] ?? 3 );
+		$max_consecutive_fail_retries = intval( $assoc_args['max-consecutive-fail-retries'] ?? 2 );
 		$max_success_retries  = intval( $assoc_args['max-success-retries'] ?? 10 );
 		$retry_delay          = intval( $assoc_args['retry-delay'] ?? 5 );
 		$restart_on_success   = isset( $assoc_args['restart-on-success'] );
@@ -135,9 +143,11 @@ class CommandSupervisor implements WpCliCommandInterface {
 		);
 
 		$attempt         = 0;
-		$fail_count      = 0;
-		$success_count   = 0;
+		$total_fail_count = 0;
+		$consecutive_fail_count = 0;
+		$total_success_count = 0;
 		$final_exit_code = null;
+		$operation_status_stack = [ null, null ];
 
 		while ( true ) {
 			++$attempt;
@@ -147,13 +157,17 @@ class CommandSupervisor implements WpCliCommandInterface {
 			$process         = $this->execute_command( $command );
 			$final_exit_code = $process->return_code;
 			$success         = ( 0 === $process->return_code );
+			if ( $operation_status_stack[0] !== null ) {
+				$operation_status_stack[1] = $operation_status_stack[0];
+			}
+			$operation_status_stack[0] = $success;
 
 			if ( ! empty( $process->stdout ) ) {
 				$this->logger->info( $process->stdout );
 			}
 
 			if ( $success ) {
-				++$success_count;
+				++$total_success_count;
 				$this->logger->info( "Command succeeded on attempt #{$attempt} (exit code 0)." );
 
 				if ( ! $restart_on_success ) {
@@ -167,22 +181,28 @@ class CommandSupervisor implements WpCliCommandInterface {
 						$this->logger->info( "Completion criteria \"{$completion_criteria}\" found in output. Stopping." );
 						break;
 					}
-				} elseif ( $success_count >= $max_success_retries ) {
+				} elseif ( $total_success_count >= $max_success_retries ) {
 					$this->logger->info( "Max success retries ({$max_success_retries}) reached. Stopping." );
 					break;
 				}
 
-				$this->logger->info( "--restart-on-success is set; will restart after delay (success {$success_count}" . ( empty( $completion_criteria ) ? "/{$max_success_retries})." : ').' ) );
+				$this->logger->info( "--restart-on-success is set; will restart after delay (success {$total_success_count}" . ( empty( $completion_criteria ) ? "/{$max_success_retries})." : ').' ) );
 			} else {
-				++$fail_count;
+				++$total_fail_count;
+
+				if ( false === $operation_status_stack[1] ) {
+					++$consecutive_fail_count;
+				} else {
+					$consecutive_fail_count = 1;
+				}
 
 				if ( ! empty( $process->stderr ) ) {
 					$this->logger->error( $process->stderr );
 				}
-				$this->logger->warning( "Command failed with exit code {$process->return_code} on attempt #{$attempt} (failure {$fail_count}/{$max_fail_retries})." );
+				$this->logger->warning( "Command failed with exit code {$process->return_code} on attempt #{$attempt} (consecutive failures {$consecutive_fail_count}/{$max_consecutive_fail_retries} failure {$total_fail_count}/{$max_fail_retries})." );
 
 				// Check whether we've exhausted failure retries.
-				if ( $fail_count >= $max_fail_retries ) {
+				if ( $total_fail_count >= $max_fail_retries ) {
 					$this->logger->warning( "Max fail retries ({$max_fail_retries}) reached. Stopping." );
 					break;
 				}
@@ -194,7 +214,7 @@ class CommandSupervisor implements WpCliCommandInterface {
 
 		// Final summary.
 		$this->logger->info( '========== Supervision Complete ==========' );
-		$this->logger->info( sprintf( 'Finished after %d attempt(s), %d failure(s). Final exit code: %d.', $attempt, $fail_count, $final_exit_code ) );
+		$this->logger->info( sprintf( 'Finished after %d attempt(s), %d failure(s). Final exit code: %d.', $attempt, $total_fail_count, $final_exit_code ) );
 
 		if ( $notify_email ) {
 			if ( ! is_email( $notify_email ) ) {
@@ -204,10 +224,14 @@ class CommandSupervisor implements WpCliCommandInterface {
 			}
 		}
 
-		if ( 0 !== $final_exit_code ) {
-			$this->logger->error( sprintf( 'Command did not complete successfully after %d failure(s).', $fail_count ) );
+		if ( $total_success_count >= $max_success_retries ) {
+			$this->logger->info( 'Command succeeded after max success retries.' );
+		} elseif ( $consecutive_fail_count >= $max_consecutive_fail_retries || $total_fail_count >= $max_fail_retries ) {
+			$this->logger->error( 'Command failed after max consecutive failures or max fail retries.' );
 			WP_CLI::halt( 1 );
 		}
+
+		$this->logger->info( 'Command supervision completed successfully.' );
 	}
 
 	/**

--- a/src/Command/CommandSupervisor.php
+++ b/src/Command/CommandSupervisor.php
@@ -132,7 +132,7 @@ class CommandSupervisor implements WpCliCommandInterface {
 		$command = preg_replace( '/^\S*wp\s+/', '', $command );
 		$command = $this->inject_wp_cli_global_flags( $command, $active_plugins_arg );
 
-		$this->logger->info( "Starting supervision of: {$command}" );
+		$this->logger->info( sprintf( 'Starting supervision of: %s', $command ) );
 		$this->logger->info(
 			sprintf(
 				'Config: max-fail-retries=%d, retry-delay=%ds, restart-on-success=%s',
@@ -152,7 +152,7 @@ class CommandSupervisor implements WpCliCommandInterface {
 		while ( true ) {
 			++$attempt;
 
-			$this->logger->info( "========== Attempt #{$attempt} ==========" );
+			$this->logger->info( sprintf( '========== Attempt #%d ==========', $attempt ) );
 
 			$process         = $this->execute_command( $command );
 			$final_exit_code = $process->return_code;
@@ -168,7 +168,7 @@ class CommandSupervisor implements WpCliCommandInterface {
 
 			if ( $success ) {
 				++$total_success_count;
-				$this->logger->info( "Command succeeded on attempt #{$attempt} (exit code 0)." );
+				$this->logger->info( sprintf( 'Command succeeded on attempt #%d (exit code 0).', $attempt ) );
 
 				if ( ! $restart_on_success ) {
 					break;
@@ -178,15 +178,19 @@ class CommandSupervisor implements WpCliCommandInterface {
 					// Check if the output contains the completion criteria string.
 					$output = ( $process->stdout ?? '' ) . ( $process->stderr ?? '' );
 					if ( false !== strpos( $output, $completion_criteria ) ) {
-						$this->logger->info( "Completion criteria \"{$completion_criteria}\" found in output. Stopping." );
+						$this->logger->info( sprintf( 'Completion criteria "%s" found in output. Stopping.', $completion_criteria ) );
 						break;
 					}
 				} elseif ( $total_success_count >= $max_success_retries ) {
-					$this->logger->info( "Max success retries ({$max_success_retries}) reached. Stopping." );
+					$this->logger->info( sprintf( 'Max success retries (%d) reached. Stopping.', $max_success_retries ) );
 					break;
 				}
 
-				$this->logger->info( "--restart-on-success is set; will restart after delay (success {$total_success_count}" . ( empty( $completion_criteria ) ? "/{$max_success_retries})." : ').' ) );
+				$this->logger->info(
+					empty( $completion_criteria )
+						? sprintf( '--restart-on-success is set; will restart after delay (success %d/%d).', $total_success_count, $max_success_retries )
+						: sprintf( '--restart-on-success is set; will restart after delay (success %d).', $total_success_count )
+				);
 			} else {
 				++$total_fail_count;
 
@@ -199,16 +203,16 @@ class CommandSupervisor implements WpCliCommandInterface {
 				if ( ! empty( $process->stderr ) ) {
 					$this->logger->error( $process->stderr );
 				}
-				$this->logger->warning( "Command failed with exit code {$process->return_code} on attempt #{$attempt} (consecutive failures {$consecutive_fail_count}/{$max_consecutive_fail_retries} failure {$total_fail_count}/{$max_fail_retries})." );
+				$this->logger->warning( sprintf( 'Command failed with exit code %d on attempt #%d (consecutive failures %d/%d, failure %d/%d).', $process->return_code, $attempt, $consecutive_fail_count, $max_consecutive_fail_retries, $total_fail_count, $max_fail_retries ) );
 
 				// Check whether we've exhausted failure retries.
 				if ( $total_fail_count >= $max_fail_retries ) {
-					$this->logger->warning( "Max fail retries ({$max_fail_retries}) reached. Stopping." );
+					$this->logger->warning( sprintf( 'Max fail retries (%d) reached. Stopping.', $max_fail_retries ) );
 					break;
 				}
 			}
 
-			$this->logger->info( "Retrying in {$retry_delay} seconds..." );
+			$this->logger->info( sprintf( 'Retrying in %d seconds...', $retry_delay ) );
 			sleep( $retry_delay );
 		}
 
@@ -354,20 +358,20 @@ class CommandSupervisor implements WpCliCommandInterface {
 		$body    = implode(
 			"\n",
 			[
-				"Command:  {$command}",
-				"Status:   {$status}",
-				"Exit code: {$exit_code}",
-				"Attempts: {$attempts}",
-				'Time:     ' . gmdate( 'Y-m-d H:i:s' ),
+				sprintf( 'Command:   %s', $command ),
+				sprintf( 'Status:    %s', $status ),
+				sprintf( 'Exit code: %d', $exit_code ),
+				sprintf( 'Attempts:  %d', $attempts ),
+				sprintf( 'Time:      %s', gmdate( 'Y-m-d H:i:s' ) ),
 			]
 		);
 
 		$sent = wp_mail( $email, $subject, $body );
 
 		if ( $sent ) {
-			$this->logger->info( "Notification sent to {$email}." );
+			$this->logger->info( sprintf( 'Notification sent to %s.', $email ) );
 		} else {
-			$this->logger->warning( "Failed to send notification to {$email}." );
+			$this->logger->warning( sprintf( 'Failed to send notification to %s.', $email ) );
 		}
 	}
 }

--- a/src/Command/CommandSupervisor.php
+++ b/src/Command/CommandSupervisor.php
@@ -197,7 +197,11 @@ class CommandSupervisor implements WpCliCommandInterface {
 		$this->logger->info( sprintf( 'Finished after %d attempt(s), %d failure(s). Final exit code: %d.', $attempt, $fail_count, $final_exit_code ) );
 
 		if ( $notify_email ) {
-			$this->send_notification( $notify_email, $final_exit_code, $command, $attempt );
+			if ( ! is_email( $notify_email ) ) {
+				$this->logger->error( sprintf( 'Invalid notify-email address provided: %s', $notify_email ) );
+			} else {
+				$this->send_notification( $notify_email, $final_exit_code, $command, $attempt );
+			}
 		}
 
 		if ( 0 !== $final_exit_code ) {

--- a/src/Command/CommandSupervisor.php
+++ b/src/Command/CommandSupervisor.php
@@ -129,7 +129,7 @@ class CommandSupervisor implements WpCliCommandInterface {
 		$this->logger = MultiLog::get_cli_and_file_logger( 'CommandSupervisor' );
 
 		// Strip the "wp" prefix if the caller included it.
-		$command = preg_replace( '/^\S*wp\s+/', '', $command );
+		$command = preg_replace( '/^wp\s+/', '', $command );
 		$command = $this->inject_wp_cli_global_flags( $command, $active_plugins_arg );
 
 		$this->logger->info( sprintf( 'Starting supervision of: %s', $command ) );

--- a/src/Command/CommandSupervisor.php
+++ b/src/Command/CommandSupervisor.php
@@ -116,15 +116,15 @@ class CommandSupervisor implements WpCliCommandInterface {
 	 * @throws ExitException Thrown if the command fails beyond or equal to the maximum number of retries.
 	 */
 	public function cmd_supervise( array $args, array $assoc_args ): void {
-		$command              = $assoc_args['command'];
-		$max_fail_retries     = abs( intval( $assoc_args['max-fail-retries'] ?? 3 ) );
+		$command                      = $assoc_args['command'];
+		$max_fail_retries             = abs( intval( $assoc_args['max-fail-retries'] ?? 3 ) );
 		$max_consecutive_fail_retries = abs( intval( $assoc_args['max-consecutive-fail-retries'] ?? 2 ) );
-		$max_success_retries  = abs( intval( $assoc_args['max-success-retries'] ?? 10 ) );
-		$retry_delay          = abs( intval( $assoc_args['retry-delay'] ?? 5 ) );
-		$restart_on_success   = isset( $assoc_args['restart-on-success'] );
-		$completion_criteria  = $assoc_args['completion-criteria'] ?? null;
-		$active_plugins_arg   = $assoc_args['active-plugins'] ?? '';
-		$notify_email         = $assoc_args['notify-email'] ?? null;
+		$max_success_retries          = abs( intval( $assoc_args['max-success-retries'] ?? 10 ) );
+		$retry_delay                  = abs( intval( $assoc_args['retry-delay'] ?? 5 ) );
+		$restart_on_success           = isset( $assoc_args['restart-on-success'] );
+		$completion_criteria          = $assoc_args['completion-criteria'] ?? null;
+		$active_plugins_arg           = $assoc_args['active-plugins'] ?? '';
+		$notify_email                 = $assoc_args['notify-email'] ?? null;
 
 		$this->logger = MultiLog::get_cli_and_file_logger( 'CommandSupervisor' );
 
@@ -142,11 +142,11 @@ class CommandSupervisor implements WpCliCommandInterface {
 			)
 		);
 
-		$attempt         = 0;
-		$total_fail_count = 0;
+		$attempt                = 0;
+		$total_fail_count       = 0;
 		$consecutive_fail_count = 0;
-		$total_success_count = 0;
-		$final_exit_code = null;
+		$total_success_count    = 0;
+		$final_exit_code        = null;
 		$operation_status_stack = [ null, null ];
 
 		while ( true ) {
@@ -157,7 +157,7 @@ class CommandSupervisor implements WpCliCommandInterface {
 			$process         = $this->execute_command( $command );
 			$final_exit_code = $process->return_code;
 			$success         = ( 0 === $process->return_code );
-			if ( $operation_status_stack[0] !== null ) {
+			if ( null !== $operation_status_stack[0] ) {
 				$operation_status_stack[1] = $operation_status_stack[0];
 			}
 			$operation_status_stack[0] = $success;
@@ -371,7 +371,8 @@ class CommandSupervisor implements WpCliCommandInterface {
 				continue;
 			}
 
-			$composer_json = file_get_contents( $composer_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents,WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+			$composer_json = file_get_contents( $composer_file );
 			$composer      = json_decode( $composer_json, true );
 			if ( ! is_array( $composer ) ) {
 				continue;
@@ -413,6 +414,7 @@ class CommandSupervisor implements WpCliCommandInterface {
 			]
 		);
 
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
 		$sent = wp_mail( $email, $subject, $body );
 
 		if ( $sent ) {

--- a/src/Command/WpCliCommands.php
+++ b/src/Command/WpCliCommands.php
@@ -15,6 +15,7 @@ class WpCliCommands {
 			AttachmentsMigrator::class,
 			BlockTransformerCommand::class,
 			CampaignsMigrator::class,
+			CommandSupervisor::class,
 			ContentConverterPluginMigrator::class,
 			CraftCMSMigrator::class,
 			CssMigrator::class,

--- a/src/NMT.php
+++ b/src/NMT.php
@@ -17,6 +17,16 @@ defined( 'ABSPATH' ) || exit;
 class NMT {
 
 	/**
+	 * Exit code that commands can use to signal "done, no more work."
+	 *
+	 * Used by CommandSupervisor: when --restart-on-success is set, exit 0 means
+	 * "succeeded, restart" and EXIT_DONE means "succeeded, stop."
+	 *
+	 * Usage in a migration command: WP_CLI::halt( NMT::EXIT_DONE );
+	 */
+	public const EXIT_DONE = 2;
+
+	/**
 	 * Log level.
 	 *
 	 * @see \Monolog\Level

--- a/tests/Command/TestCommandSupervisor.php
+++ b/tests/Command/TestCommandSupervisor.php
@@ -8,6 +8,8 @@ use Newspack\MigrationTools\Util\Log\MultiLog;
 use ReflectionClass;
 use WP_UnitTestCase;
 
+require_once __DIR__ . '/TestableCommandSupervisor.php';
+
 /**
  * Class TestCommandSupervisor
  *
@@ -875,56 +877,5 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 3, $supervisor->execute_count );
-	}
-}
-
-/**
- * Test double for CommandSupervisor that returns pre-configured process results.
- *
- * Overrides execute_command() to avoid real subprocess execution, allowing
- * the supervision loop in cmd_supervise() to be tested in isolation.
- */
-class TestableCommandSupervisor extends CommandSupervisor {
-
-	/**
-	 * Sequence of process results to return from execute_command().
-	 *
-	 * @var object[]
-	 */
-	public array $process_results = [];
-
-	/**
-	 * Number of times execute_command() has been called.
-	 *
-	 * @var int
-	 */
-	public int $execute_count = 0;
-
-	/**
-	 * Constructor — replaces the private constructor from WpCliCommandTrait.
-	 */
-	public function __construct() {
-		// Intentionally empty.
-	}
-
-	/**
-	 * Returns the next pre-configured process result instead of running a real command.
-	 *
-	 * Falls back to a successful result (exit code 0) if the sequence is exhausted.
-	 *
-	 * @param string $command Ignored.
-	 *
-	 * @return object Process result with stdout, stderr, and return_code.
-	 */
-	protected function execute_command( string $command ): object {
-		$result = $this->process_results[ $this->execute_count ]
-			?? (object) [
-				'stdout'      => '',
-				'stderr'      => '',
-				'return_code' => 0,
-			];
-		++$this->execute_count;
-
-		return $result;
 	}
 }

--- a/tests/Command/TestCommandSupervisor.php
+++ b/tests/Command/TestCommandSupervisor.php
@@ -114,7 +114,7 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 	private function create_temp_plugin( string $slug, ?array $composer_data = null ): void {
 		$plugin_dir = WP_PLUGIN_DIR . '/' . $slug;
 		if ( ! is_dir( $plugin_dir ) ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir,WordPressVIPMinimum.Functions.RestrictedFunctions.directory_mkdir
 			mkdir( $plugin_dir, 0755, true );
 		}
 		if ( null !== $composer_data ) {
@@ -148,8 +148,8 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 	 * Test that all expected synopsis parameters are present.
 	 */
 	public function test_get_cli_commands_has_all_synopsis_params(): void {
-		$commands   = CommandSupervisor::get_cli_commands();
-		$synopsis   = $commands[0][2]['synopsis'];
+		$commands    = CommandSupervisor::get_cli_commands();
+		$synopsis    = $commands[0][2]['synopsis'];
 		$param_names = array_column( $synopsis, 'name' );
 
 		$expected = [
@@ -463,7 +463,7 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 	public function test_get_host_plugin_slugs_handles_invalid_json(): void {
 		$plugin_dir = WP_PLUGIN_DIR . '/invalid-json-plugin';
 		if ( ! is_dir( $plugin_dir ) ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir,WordPressVIPMinimum.Functions.RestrictedFunctions.directory_mkdir
 			mkdir( $plugin_dir, 0755, true );
 		}
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
@@ -547,23 +547,23 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 	 */
 	public function data_wp_prefix_stripping(): array {
 		return [
-			'simple wp prefix'          => [
+			'simple wp prefix'         => [
 				'wp some-command --flag',
 				'some-command --flag',
 			],
-			'full path wp prefix'       => [
+			'full path wp prefix'      => [
 				'/usr/local/bin/wp some-command --flag',
 				'some-command --flag',
 			],
-			'no wp prefix'              => [
+			'no wp prefix'             => [
 				'some-command --flag',
 				'some-command --flag',
 			],
-			'wp in middle of word'      => [
+			'wp in middle of word'     => [
 				'newspack-wp-migrator some-command',
 				'newspack-wp-migrator some-command',
 			],
-			'wp with extra whitespace'  => [
+			'wp with extra whitespace' => [
 				'wp   some-command',
 				'some-command',
 			],
@@ -581,7 +581,7 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 		$captured_atts = null;
 		add_filter(
 			'pre_wp_mail',
-			function ( $null, $atts ) use ( &$captured_atts ) {
+			function ( $no_value, $atts ) use ( &$captured_atts ) {
 				$captured_atts = $atts;
 				return true;
 			},
@@ -608,7 +608,7 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 		$captured_atts = null;
 		add_filter(
 			'pre_wp_mail',
-			function ( $null, $atts ) use ( &$captured_atts ) {
+			function ( $no_value, $atts ) use ( &$captured_atts ) {
 				$captured_atts = $atts;
 				return true;
 			},
@@ -633,7 +633,7 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 		$captured_atts = null;
 		add_filter(
 			'pre_wp_mail',
-			function ( $null, $atts ) use ( &$captured_atts ) {
+			function ( $no_value, $atts ) use ( &$captured_atts ) {
 				$captured_atts = $atts;
 				return true;
 			},

--- a/tests/Command/TestCommandSupervisor.php
+++ b/tests/Command/TestCommandSupervisor.php
@@ -36,6 +36,15 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 	private array $temp_plugin_dirs = [];
 
 	/**
+	 * Filters registered during tests that need to be removed in tearDown.
+	 *
+	 * Each entry is [ hook, callback, priority ].
+	 *
+	 * @var array[]
+	 */
+	private array $filters_to_remove = [];
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function setUp(): void {
@@ -69,6 +78,11 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 		}
 		$this->temp_plugin_dirs = [];
 
+		foreach ( $this->filters_to_remove as list( $hook, $callback, $priority ) ) {
+			remove_filter( $hook, $callback, $priority );
+		}
+		$this->filters_to_remove = [];
+
 		parent::tearDown();
 	}
 
@@ -97,12 +111,11 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 	 * @param array $plugins The active plugins array to use.
 	 */
 	private function set_active_plugins( array $plugins ): void {
-		add_filter(
-			'pre_option_active_plugins',
-			function () use ( $plugins ) {
-				return $plugins;
-			}
-		);
+		$callback = function () use ( $plugins ) {
+			return $plugins;
+		};
+		add_filter( 'pre_option_active_plugins', $callback );
+		$this->filters_to_remove[] = [ 'pre_option_active_plugins', $callback, 10 ];
 	}
 
 	/**
@@ -579,15 +592,12 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 	 */
 	public function test_send_notification_sends_success_email(): void {
 		$captured_atts = null;
-		add_filter(
-			'pre_wp_mail',
-			function ( $no_value, $atts ) use ( &$captured_atts ) {
-				$captured_atts = $atts;
-				return true;
-			},
-			10,
-			2
-		);
+		$callback      = function ( $no_value, $atts ) use ( &$captured_atts ) {
+			$captured_atts = $atts;
+			return true;
+		};
+		add_filter( 'pre_wp_mail', $callback, 10, 2 );
+		$this->filters_to_remove[] = [ 'pre_wp_mail', $callback, 10 ];
 
 		$this->invoke_private_method(
 			'send_notification',
@@ -606,15 +616,12 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 	 */
 	public function test_send_notification_sends_failure_email(): void {
 		$captured_atts = null;
-		add_filter(
-			'pre_wp_mail',
-			function ( $no_value, $atts ) use ( &$captured_atts ) {
-				$captured_atts = $atts;
-				return true;
-			},
-			10,
-			2
-		);
+		$callback      = function ( $no_value, $atts ) use ( &$captured_atts ) {
+			$captured_atts = $atts;
+			return true;
+		};
+		add_filter( 'pre_wp_mail', $callback, 10, 2 );
+		$this->filters_to_remove[] = [ 'pre_wp_mail', $callback, 10 ];
 
 		$this->invoke_private_method(
 			'send_notification',
@@ -631,15 +638,12 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 	 */
 	public function test_send_notification_email_body_content(): void {
 		$captured_atts = null;
-		add_filter(
-			'pre_wp_mail',
-			function ( $no_value, $atts ) use ( &$captured_atts ) {
-				$captured_atts = $atts;
-				return true;
-			},
-			10,
-			2
-		);
+		$callback      = function ( $no_value, $atts ) use ( &$captured_atts ) {
+			$captured_atts = $atts;
+			return true;
+		};
+		add_filter( 'pre_wp_mail', $callback, 10, 2 );
+		$this->filters_to_remove[] = [ 'pre_wp_mail', $callback, 10 ];
 
 		$this->invoke_private_method(
 			'send_notification',

--- a/tests/Command/TestCommandSupervisor.php
+++ b/tests/Command/TestCommandSupervisor.php
@@ -1,0 +1,655 @@
+<?php
+
+namespace Newspack\MigrationTools\Tests\Command;
+
+use Newspack\MigrationTools\Command\CommandSupervisor;
+use Newspack\MigrationTools\Util\Log\MultiLog;
+use ReflectionClass;
+use WP_UnitTestCase;
+
+/**
+ * Class TestCommandSupervisor
+ *
+ * @package newspack-migration-tools
+ */
+class TestCommandSupervisor extends WP_UnitTestCase {
+
+	/**
+	 * The CommandSupervisor instance under test.
+	 *
+	 * @var CommandSupervisor
+	 */
+	private CommandSupervisor $supervisor;
+
+	/**
+	 * Reflection class for accessing private methods.
+	 *
+	 * @var ReflectionClass
+	 */
+	private ReflectionClass $reflection;
+
+	/**
+	 * Temporary plugin directories created during tests.
+	 *
+	 * @var string[]
+	 */
+	private array $temp_plugin_dirs = [];
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter( 'newspack_migration_tools_log_file_logger_disable', '__return_true' );
+		add_filter( 'newspack_migration_tools_log_clilog_disable', '__return_true' );
+
+		$this->reflection = new ReflectionClass( CommandSupervisor::class );
+		$this->supervisor = $this->reflection->newInstanceWithoutConstructor();
+
+		// Initialize logger since private methods depend on it.
+		$logger_prop = $this->reflection->getProperty( 'logger' );
+		$logger_prop->setAccessible( true );
+		$logger_prop->setValue( $this->supervisor, MultiLog::get_cli_and_file_logger( 'CommandSupervisorTest' ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function tearDown(): void {
+		foreach ( $this->temp_plugin_dirs as $dir ) {
+			if ( file_exists( $dir . '/composer.json' ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+				unlink( $dir . '/composer.json' );
+			}
+			if ( is_dir( $dir ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.directory_rmdir
+				rmdir( $dir );
+			}
+		}
+		$this->temp_plugin_dirs = [];
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Invoke a private method on the supervisor instance via reflection.
+	 *
+	 * @param string $method Method name.
+	 * @param array  $args   Method arguments.
+	 *
+	 * @return mixed The method's return value.
+	 */
+	private function invoke_private_method( string $method, array $args = [] ) {
+		$method_ref = $this->reflection->getMethod( $method );
+		$method_ref->setAccessible( true );
+
+		return $method_ref->invokeArgs( $this->supervisor, $args );
+	}
+
+	/**
+	 * Override the active_plugins option for the duration of a test.
+	 *
+	 * The test bootstrap sets $GLOBALS['wp_tests_options']['active_plugins'] which
+	 * gets returned by get_option() via a pre_option filter, bypassing the database.
+	 * This helper overrides that filter so our test value is used instead.
+	 *
+	 * @param array $plugins The active plugins array to use.
+	 */
+	private function set_active_plugins( array $plugins ): void {
+		add_filter(
+			'pre_option_active_plugins',
+			function () use ( $plugins ) {
+				return $plugins;
+			}
+		);
+	}
+
+	/**
+	 * Create a temporary plugin directory with an optional composer.json.
+	 *
+	 * @param string     $slug          Plugin slug (directory name).
+	 * @param array|null $composer_data Composer data to write as JSON, or null for no composer.json.
+	 */
+	private function create_temp_plugin( string $slug, ?array $composer_data = null ): void {
+		$plugin_dir = WP_PLUGIN_DIR . '/' . $slug;
+		if ( ! is_dir( $plugin_dir ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+			mkdir( $plugin_dir, 0755, true );
+		}
+		if ( null !== $composer_data ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			file_put_contents( $plugin_dir . '/composer.json', wp_json_encode( $composer_data ) );
+		}
+		$this->temp_plugin_dirs[] = $plugin_dir;
+	}
+
+	// ==========================================================================
+	// Tests for get_cli_commands().
+	// ==========================================================================
+
+	/**
+	 * Test that get_cli_commands returns a valid structure.
+	 */
+	public function test_get_cli_commands_returns_valid_structure(): void {
+		$commands = CommandSupervisor::get_cli_commands();
+
+		$this->assertIsArray( $commands );
+		$this->assertCount( 1, $commands );
+
+		$command = $commands[0];
+		$this->assertSame( 'newspack-content-migrator command-supervisor', $command[0] );
+		$this->assertIsCallable( $command[1] );
+		$this->assertArrayHasKey( 'shortdesc', $command[2] );
+		$this->assertArrayHasKey( 'synopsis', $command[2] );
+	}
+
+	/**
+	 * Test that all expected synopsis parameters are present.
+	 */
+	public function test_get_cli_commands_has_all_synopsis_params(): void {
+		$commands   = CommandSupervisor::get_cli_commands();
+		$synopsis   = $commands[0][2]['synopsis'];
+		$param_names = array_column( $synopsis, 'name' );
+
+		$expected = [
+			'command',
+			'max-fail-retries',
+			'max-consecutive-fail-retries',
+			'retry-delay',
+			'restart-on-success',
+			'completion-criteria',
+			'max-success-retries',
+			'active-plugins',
+			'notify-email',
+		];
+
+		foreach ( $expected as $param ) {
+			$this->assertContains( $param, $param_names, sprintf( 'Missing synopsis param: %s', $param ) );
+		}
+	}
+
+	/**
+	 * Test that --command is the only required parameter.
+	 */
+	public function test_command_param_is_required(): void {
+		$commands = CommandSupervisor::get_cli_commands();
+		$synopsis = $commands[0][2]['synopsis'];
+
+		foreach ( $synopsis as $param ) {
+			if ( 'command' === $param['name'] ) {
+				$this->assertFalse( $param['optional'] );
+			} else {
+				$this->assertTrue(
+					$param['optional'] ?? true,
+					sprintf( 'Param %s should be optional', $param['name'] )
+				);
+			}
+		}
+	}
+
+	// ==========================================================================
+	// Tests for inject_wp_cli_global_flags().
+	// ==========================================================================
+
+	/**
+	 * Test that --skip-themes and --skip-plugins are injected.
+	 */
+	public function test_inject_flags_adds_skip_themes_and_plugins(): void {
+		$this->set_active_plugins( [ 'some-plugin/some-plugin.php' ] );
+
+		$result = $this->invoke_private_method(
+			'inject_wp_cli_global_flags',
+			[ 'newspack-content-migrator some-command', '' ]
+		);
+
+		$this->assertStringContainsString( '--skip-themes', $result );
+		$this->assertStringContainsString( '--skip-plugins=', $result );
+		$this->assertStringEndsWith( 'newspack-content-migrator some-command', $result );
+	}
+
+	/**
+	 * Test that existing --skip-themes is not duplicated.
+	 */
+	public function test_inject_flags_respects_existing_skip_themes(): void {
+		$result = $this->invoke_private_method(
+			'inject_wp_cli_global_flags',
+			[ '--skip-themes newspack-content-migrator some-command', '' ]
+		);
+
+		$this->assertSame( 1, substr_count( $result, '--skip-themes' ) );
+	}
+
+	/**
+	 * Test that existing --skip-plugins is not duplicated.
+	 */
+	public function test_inject_flags_respects_existing_skip_plugins(): void {
+		$result = $this->invoke_private_method(
+			'inject_wp_cli_global_flags',
+			[ '--skip-plugins=foo newspack-content-migrator some-command', '' ]
+		);
+
+		$this->assertSame( 1, substr_count( $result, '--skip-plugins' ) );
+	}
+
+	/**
+	 * Test that the command is returned unchanged when both flags are already present.
+	 */
+	public function test_inject_flags_returns_unchanged_when_both_present(): void {
+		$command = '--skip-themes --skip-plugins=foo newspack-content-migrator some-command';
+		$result  = $this->invoke_private_method( 'inject_wp_cli_global_flags', [ $command, '' ] );
+
+		$this->assertSame( $command, $result );
+	}
+
+	/**
+	 * Test that --skip-plugins is omitted when there are no plugins to skip.
+	 */
+	public function test_inject_flags_omits_skip_plugins_when_none_to_skip(): void {
+		$this->set_active_plugins( [] );
+
+		$result = $this->invoke_private_method(
+			'inject_wp_cli_global_flags',
+			[ 'newspack-content-migrator some-command', '' ]
+		);
+
+		$this->assertStringContainsString( '--skip-themes', $result );
+		$this->assertStringNotContainsString( '--skip-plugins', $result );
+	}
+
+	/**
+	 * Test that flags are prepended before the subcommand.
+	 */
+	public function test_inject_flags_prepends_before_subcommand(): void {
+		$this->set_active_plugins( [ 'some-plugin/some-plugin.php' ] );
+
+		$result = $this->invoke_private_method(
+			'inject_wp_cli_global_flags',
+			[ 'newspack-content-migrator some-command --batch-size=100', '' ]
+		);
+
+		// Flags should come before the subcommand.
+		$skip_pos    = strpos( $result, '--skip-themes' );
+		$command_pos = strpos( $result, 'newspack-content-migrator' );
+		$this->assertLessThan( $command_pos, $skip_pos );
+	}
+
+	// ==========================================================================
+	// Tests for get_plugins_to_skip().
+	// ==========================================================================
+
+	/**
+	 * Test that all non-whitelisted active plugins are skipped.
+	 */
+	public function test_get_plugins_to_skip_skips_non_whitelisted(): void {
+		$this->set_active_plugins(
+			[
+				'plugin-a/plugin-a.php',
+				'plugin-b/plugin-b.php',
+			]
+		);
+
+		$result = $this->invoke_private_method( 'get_plugins_to_skip', [ '' ] );
+
+		$this->assertContains( 'plugin-a', $result );
+		$this->assertContains( 'plugin-b', $result );
+	}
+
+	/**
+	 * Test that caller-specified plugins are kept active (not skipped).
+	 */
+	public function test_get_plugins_to_skip_keeps_whitelisted_plugins(): void {
+		$this->set_active_plugins(
+			[
+				'plugin-a/plugin-a.php',
+				'plugin-b/plugin-b.php',
+			]
+		);
+
+		$result = $this->invoke_private_method( 'get_plugins_to_skip', [ 'plugin-a' ] );
+
+		$this->assertNotContains( 'plugin-a', $result );
+		$this->assertContains( 'plugin-b', $result );
+	}
+
+	/**
+	 * Test that multiple comma-separated whitelist plugins are all kept.
+	 */
+	public function test_get_plugins_to_skip_handles_multiple_whitelisted(): void {
+		$this->set_active_plugins(
+			[
+				'plugin-a/plugin-a.php',
+				'plugin-b/plugin-b.php',
+				'plugin-c/plugin-c.php',
+			]
+		);
+
+		$result = $this->invoke_private_method( 'get_plugins_to_skip', [ 'plugin-a, plugin-c' ] );
+
+		$this->assertNotContains( 'plugin-a', $result );
+		$this->assertNotContains( 'plugin-c', $result );
+		$this->assertContains( 'plugin-b', $result );
+	}
+
+	/**
+	 * Test that single-file plugins use the basename (minus .php) as their slug.
+	 */
+	public function test_get_plugins_to_skip_handles_single_file_plugins(): void {
+		$this->set_active_plugins(
+			[
+				'single-file-plugin.php',
+				'plugin-a/plugin-a.php',
+			]
+		);
+
+		$result = $this->invoke_private_method( 'get_plugins_to_skip', [ '' ] );
+
+		$this->assertContains( 'single-file-plugin', $result );
+		$this->assertContains( 'plugin-a', $result );
+	}
+
+	/**
+	 * Test that an empty skip list is returned when there are no active plugins.
+	 */
+	public function test_get_plugins_to_skip_returns_empty_when_no_active_plugins(): void {
+		$this->set_active_plugins( [] );
+
+		$result = $this->invoke_private_method( 'get_plugins_to_skip', [ '' ] );
+
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test that detected host plugins are whitelisted automatically.
+	 */
+	public function test_get_plugins_to_skip_whitelists_host_plugin(): void {
+		$this->create_temp_plugin(
+			'test-nmt-host',
+			[
+				'require' => [
+					'automattic/newspack-migration-tools' => 'dev-trunk',
+				],
+			]
+		);
+
+		$this->set_active_plugins(
+			[
+				'test-nmt-host/test-nmt-host.php',
+				'some-other-plugin/some-other-plugin.php',
+			]
+		);
+
+		$result = $this->invoke_private_method( 'get_plugins_to_skip', [ '' ] );
+
+		$this->assertNotContains( 'test-nmt-host', $result );
+		$this->assertContains( 'some-other-plugin', $result );
+	}
+
+	// ==========================================================================
+	// Tests for get_host_plugin_slugs().
+	// ==========================================================================
+
+	/**
+	 * Test that a plugin requiring newspack-migration-tools is detected.
+	 */
+	public function test_get_host_plugin_slugs_detects_dependency(): void {
+		$this->create_temp_plugin(
+			'test-host-plugin',
+			[
+				'require' => [
+					'automattic/newspack-migration-tools' => 'dev-trunk',
+				],
+			]
+		);
+
+		$result = $this->invoke_private_method(
+			'get_host_plugin_slugs',
+			[ [ 'test-host-plugin/test-host-plugin.php' ] ]
+		);
+
+		$this->assertContains( 'test-host-plugin', $result );
+	}
+
+	/**
+	 * Test that a plugin without the dependency is not detected.
+	 */
+	public function test_get_host_plugin_slugs_ignores_non_dependent_plugins(): void {
+		$this->create_temp_plugin(
+			'not-a-host',
+			[
+				'require' => [
+					'some/other-package' => '^1.0',
+				],
+			]
+		);
+
+		$result = $this->invoke_private_method(
+			'get_host_plugin_slugs',
+			[ [ 'not-a-host/not-a-host.php' ] ]
+		);
+
+		$this->assertNotContains( 'not-a-host', $result );
+	}
+
+	/**
+	 * Test that plugins without a composer.json are skipped.
+	 */
+	public function test_get_host_plugin_slugs_skips_plugins_without_composer_json(): void {
+		$this->create_temp_plugin( 'no-composer', null );
+
+		$result = $this->invoke_private_method(
+			'get_host_plugin_slugs',
+			[ [ 'no-composer/no-composer.php' ] ]
+		);
+
+		$this->assertNotContains( 'no-composer', $result );
+	}
+
+	/**
+	 * Test that single-file plugins (no directory) are skipped.
+	 */
+	public function test_get_host_plugin_slugs_skips_single_file_plugins(): void {
+		$result = $this->invoke_private_method(
+			'get_host_plugin_slugs',
+			[ [ 'single-file.php' ] ]
+		);
+
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test that a plugin with invalid JSON in composer.json is skipped.
+	 */
+	public function test_get_host_plugin_slugs_handles_invalid_json(): void {
+		$plugin_dir = WP_PLUGIN_DIR . '/invalid-json-plugin';
+		if ( ! is_dir( $plugin_dir ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+			mkdir( $plugin_dir, 0755, true );
+		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $plugin_dir . '/composer.json', 'not valid json{{{' );
+		$this->temp_plugin_dirs[] = $plugin_dir;
+
+		$result = $this->invoke_private_method(
+			'get_host_plugin_slugs',
+			[ [ 'invalid-json-plugin/invalid-json-plugin.php' ] ]
+		);
+
+		$this->assertNotContains( 'invalid-json-plugin', $result );
+	}
+
+	/**
+	 * Test that multiple host plugins are detected.
+	 */
+	public function test_get_host_plugin_slugs_returns_multiple_hosts(): void {
+		$this->create_temp_plugin(
+			'host-one',
+			[
+				'require' => [
+					'automattic/newspack-migration-tools' => 'dev-trunk',
+				],
+			]
+		);
+		$this->create_temp_plugin(
+			'host-two',
+			[
+				'require' => [
+					'automattic/newspack-migration-tools' => '^1.0',
+				],
+			]
+		);
+
+		$result = $this->invoke_private_method(
+			'get_host_plugin_slugs',
+			[
+				[
+					'host-one/host-one.php',
+					'host-two/host-two.php',
+				],
+			]
+		);
+
+		$this->assertContains( 'host-one', $result );
+		$this->assertContains( 'host-two', $result );
+		$this->assertCount( 2, $result );
+	}
+
+	/**
+	 * Test that an empty list is returned when no active plugins exist.
+	 */
+	public function test_get_host_plugin_slugs_returns_empty_for_no_plugins(): void {
+		$result = $this->invoke_private_method( 'get_host_plugin_slugs', [ [] ] );
+
+		$this->assertEmpty( $result );
+	}
+
+	// ==========================================================================
+	// Tests for wp prefix stripping (regex used in cmd_supervise).
+	// ==========================================================================
+
+	/**
+	 * Test that the wp prefix is correctly stripped from various command formats.
+	 *
+	 * @dataProvider data_wp_prefix_stripping
+	 *
+	 * @param string $input    The input command string.
+	 * @param string $expected The expected result after stripping.
+	 */
+	public function test_wp_prefix_is_stripped( string $input, string $expected ): void {
+		$result = preg_replace( '/^\S*wp\s+/', '', $input );
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Data provider for wp prefix stripping tests.
+	 *
+	 * @return array[] Test cases.
+	 */
+	public function data_wp_prefix_stripping(): array {
+		return [
+			'simple wp prefix'          => [
+				'wp some-command --flag',
+				'some-command --flag',
+			],
+			'full path wp prefix'       => [
+				'/usr/local/bin/wp some-command --flag',
+				'some-command --flag',
+			],
+			'no wp prefix'              => [
+				'some-command --flag',
+				'some-command --flag',
+			],
+			'wp in middle of word'      => [
+				'newspack-wp-migrator some-command',
+				'newspack-wp-migrator some-command',
+			],
+			'wp with extra whitespace'  => [
+				'wp   some-command',
+				'some-command',
+			],
+		];
+	}
+
+	// ==========================================================================
+	// Tests for send_notification().
+	// ==========================================================================
+
+	/**
+	 * Test that a success notification is sent with the correct content.
+	 */
+	public function test_send_notification_sends_success_email(): void {
+		$captured_atts = null;
+		add_filter(
+			'pre_wp_mail',
+			function ( $null, $atts ) use ( &$captured_atts ) {
+				$captured_atts = $atts;
+				return true;
+			},
+			10,
+			2
+		);
+
+		$this->invoke_private_method(
+			'send_notification',
+			[ 'test@example.com', 0, 'newspack-content-migrator some-command', 3 ]
+		);
+
+		$this->assertNotNull( $captured_atts );
+		$this->assertSame( 'test@example.com', $captured_atts['to'] );
+		$this->assertStringContainsString( 'succeeded', $captured_atts['subject'] );
+		$this->assertStringContainsString( '3 attempt(s)', $captured_atts['subject'] );
+		$this->assertStringContainsString( 'newspack-content-migrator some-command', $captured_atts['message'] );
+	}
+
+	/**
+	 * Test that a failure notification is sent with the correct status.
+	 */
+	public function test_send_notification_sends_failure_email(): void {
+		$captured_atts = null;
+		add_filter(
+			'pre_wp_mail',
+			function ( $null, $atts ) use ( &$captured_atts ) {
+				$captured_atts = $atts;
+				return true;
+			},
+			10,
+			2
+		);
+
+		$this->invoke_private_method(
+			'send_notification',
+			[ 'test@example.com', 1, 'some-command', 5 ]
+		);
+
+		$this->assertNotNull( $captured_atts );
+		$this->assertStringContainsString( 'failed', $captured_atts['subject'] );
+		$this->assertStringContainsString( '5 attempt(s)', $captured_atts['subject'] );
+	}
+
+	/**
+	 * Test that the email body contains all expected fields.
+	 */
+	public function test_send_notification_email_body_content(): void {
+		$captured_atts = null;
+		add_filter(
+			'pre_wp_mail',
+			function ( $null, $atts ) use ( &$captured_atts ) {
+				$captured_atts = $atts;
+				return true;
+			},
+			10,
+			2
+		);
+
+		$this->invoke_private_method(
+			'send_notification',
+			[ 'test@example.com', 0, 'my-command --flag', 2 ]
+		);
+
+		$body = $captured_atts['message'];
+		$this->assertStringContainsString( 'my-command --flag', $body );
+		$this->assertStringContainsString( 'succeeded', $body );
+		$this->assertStringContainsString( 'Exit code: 0', $body );
+		$this->assertStringContainsString( 'Attempts:  2', $body );
+	}
+}

--- a/tests/Command/TestCommandSupervisor.php
+++ b/tests/Command/TestCommandSupervisor.php
@@ -3,6 +3,7 @@
 namespace Newspack\MigrationTools\Tests\Command;
 
 use Newspack\MigrationTools\Command\CommandSupervisor;
+use Newspack\MigrationTools\NMT;
 use Newspack\MigrationTools\Util\Log\MultiLog;
 use ReflectionClass;
 use WP_UnitTestCase;
@@ -135,6 +136,17 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 			file_put_contents( $plugin_dir . '/composer.json', wp_json_encode( $composer_data ) );
 		}
 		$this->temp_plugin_dirs[] = $plugin_dir;
+	}
+
+	// ==========================================================================
+	// Tests for EXIT_DONE constant.
+	// ==========================================================================
+
+	/**
+	 * Test that EXIT_DONE constant is defined on NMT and equals 2.
+	 */
+	public function test_exit_done_constant_is_defined(): void {
+		$this->assertSame( 2, NMT::EXIT_DONE );
 	}
 
 	// ==========================================================================
@@ -370,6 +382,29 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 		$result = $this->invoke_private_method( 'get_plugins_to_skip', [ '' ] );
 
 		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test that default migration plugins (Co-Authors Plus, Simple Local Avatars, Yoast, Newspack) are whitelisted.
+	 */
+	public function test_get_plugins_to_skip_whitelists_default_migration_plugins(): void {
+		$this->set_active_plugins(
+			[
+				'co-authors-plus/co-authors-plus.php',
+				'simple-local-avatars/simple-local-avatars.php',
+				'wordpress-seo/wp-seo.php',
+				'newspack-plugin/newspack.php',
+				'some-other-plugin/some-other-plugin.php',
+			]
+		);
+
+		$result = $this->invoke_private_method( 'get_plugins_to_skip', [ '' ] );
+
+		$this->assertNotContains( 'co-authors-plus', $result );
+		$this->assertNotContains( 'simple-local-avatars', $result );
+		$this->assertNotContains( 'wordpress-seo', $result );
+		$this->assertNotContains( 'newspack-plugin', $result );
+		$this->assertContains( 'some-other-plugin', $result );
 	}
 
 	/**
@@ -655,5 +690,241 @@ class TestCommandSupervisor extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'succeeded', $body );
 		$this->assertStringContainsString( 'Exit code: 0', $body );
 		$this->assertStringContainsString( 'Attempts:  2', $body );
+	}
+
+	// ==========================================================================
+	// Tests for cmd_supervise() supervision loop.
+	// ==========================================================================
+
+	/**
+	 * Create a process result object for use with TestableCommandSupervisor.
+	 *
+	 * @param int    $return_code Exit code.
+	 * @param string $stdout      Standard output.
+	 * @param string $stderr      Standard error.
+	 *
+	 * @return object Process result.
+	 */
+	private function make_process_result( int $return_code, string $stdout = '', string $stderr = '' ): object {
+		return (object) [
+			'stdout'      => $stdout,
+			'stderr'      => $stderr,
+			'return_code' => $return_code,
+		];
+	}
+
+	/**
+	 * Create a TestableCommandSupervisor with pre-configured process results.
+	 *
+	 * @param object[] $process_results Sequence of process results to return.
+	 *
+	 * @return TestableCommandSupervisor
+	 */
+	private function create_testable_supervisor( array $process_results ): TestableCommandSupervisor {
+		$supervisor                  = new TestableCommandSupervisor();
+		$supervisor->process_results = $process_results;
+
+		return $supervisor;
+	}
+
+	/**
+	 * Build assoc_args for cmd_supervise() with sensible test defaults.
+	 *
+	 * @param array $overrides Key-value pairs to merge into defaults.
+	 *
+	 * @return array
+	 */
+	private function get_default_supervise_args( array $overrides = [] ): array {
+		return array_merge(
+			[
+				'command'     => 'some-command --batch-size=100',
+				'retry-delay' => 0,
+			],
+			$overrides
+		);
+	}
+
+	/**
+	 * Test that EXIT_DONE stops the loop even when --restart-on-success is set.
+	 */
+	public function test_cmd_supervise_stops_on_exit_done_with_restart_on_success(): void {
+		$this->set_active_plugins( [] );
+		$supervisor = $this->create_testable_supervisor(
+			[
+				$this->make_process_result( 0 ),
+				$this->make_process_result( NMT::EXIT_DONE ),
+			]
+		);
+
+		$supervisor->cmd_supervise(
+			[],
+			$this->get_default_supervise_args( [ 'restart-on-success' => true ] )
+		);
+
+		$this->assertSame( 2, $supervisor->execute_count );
+	}
+
+	/**
+	 * Test that EXIT_DONE stops the loop when --restart-on-success is not set.
+	 */
+	public function test_cmd_supervise_stops_on_exit_done_without_restart_on_success(): void {
+		$this->set_active_plugins( [] );
+		$supervisor = $this->create_testable_supervisor(
+			[
+				$this->make_process_result( NMT::EXIT_DONE ),
+			]
+		);
+
+		$supervisor->cmd_supervise(
+			[],
+			$this->get_default_supervise_args()
+		);
+
+		$this->assertSame( 1, $supervisor->execute_count );
+	}
+
+	/**
+	 * Test that exit 0 continues the loop with --restart-on-success until EXIT_DONE.
+	 */
+	public function test_cmd_supervise_continues_on_exit_0_with_restart_on_success(): void {
+		$this->set_active_plugins( [] );
+		$supervisor = $this->create_testable_supervisor(
+			[
+				$this->make_process_result( 0 ),
+				$this->make_process_result( 0 ),
+				$this->make_process_result( NMT::EXIT_DONE ),
+			]
+		);
+
+		$supervisor->cmd_supervise(
+			[],
+			$this->get_default_supervise_args( [ 'restart-on-success' => true ] )
+		);
+
+		$this->assertSame( 3, $supervisor->execute_count );
+	}
+
+	/**
+	 * Test that exit 0 stops the loop when --restart-on-success is not set.
+	 */
+	public function test_cmd_supervise_stops_on_exit_0_without_restart_on_success(): void {
+		$this->set_active_plugins( [] );
+		$supervisor = $this->create_testable_supervisor(
+			[
+				$this->make_process_result( 0 ),
+			]
+		);
+
+		$supervisor->cmd_supervise(
+			[],
+			$this->get_default_supervise_args()
+		);
+
+		$this->assertSame( 1, $supervisor->execute_count );
+	}
+
+	/**
+	 * Test that EXIT_DONE normalizes the final exit code to 0 (notification says "succeeded").
+	 */
+	public function test_cmd_supervise_exit_done_sends_success_notification(): void {
+		$this->set_active_plugins( [] );
+		$captured_atts = null;
+		$callback      = function ( $no_value, $atts ) use ( &$captured_atts ) {
+			$captured_atts = $atts;
+			return true;
+		};
+		add_filter( 'pre_wp_mail', $callback, 10, 2 );
+		$this->filters_to_remove[] = [ 'pre_wp_mail', $callback, 10 ];
+
+		$supervisor = $this->create_testable_supervisor(
+			[
+				$this->make_process_result( NMT::EXIT_DONE ),
+			]
+		);
+
+		$supervisor->cmd_supervise(
+			[],
+			$this->get_default_supervise_args( [ 'notify-email' => 'test@example.com' ] )
+		);
+
+		$this->assertNotNull( $captured_atts );
+		$this->assertStringContainsString( 'succeeded', $captured_atts['subject'] );
+	}
+
+	/**
+	 * Test that --restart-on-success stops at max-success-retries when no EXIT_DONE is received.
+	 */
+	public function test_cmd_supervise_stops_at_max_success_retries(): void {
+		$this->set_active_plugins( [] );
+		$supervisor = $this->create_testable_supervisor(
+			[
+				$this->make_process_result( 0 ),
+				$this->make_process_result( 0 ),
+				$this->make_process_result( 0 ),
+			]
+		);
+
+		$supervisor->cmd_supervise(
+			[],
+			$this->get_default_supervise_args(
+				[
+					'restart-on-success'  => true,
+					'max-success-retries' => 3,
+				]
+			)
+		);
+
+		$this->assertSame( 3, $supervisor->execute_count );
+	}
+}
+
+/**
+ * Test double for CommandSupervisor that returns pre-configured process results.
+ *
+ * Overrides execute_command() to avoid real subprocess execution, allowing
+ * the supervision loop in cmd_supervise() to be tested in isolation.
+ */
+class TestableCommandSupervisor extends CommandSupervisor {
+
+	/**
+	 * Sequence of process results to return from execute_command().
+	 *
+	 * @var object[]
+	 */
+	public array $process_results = [];
+
+	/**
+	 * Number of times execute_command() has been called.
+	 *
+	 * @var int
+	 */
+	public int $execute_count = 0;
+
+	/**
+	 * Constructor — replaces the private constructor from WpCliCommandTrait.
+	 */
+	public function __construct() {
+		// Intentionally empty.
+	}
+
+	/**
+	 * Returns the next pre-configured process result instead of running a real command.
+	 *
+	 * Falls back to a successful result (exit code 0) if the sequence is exhausted.
+	 *
+	 * @param string $command Ignored.
+	 *
+	 * @return object Process result with stdout, stderr, and return_code.
+	 */
+	protected function execute_command( string $command ): object {
+		$result = $this->process_results[ $this->execute_count ]
+			?? (object) [
+				'stdout'      => '',
+				'stderr'      => '',
+				'return_code' => 0,
+			];
+		++$this->execute_count;
+
+		return $result;
 	}
 }

--- a/tests/Command/TestableCommandSupervisor.php
+++ b/tests/Command/TestableCommandSupervisor.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Newspack\MigrationTools\Tests\Command;
+
+use Newspack\MigrationTools\Command\CommandSupervisor;
+
+/**
+ * Test double for CommandSupervisor that returns pre-configured process results.
+ *
+ * Overrides execute_command() to avoid real subprocess execution, allowing
+ * the supervision loop in cmd_supervise() to be tested in isolation.
+ */
+class TestableCommandSupervisor extends CommandSupervisor {
+
+	/**
+	 * Sequence of process results to return from execute_command().
+	 *
+	 * @var object[]
+	 */
+	public array $process_results = [];
+
+	/**
+	 * Number of times execute_command() has been called.
+	 *
+	 * @var int
+	 */
+	public int $execute_count = 0;
+
+	/**
+	 * Constructor — replaces the private constructor from WpCliCommandTrait.
+	 */
+	public function __construct() {
+		// Intentionally empty.
+	}
+
+	/**
+	 * Returns the next pre-configured process result instead of running a real command.
+	 *
+	 * Falls back to a successful result (exit code 0) if the sequence is exhausted.
+	 *
+	 * @param string $command Ignored.
+	 *
+	 * @return object Process result with stdout, stderr, and return_code.
+	 */
+	protected function execute_command( string $command ): object {
+		$result = $this->process_results[ $this->execute_count ]
+			?? (object) [
+				'stdout'      => '',
+				'stderr'      => '',
+				'return_code' => 0,
+			];
+		++$this->execute_count;
+
+		return $result;
+	}
+}


### PR DESCRIPTION
Summary
--
  Adds a new CommandSupervisor WP-CLI command to newspack-migration-tools that wraps and supervises the execution of other WP-CLI commands. It automatically restarts commands that fail due to crashes, timeouts, or OOM kills -- a common occurrence during long-running content migrations.

  - Automatic retry on failure with configurable total and consecutive failure limits
  - Restart-on-success mode for batch-processing commands that need multiple passes
  - Exit-code-based completion signaling (NMT::EXIT_DONE) -- supervised commands call WP_CLI::halt( NMT::EXIT_DONE ) to tell the supervisor they're finished. String-based --completion-criteria is available as a fallback for commands that haven't adopted the exit code convention.
  - Memory optimization via automatic `--skip-themes` and `--skip-plugins` flag injection
  - Default plugin whitelist -- Co-Authors Plus, Simple Local Avatars, Yoast, and Newspack are kept active by default, along with any plugin that depends on automattic/newspack-migration-tools (detected dynamically via composer.json)
  - Logging to both CLI and file via MultiLog
  - Optional email notification when supervision ends

  Why
--
  Migration scripts often run for hours and can fail unpredictably due to memory limits or migration issues. Today, engineers have to manually monitor and restart these scripts. CommandSupervisor automates this, making unattended migration runs possible.

  For batch-processing migrations (e.g., "process 500 posts per run"), the --restart-on-success mode lets the supervisor keep re-running the command until it signals completion via `NMT::EXIT_DONE`, without human intervention.

  Usage
--
  Basic: auto-restart on failure

```bash
wp newspack-content-migrator command-supervisor \
    --command="newspack-content-migrator some-migration --batch-size=500"
```

  Runs the migration command. If it crashes, waits 5 seconds and retries. Stops after 3 total failures or 2 consecutive failures.

  Batch processing with EXIT_DONE (preferred)

```bash
wp newspack-content-migrator command-supervisor \
    --command="newspack-content-migrator migrate-posts --batch-size=200" \
    --restart-on-success
```
  Keeps re-running the command after each successful exit (exit code 0). The supervised command signals completion by calling WP_CLI::halt( NMT::EXIT_DONE ) (exit code 2) when there's no more work. No additional flags needed.

  Batch processing with completion criteria (fallback)

```bash
wp newspack-content-migrator command-supervisor \
    --command="newspack-content-migrator migrate-posts --batch-size=200" \
    --restart-on-success \
    --completion-criteria="No more posts to process"
```
  For commands that haven't adopted NMT::EXIT_DONE, the supervisor can scan output for a completion string instead.

  Batch processing with a fixed number of passes

```bash
wp newspack-content-migrator command-supervisor \
    --command="newspack-content-migrator migrate-posts --batch-size=200" \
    --restart-on-success \
    --max-success-retries=20
```
  Re-runs the command up to 20 successful times, then stops. Useful when you know roughly how many passes are needed.

  With email notification and custom retry settings

```bash
wp newspack-content-migrator command-supervisor \
    --command="newspack-content-migrator heavy-migration" \
    --max-fail-retries=5 \
    --max-consecutive-fail-retries=3 \
    --retry-delay=30 \
    --notify-email=engineer@example.com
```

  Allows up to 5 total failures (3 consecutive) with a 30-second delay between retries. Sends an email when supervision ends.

  Keeping specific plugins active

```bash
wp newspack-content-migrator command-supervisor \
    --command="newspack-content-migrator migrate-woo-orders" \
    --active-plugins="woocommerce,woocommerce-subscriptions"
```

  By default, all themes and non-essential plugins are skipped for memory optimization. Co-Authors Plus, Simple Local Avatars, Yoast, and Newspack are kept active by default, along with any plugin that depends on newspack-migration-tools (detected via composer.json). Use --active-plugins to whitelist additional plugins the supervised command depends on.

  Parameters

| Parameter| Required | Default |Description |
|--------|--------|--------|--------|
| --command| Yes | -- | The WP-CLI command to supervise (without the wp prefix)|
| --max-fail-retries | No | 3 | Max total failed attempts before stopping |
| --max-consecutive-fail-retries | No | 2 | Max consecutive failures before stopping |
| --retry-delay | No | 5 | Seconds to wait between retries |
| --restart-on-success | No | -- | Also restart after successful exits (exit code 0). The command can signal completion via exit code 2 (NMT::EXIT_DONE). |
| --completion-criteria | No | -- | Fallback: string to look for in output that signals "done" (for commands that don't use NMT::EXIT_DONE) |
| --max-success-retries | No | 10 | Max successful runs (only when --restart-on-success is set without --completion-criteria) |
| --active-plugins | No | -- | Comma-separated additional plugin slugs to keep active (Co-Authors Plus, Simple Local Avatars, Yoast, and Newspack are kept active by default) |
| --notify-email | No | --| Email address to notify when supervision ends |

  Test plan
--
  - Unit tests added (38 tests, 84 assertions) covering:
    - Command registration and synopsis structure
    - Global flag injection (`--skip-themes`, `--skip-plugins`)
    - Plugin skip-list building with whitelist support
    - Default migration plugin whitelist (Co-Authors Plus, Simple Local Avatars, Yoast, Newspack)
    - Dynamic host plugin detection via composer.json
    - WP prefix stripping from command input
    - Email notification content for success and failure
    - `NMT::EXIT_DONE` constant definition
    - Supervision loop: `EXIT_DONE` stops loop with and without `--restart-on-success`
    - Supervision loop: exit 0 continues with `--restart-on-success`, stops without
    - Supervision loop: `EXIT_DONE` normalizes final exit code to 0 in notifications
    - Supervision loop: `--max-success-retries` stops the loop