### PR TITLE
CsvWriter: auto-close file handle on __destruct

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,7 +243,7 @@ $json_iterator->items( $file, [ 'pointer' => '/data/posts' ] );
 ### CsvWriter vs JsonWriter
 
 - `CsvWriter` opens the filename as-is. `JsonWriter` prepends `getcwd() . '/'`, so **never pass absolute paths to JsonWriter**.
-- Both classes close their file handle automatically via `__destruct()`. `JsonWriter::close()` also writes the closing `]\n` to finalize the JSON array — omitting it corrupts the file. `CsvWriter::close()` only flushes the OS buffer; forgetting it won't corrupt data, but calling it explicitly (or relying on `__destruct`) is still good practice.
+- Both classes close their file handle automatically via `__destruct()`. `JsonWriter::close()` also writes the closing `]\n` to finalize the JSON array — omitting it corrupts the file. `CsvWriter::close()` just calls `fclose()` (which flushes and releases the handle); forgetting it doesn't leave an invalid CSV, but it can leak a file handle and lose buffered writes — calling it explicitly (or letting `__destruct` run) is still good practice.
 - Both open in append mode. `CsvWriter::set_header()` only writes if the file is empty, making re-runs safe.
 
 ### PostSelect

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,7 +243,7 @@ $json_iterator->items( $file, [ 'pointer' => '/data/posts' ] );
 ### CsvWriter vs JsonWriter
 
 - `CsvWriter` opens the filename as-is. `JsonWriter` prepends `getcwd() . '/'`, so **never pass absolute paths to JsonWriter**.
-- `CsvWriter` has no destructor (call `close()` explicitly). `JsonWriter` has a destructor that finalizes the JSON.
+- Both classes close their file handle automatically via `__destruct()`. `JsonWriter::close()` also writes the closing `]\n` to finalize the JSON array — omitting it corrupts the file. `CsvWriter::close()` only flushes the OS buffer; forgetting it won't corrupt data, but calling it explicitly (or relying on `__destruct`) is still good practice.
 - Both open in append mode. `CsvWriter::set_header()` only writes if the file is empty, making re-runs safe.
 
 ### PostSelect

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -21,7 +21,7 @@ download() {
     if [ `which curl` ]; then
         curl -s "$1" > "$2";
     elif [ `which wget` ]; then
-        wget -nv -O "$2" "$1"
+        curl -sL -o "$2" "$1"
     fi
 }
 
@@ -98,11 +98,11 @@ install_wp() {
 # Install plugins needed for the test suite.
 install_contrib_plugins() {
   # Also see set_up_contrib_plugins() in ./bootstrap.php in this repo for how to activate plugins in the test suite.
-  wget -nv -O $TMPDIR/co-authors-plus.zip https://downloads.wordpress.org/plugin/co-authors-plus.zip
+  curl -sL -o $TMPDIR/co-authors-plus.zip https://downloads.wordpress.org/plugin/co-authors-plus.zip
   unzip -q -o $TMPDIR/co-authors-plus.zip -d $WP_CORE_DIR/wp-content/plugins/
-  wget -nv -O $TMPDIR/newspack-plugin.zip https://github.com/Automattic/newspack-plugin/releases/latest/download/newspack-plugin.zip
+  curl -sL -o $TMPDIR/newspack-plugin.zip https://github.com/Automattic/newspack-plugin/releases/latest/download/newspack-plugin.zip
   unzip -q -o $TMPDIR/newspack-plugin.zip -d $WP_CORE_DIR/wp-content/plugins/
-  wget -nv -O $TMPDIR/simple-local-avatars.zip https://downloads.wordpress.org/plugin/simple-local-avatars.zip
+  curl -sL -o $TMPDIR/simple-local-avatars.zip https://downloads.wordpress.org/plugin/simple-local-avatars.zip
   unzip -q -o $TMPDIR/simple-local-avatars.zip -d $WP_CORE_DIR/wp-content/plugins/
 }
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -21,7 +21,7 @@ download() {
     if [ `which curl` ]; then
         curl -s "$1" > "$2";
     elif [ `which wget` ]; then
-        curl -sL -o "$2" "$1"
+        wget -nv -O "$2" "$1"
     fi
 }
 
@@ -98,11 +98,11 @@ install_wp() {
 # Install plugins needed for the test suite.
 install_contrib_plugins() {
   # Also see set_up_contrib_plugins() in ./bootstrap.php in this repo for how to activate plugins in the test suite.
-  curl -sL -o $TMPDIR/co-authors-plus.zip https://downloads.wordpress.org/plugin/co-authors-plus.zip
+  wget -nv -O $TMPDIR/co-authors-plus.zip https://downloads.wordpress.org/plugin/co-authors-plus.zip
   unzip -q -o $TMPDIR/co-authors-plus.zip -d $WP_CORE_DIR/wp-content/plugins/
-  curl -sL -o $TMPDIR/newspack-plugin.zip https://github.com/Automattic/newspack-plugin/releases/latest/download/newspack-plugin.zip
+  wget -nv -O $TMPDIR/newspack-plugin.zip https://github.com/Automattic/newspack-plugin/releases/latest/download/newspack-plugin.zip
   unzip -q -o $TMPDIR/newspack-plugin.zip -d $WP_CORE_DIR/wp-content/plugins/
-  curl -sL -o $TMPDIR/simple-local-avatars.zip https://downloads.wordpress.org/plugin/simple-local-avatars.zip
+  wget -nv -O $TMPDIR/simple-local-avatars.zip https://downloads.wordpress.org/plugin/simple-local-avatars.zip
   unzip -q -o $TMPDIR/simple-local-avatars.zip -d $WP_CORE_DIR/wp-content/plugins/
 }
 

--- a/src/Util/CsvWriter.php
+++ b/src/Util/CsvWriter.php
@@ -77,4 +77,17 @@ class CsvWriter {
 			throw new Exception( "Could not close file: {$this->filename}" );
 		}
 	}
+
+	/**
+	 * Closes the file pointer when the object is destroyed.
+	 *
+	 * Ensures the file handle is released even if close() was never called
+	 * explicitly. Safe to call after close() — is_resource() returns false
+	 * on an already-closed handle, so this is a no-op in that case.
+	 */
+	public function __destruct() {
+		if ( is_resource( $this->file_pointer ) ) {
+			$this->close();
+		}
+	}
 }

