### PR TITLE
FG Joomla Plugin Name Match

### DIFF
--- a/src/Util/FgHelper.php
+++ b/src/Util/FgHelper.php
@@ -64,7 +64,10 @@ class FgHelper {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		if ( ! is_plugin_active( "fg-{$this->type}-to-wp-premium/fg-{$this->type}-to-wp-premium.php" ) ) {
+		// FG Drupal uses "to-wp-premium", while FG Joomla uses "to-wordpress-premium".
+		if ( ! is_plugin_active( "fg-{$this->type}-to-wp-premium/fg-{$this->type}-to-wp-premium.php" )
+			&& ! is_plugin_active( "fg-{$this->type}-to-wordpress-premium/fg-{$this->type}-to-wordpress-premium.php" )
+		) {
 			NMT::exit_with_message( "FG {$this->type} to WP Premium plugin not found. Install and activate it before using this class." );
 		}
 	}


### PR DESCRIPTION
## Changes

FG plugin names have different formats for "wp" vs "wordpress":

Drupal: `fg-drupal-to-wp-premium`
Joomla: `fg-joomla-to-wordpress-premium`

This PR will check both naming formats.

## Other Idea

I could hard code the plugin names in the [switch statement](https://github.com/Automattic/newspack-migration-tools/blob/5405933e19760f458ebb5d9e501a57941c6ef13b/src/Util/FgHelper.php#L38) if desired.  Let me know if so.

## Tests

Activate this PR via NCCM => vendor => NMT symlink.
`wp plugin activate newspack-custom-content-migrator`

Activate FG Drupal:
`wp plugin activate fg-drupal-to-wp-premium`
Run the following test file: `wp eval-file test.php`
```php
<?php
use Newspack\MigrationTools\Util\FgHelper;
$fg = new FgHelper( 'drupal' );
// FgHelper will output an error if plugin is not active.
if( $fg instanceof FgHelper) \WP_CLI::success( "success" );
```

Success will show when FG plugin is active.

Now deactivate plugin: `wp plugin deactivate fg-drupal-to-wp-premium` and re-run test to cause error to show.  

For Joomla, update the `test.php` file for `FgHelper( 'joomla' )` and activate/deactivate the FG Joomla plugin 
`wp plugin activate fg-joomla-to-wordpress-premium`

If you need the FG Joomla plugin, let me know.