--- a/src/Util/CsvWriter.php
+++ b/src/Util/CsvWriter.php
@@ -84,10 +84,22 @@ class CsvWriter {
 	 * Ensures the file handle is released even if close() was never called
 	 * explicitly. Safe to call after close() — is_resource() returns false
 	 * on an already-closed handle, so this is a no-op in that case.
+	 *
+	 * Any exception from close() is swallowed and re-emitted as a warning,
+	 * because exceptions thrown from a destructor during shutdown become
+	 * fatal errors that callers cannot catch.
 	 */
 	public function __destruct() {
-		if ( is_resource( $this->file_pointer ) ) {
+		if ( ! is_resource( $this->file_pointer ) ) {
+			return;
+		}
+		try {
 			$this->close();
+		} catch ( Exception $e ) {
+			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+				esc_html( "CsvWriter::__destruct could not close {$this->filename}: " . $e->getMessage() ),
+				E_USER_WARNING
+			);
 		}
 	}
 }

--- a/tests/Util/CsvWriterTest.php
+++ b/tests/Util/CsvWriterTest.php
@@ -75,4 +75,35 @@ class CsvWriterTest extends TestCase {
 		$content = file_get_contents( $this->test_file );
 		$this->assertStringNotContainsString( 'Header1,Header2', $content );
 	}
+
+	public function testFileIsClosedOnDestruct(): void {
+		$test_file = $this->test_file;
+
+		// Write inside a closure so the CsvWriter goes out of scope (triggering
+		// __destruct) before we read the file back.
+		$write = function () use ( $test_file ): void {
+			$csv_writer = new CsvWriter( $test_file );
+			$csv_writer->set_header( [ 'col1', 'col2' ] );
+			$csv_writer->put( [ 'a', 'b' ] );
+			// No explicit close() — destructor must handle it.
+		};
+		$write();
+
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		$content = file_get_contents( $test_file );
+		$this->assertStringContainsString( 'col1,col2', $content );
+		$this->assertStringContainsString( 'a,b', $content );
+	}
+
+	public function testDestructIsNoopAfterExplicitClose(): void {
+		$csv_writer = new CsvWriter( $this->test_file );
+		$csv_writer->put( [ 'x', 'y' ] );
+		$csv_writer->close();
+
+		// Unsetting triggers __destruct on the already-closed handle.
+		// No exception should be thrown.
+		unset( $csv_writer );
+
+		$this->assertTrue( true ); // reached without error.
+	}
 }

--- a/tests/Util/CsvWriterTest.php
+++ b/tests/Util/CsvWriterTest.php
@@ -96,14 +96,14 @@ class CsvWriterTest extends TestCase {
 	}
 
 	public function testDestructIsNoopAfterExplicitClose(): void {
+		$this->expectNotToPerformAssertions();
+
 		$csv_writer = new CsvWriter( $this->test_file );
 		$csv_writer->put( [ 'x', 'y' ] );
 		$csv_writer->close();
 
 		// Unsetting triggers __destruct on the already-closed handle.
-		// No exception should be thrown.
+		// is_resource() returns false on a closed handle, so this is a no-op.
 		unset( $csv_writer );
-
-		$this->assertTrue( true ); // reached without error.
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `__destruct()` to `CsvWriter` that closes the file handle when the object is garbage collected, matching the pattern already used by `JsonWriter`
- Guards with `is_resource()` so calling `close()` explicitly first is still safe — the destructor becomes a no-op on an already-closed handle
- Catches any exception from `close()` inside the destructor and re-emits it as `E_USER_WARNING`, since exceptions thrown during shutdown become fatal errors the caller can't handle
- Updates `AGENTS.md` to drop the callout that `CsvWriter` had no destructor and explain the actual difference between the two classes

## Why

`JsonWriter` already had this because its `close()` writes the closing `]\n` — omitting it corrupts the JSON. `CsvWriter::close()` is just `fclose()`, so forgetting it leaks a file handle rather than corrupting data. Still worth fixing for symmetry: callers shouldn't need to know which writer class requires explicit cleanup.

## Test plan

- [x] `composer phpcs` passes on changed files
- [ ] `composer phpunit tests/Util/CsvWriterTest.php` — two new tests cover the destruct behaviour; runs on CI