### PR TITLE
Add FileLog Truncate

### DIFF
--- a/src/Util/Log/FileLog.php
+++ b/src/Util/Log/FileLog.php
@@ -91,7 +91,7 @@ class FileLog {
 			if ( ! $handler instanceof StreamHandler ) {
 				continue;
 			}
- 			
+			
 			// Get the file path. (Note: MonoLog stores the path as "url").
 			$file_path = $handler->getUrl();
 

--- a/src/Util/Log/FileLog.php
+++ b/src/Util/Log/FileLog.php
@@ -101,8 +101,7 @@ class FileLog {
 			}
 
 			// Try to use the existing file resource, otherwise a new resource will need to be opened.
-			$file_resource       = $handler->getStream();
-			$new_resource_opened = false;
+			$file_resource = $handler->getStream();
 
 			// If file resource is not already open, attempt to open it, but do not create it.
 			if ( ! is_resource( $file_resource ) ) {
@@ -114,7 +113,6 @@ class FileLog {
 					// file doesn't exist, so no need to truncate.
 					continue;
 				}
-				$new_resource_opened = true;
 			}
 
 			// Truncate and must rewind the resource.
@@ -123,10 +121,10 @@ class FileLog {
 				++$truncated_count;
 			}
 
-			// Close the resource if it was opened just to do the truncate (ie: don't close the Stream resource).
-			if ( $new_resource_opened ) {
-				fclose( $file_resource );
-			}       
+			// Close the stream if we opened it just for truncation (ie: the handler stream was not open).
+			if ( is_resource( $file_resource ) && ! is_resource( $handler->getStream() ) ) {
+				fclose( $file_resource ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+			}
 		}
 		
 		return $truncated_count;

--- a/src/Util/Log/FileLog.php
+++ b/src/Util/Log/FileLog.php
@@ -6,12 +6,9 @@ use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
-use Monolog\Level;
 use Monolog\Logger;
-use Monolog\LogRecord;
 use Newspack\MigrationTools\NMT;
 use Psr\Log\LoggerInterface;
-use Throwable;
 
 class FileLog {
 
@@ -79,61 +76,51 @@ class FileLog {
 	 * Truncate file(s) on disk.
 	 * 
 	 * Loggers write to disk files using handlers. For FileLog, the handler is StreamHandler,
-	 * which handles the underlying fopen, fwrite, etc.  A file must first be fopen and a resource handler
-	 * assigned before truncate can happen.
-	 * 
-	 * Note: Creating a Logger does not create the file...MonoLog needs to "write" once to open the
-	 * file (resource) so it can then be truncated.
-	 * 
-	 * Loggers can have multiple handlers, so each handler's file (if exists) will be truncated.
+	 * which handles the underlying fopen, fwrite, etc.  Loggers can have multiple handlers,
+	 * so each handler's file (if exists) will be truncated.
 	 *
 	 * @param Logger $logger Logger object.
 	 * @return int Count of truncated files.
-	 * 
-	 * @throws Throwable If MonoLog is unable to fopen/fwrite to the file path, an exception will be thrown.
 	 */
 	public static function truncate_files( Logger $logger ): int {
 
 		$truncated_count = 0;
 		foreach ( $logger->getHandlers() as $handler ) {
 			
-			// Only StreamHandler at this time since that is the stream type used above in the get_logger function.
+			// Only StreamHandler.
 			if ( ! $handler instanceof StreamHandler ) {
 				continue;
 			}
 
-			// Monolog file resource.
+			// File resource.
 			$file_resource = $handler->getStream();
 
-			// If file is not already open, write a blank line so MonoLog will do it's magic and open the file.
-			// Note: Creating a Logger does not create the file...MonoLog needs to "write" once to open the file resource.
+			// If file resource is not already open, attempt to open it, but do not create it.
+			// A file must first be fopen before truncate can happen.
 			if ( ! is_resource( $file_resource ) ) {
 
-				try {
-					// Write a blank message so MonoLog will open the recource.
-					// This will catch any fopen/fwrite errors due to file path errors (eg: unwriteable).
-					$handler->handle(
-						new LogRecord(
-							datetime: new \DateTimeImmutable(),
-							channel: 'app',
-							level: Level::Info,
-							message: '',
-						)    
-					);
-				} catch ( Throwable $e ) {                   
-					// Explicity re-throw the error so future developers know the above function might throw an error.
-					throw $e;
-				}
+				// Get the file path. (Note: MonoLog stores the path as "url").
+				$file_path = $handler->getUrl();
 
-				// Set the resource to the opened file.
-				$file_resource = $handler->getStream();
+				// No need to truncate if file doesn't exist, isn't local, or isn't writeable.
+				if ( empty( $file_path ) || ! is_file( $file_path ) || ! stream_is_local( $file_path ) || ! is_writable( $file_path ) ) {
+					continue;
+				}
+				
+				// Just open in reading and writing mode so we don't create the file if it doesn't already exist.
+				// Use @ to avoid a PHP warning incase file doesn't already exist.
+				$file_resource = @fopen( $file_path, 'r+' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+				if ( false === $file_resource ) {
+					// file doesn't exist, so no need to truncate.
+					continue;
+				}
 			}
 
 			// Truncate and must rewind the resource.
-			ftruncate( $file_resource, 0 ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_ftruncate
-			rewind( $file_resource );
-
-			++$truncated_count;
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_ftruncate
+			if ( ftruncate( $file_resource, 0 ) && rewind( $file_resource ) ) {
+				++$truncated_count;
+			}
 		}
 		
 		return $truncated_count;

--- a/src/Util/Log/FileLog.php
+++ b/src/Util/Log/FileLog.php
@@ -6,9 +6,12 @@ use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
+use Monolog\Level;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use Newspack\MigrationTools\NMT;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 class FileLog {
 
@@ -70,5 +73,69 @@ class FileLog {
 		self::add_new_logger( $log_id, $logger );
 
 		return $logger;
+	}
+
+	/**
+	 * Truncate file(s) on disk.
+	 * 
+	 * Loggers write to disk files using handlers. For FileLog, the handler is StreamHandler,
+	 * which handles the underlying fopen, fwrite, etc.  A file must first be fopen and a resource handler
+	 * assigned before truncate can happen.
+	 * 
+	 * Note: Creating a Logger does not create the file...MonoLog needs to "write" once to open the
+	 * file (resource) so it can then be truncated.
+	 * 
+	 * Loggers can have multiple handlers, so each handler's file (if exists) will be truncated.
+	 *
+	 * @param Logger $logger Logger object.
+	 * @return int Count of truncated files.
+	 * 
+	 * @throws Throwable If MonoLog is unable to fopen/fwrite to the file path, an exception will be thrown.
+	 */
+	public static function truncate_files( Logger $logger ): int {
+
+		$truncated_count = 0;
+		foreach ( $logger->getHandlers() as $handler ) {
+			
+			// Only StreamHandler at this time since that is the stream type used above in the get_logger function.
+			if ( ! $handler instanceof StreamHandler ) {
+				continue;
+			}
+
+			// Monolog file resource.
+			$file_resource = $handler->getStream();
+
+			// If file is not already open, write a blank line so MonoLog will do it's magic and open the file.
+			// Note: Creating a Logger does not create the file...MonoLog needs to "write" once to open the file resource.
+			if ( ! is_resource( $file_resource ) ) {
+
+				try {
+					// Write a blank message so MonoLog will open the recource.
+					// This will catch any fopen/fwrite errors due to file path errors (eg: unwriteable).
+					$handler->handle(
+						new LogRecord(
+							datetime: new \DateTimeImmutable(),
+							channel: 'app',
+							level: Level::Info,
+							message: '',
+						)    
+					);
+				} catch ( Throwable $e ) {                   
+					// Explicity re-throw the error so future developers know the above function might throw an error.
+					throw $e;
+				}
+
+				// Set the resource to the opened file.
+				$file_resource = $handler->getStream();
+			}
+
+			// Truncate and must rewind the resource.
+			ftruncate( $file_resource, 0 ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_ftruncate
+			rewind( $file_resource );
+
+			++$truncated_count;
+		}
+		
+		return $truncated_count;
 	}
 }

--- a/src/Util/Log/FileLog.php
+++ b/src/Util/Log/FileLog.php
@@ -100,11 +100,11 @@ class FileLog {
 				continue;
 			}
 
-			// File resource.
-			$file_resource = $handler->getStream();
+			// Try to use the existing file resource, otherwise a new resource will need to be opened.
+			$file_resource       = $handler->getStream();
+			$new_resource_opened = false;
 
 			// If file resource is not already open, attempt to open it, but do not create it.
-			// A file must first be fopen before truncate can happen.
 			if ( ! is_resource( $file_resource ) ) {
 
 				// Just open in reading and writing mode so we don't create the file if it doesn't already exist.
@@ -114,6 +114,7 @@ class FileLog {
 					// file doesn't exist, so no need to truncate.
 					continue;
 				}
+				$new_resource_opened = true;
 			}
 
 			// Truncate and must rewind the resource.
@@ -121,6 +122,11 @@ class FileLog {
 			if ( ftruncate( $file_resource, 0 ) && rewind( $file_resource ) ) {
 				++$truncated_count;
 			}
+
+			// Close the resource if it was opened just to do the truncate (ie: don't close the Stream resource).
+			if ( $new_resource_opened ) {
+				fclose( $file_resource );
+			}       
 		}
 		
 		return $truncated_count;

--- a/src/Util/Log/FileLog.php
+++ b/src/Util/Log/FileLog.php
@@ -74,7 +74,7 @@ class FileLog {
 
 	/**
 	 * Truncate file(s) on disk.
-	 * 
+	 *
 	 * Loggers write to disk files using handlers. For FileLog, the handler is StreamHandler,
 	 * which handles the underlying fopen, fwrite, etc.  Loggers can have multiple handlers,
 	 * so each handler's file (if exists) will be truncated.
@@ -86,12 +86,12 @@ class FileLog {
 
 		$truncated_count = 0;
 		foreach ( $logger->getHandlers() as $handler ) {
-			
+
 			// Only StreamHandler.
 			if ( ! $handler instanceof StreamHandler ) {
 				continue;
 			}
-			
+
 			// Get the file path. (Note: MonoLog stores the path as "url").
 			$file_path = $handler->getUrl();
 
@@ -126,7 +126,7 @@ class FileLog {
 				fclose( $file_resource ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 			}
 		}
-		
+
 		return $truncated_count;
 	}
 }

--- a/src/Util/Log/FileLog.php
+++ b/src/Util/Log/FileLog.php
@@ -92,7 +92,7 @@ class FileLog {
 				continue;
 			}
 
-			// Get the file path. (Note: MonoLog stores the path as "url").
+			// Get the file path. (Note: Monolog stores the path as "url").
 			$file_path = $handler->getUrl();
 
 			// No need to truncate if file doesn't exist, isn't local, isn't writeable, or non-file stream (scheme ://), etc

--- a/src/Util/Log/FileLog.php
+++ b/src/Util/Log/FileLog.php
@@ -95,7 +95,7 @@ class FileLog {
 			// Get the file path. (Note: Monolog stores the path as "url").
 			$file_path = $handler->getUrl();
 
-			// No need to truncate if file doesn't exist, isn't local, isn't writeable, or non-file stream (scheme ://), etc
+			// No need to truncate if file doesn't exist, isn't local, isn't writable, or is a non-file stream (scheme ://), etc
 			if ( empty( $file_path ) || ! is_file( $file_path ) || ! stream_is_local( $file_path ) || ! is_writable( $file_path ) ) {
 				continue;
 			}

--- a/src/Util/Log/FileLog.php
+++ b/src/Util/Log/FileLog.php
@@ -107,7 +107,7 @@ class FileLog {
 			if ( ! is_resource( $file_resource ) ) {
 
 				// Just open in reading and writing mode so we don't create the file if it doesn't already exist.
-				// Use @ to avoid a PHP warning incase file doesn't already exist.
+				// Use @ to avoid a PHP warning in case the file doesn't already exist.
 				$file_resource = @fopen( $file_path, 'r+' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 				if ( false === $file_resource ) {
 					// file doesn't exist, so no need to truncate.

--- a/src/Util/Log/FileLog.php
+++ b/src/Util/Log/FileLog.php
@@ -91,6 +91,14 @@ class FileLog {
 			if ( ! $handler instanceof StreamHandler ) {
 				continue;
 			}
+ 			
+			// Get the file path. (Note: MonoLog stores the path as "url").
+			$file_path = $handler->getUrl();
+
+			// No need to truncate if file doesn't exist, isn't local, isn't writeable, or non-file stream (scheme ://), etc
+			if ( empty( $file_path ) || ! is_file( $file_path ) || ! stream_is_local( $file_path ) || ! is_writable( $file_path ) ) {
+				continue;
+			}
 
 			// File resource.
 			$file_resource = $handler->getStream();
@@ -99,14 +107,6 @@ class FileLog {
 			// A file must first be fopen before truncate can happen.
 			if ( ! is_resource( $file_resource ) ) {
 
-				// Get the file path. (Note: MonoLog stores the path as "url").
-				$file_path = $handler->getUrl();
-
-				// No need to truncate if file doesn't exist, isn't local, or isn't writeable.
-				if ( empty( $file_path ) || ! is_file( $file_path ) || ! stream_is_local( $file_path ) || ! is_writable( $file_path ) ) {
-					continue;
-				}
-				
 				// Just open in reading and writing mode so we don't create the file if it doesn't already exist.
 				// Use @ to avoid a PHP warning incase file doesn't already exist.
 				$file_resource = @fopen( $file_path, 'r+' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen

--- a/tests/Util/Log/LoggingTests.php
+++ b/tests/Util/Log/LoggingTests.php
@@ -212,10 +212,10 @@ class LoggingTests extends WP_UnitTestCase {
 	/**
 	 * Test truncate_files() succeeds appropriatly when file path has scheme file://
 	 */
-	public function test_truncate_files_with_file_scheme( ): void {
+	public function test_truncate_files_with_file_scheme(): void {
 		
 		$file_path = 'file://' . $this->file_log;
-		$logger = FileLog::get_logger( $file_path, $file_path );
+		$logger    = FileLog::get_logger( $file_path, $file_path );
 
 		// Replace default handler with a testable handler with scheme (://) format.
 		$logger->setHandlers( [ new \Monolog\Handler\StreamHandler( $file_path ) ] );
@@ -223,7 +223,6 @@ class LoggingTests extends WP_UnitTestCase {
 		$truncated_count = FileLog::truncate_files( $logger );
 
 		$this->assertEquals( 1, $truncated_count );
-
 	}
 
 	/**
@@ -260,6 +259,5 @@ class LoggingTests extends WP_UnitTestCase {
 		$truncated_count = FileLog::truncate_files( $logger );
 
 		$this->assertEquals( 0, $truncated_count );
-
 	}
 }

--- a/tests/Util/Log/LoggingTests.php
+++ b/tests/Util/Log/LoggingTests.php
@@ -163,7 +163,7 @@ class LoggingTests extends WP_UnitTestCase {
 	 * Test that truncate_files() empties an existing log file's contents.
 	 */
 	public function test_truncate_files_truncates_existing_content(): void {
-		$logger = FileLog::get_logger( 'test-truncate-existing', $this->file_log );
+		$logger = FileLog::get_logger( $this->file_log, $this->file_log );
 
 		$logger->info( 'Some content that should be wiped out' );
 
@@ -184,7 +184,7 @@ class LoggingTests extends WP_UnitTestCase {
 	public function test_truncate_files_does_not_create_file(): void {
 		
 		// Creating a logger does not create the file.
-		$logger = FileLog::get_logger( 'test-truncate-no-file', $this->file_log );
+		$logger = FileLog::get_logger( $this->file_log, $this->file_log );
 		$this->assertFileDoesNotExist( $this->file_log );
 
 		// Verify truncating does not create a file.
@@ -201,11 +201,70 @@ class LoggingTests extends WP_UnitTestCase {
 	public function test_truncate_files_with_null_handler(): void {
 		add_filter( 'newspack_migration_tools_enable_file_log', '__return_false' );
 
-		$logger = FileLog::get_logger( 'test-truncate-disabled', $this->file_log );
+		$logger = FileLog::get_logger( $this->file_log, $this->file_log );
 
 		$truncated_count = FileLog::truncate_files( $logger );
 
 		$this->assertEquals( 0, $truncated_count );
 		$this->assertFileDoesNotExist( $this->file_log );
+	}
+
+	/**
+	 * Test truncate_files() succeeds appropriatly when file path has scheme file://
+	 */
+	public function test_truncate_files_with_file_scheme( ): void {
+		
+		$file_path = 'file://' . $this->file_log;
+		$logger = FileLog::get_logger( $file_path, $file_path );
+
+		// Replace default handler with a testable handler with scheme (://) format.
+		$logger->setHandlers( [ new \Monolog\Handler\StreamHandler( $file_path ) ] );
+		$logger->info( 'Some content' );
+		$truncated_count = FileLog::truncate_files( $logger );
+
+		$this->assertEquals( 1, $truncated_count );
+
+	}
+
+	/**
+	 * Data provider for testing truncate_files() with scheme (://) and other failures.
+	 */
+	public function data_provider_truncate_files_with_failures() {
+		return [
+			'php://output' => [ 'php://output' ],
+			'php://stdout' => [ 'php://stdout' ],
+			'php://stderr' => [ 'php://stderr' ],
+			'http://...'   => [ 'http://example.com/test' ],
+			'/dev/null'    => [ '/dev/null' ],
+			'/dev/full'    => [ '/dev/full' ],
+		];
+	}
+
+	/**
+	 * 
+	 * Test truncate_files() fails appropriatly when file path has a scheme (://)
+	 * or other non file paths.
+	 * 
+	 * ( For file:// scheme, see test_truncate_files_with_file_scheme above )
+	 * 
+	 * @dataProvider data_provider_truncate_files_with_failures
+	 */
+	public function test_truncate_files_with_failures( $stream_with_scheme ): void {
+		
+		$logger = FileLog::get_logger( 'test-truncate-scheme-failures' );
+
+		// Replace default handler with a testable handler with scheme (://) format.
+		$logger->setHandlers( [ new \Monolog\Handler\StreamHandler( $stream_with_scheme ) ] );
+		
+		try {
+			$logger->info( 'Some content' );
+		} catch( \Throwable $e ) {
+			// Ignore any write failues, we're just testing the truncate function below.
+		}
+
+		$truncated_count = FileLog::truncate_files( $logger );
+
+		$this->assertEquals( 0, $truncated_count );
+
 	}
 }

--- a/tests/Util/Log/LoggingTests.php
+++ b/tests/Util/Log/LoggingTests.php
@@ -178,60 +178,28 @@ class LoggingTests extends WP_UnitTestCase {
 		$this->assertEquals( '', file_get_contents( $this->file_log ) );
 	}
 
-
-
-
-
-
-
-
-
-
-
-
 	/**
-	 * Test that truncate_files() will open the underlying file resource even if
-	 * nothing has been logged yet (Monolog doesn't fopen until first write).
+	 * Test that truncate_files() does not create file.
 	 */
-	public function test_truncate_files_opens_file_if_not_yet_opened(): void {
-		$logger = FileLog::get_logger( 'test-truncate-not-yet-opened', $this->file_log );
-
-		// Nothing has been logged, so the file shouldn't exist yet.
+	public function test_truncate_files_does_not_create_file(): void {
+		
+		// Creating a logger does not create the file.
+		$logger = FileLog::get_logger( 'test-truncate-no-file', $this->file_log );
 		$this->assertFileDoesNotExist( $this->file_log );
 
+		// Verify truncating does not create a file.
 		$truncated_count = FileLog::truncate_files( $logger );
 
-		$this->assertEquals( 1, $truncated_count );
-		$this->assertFileExists( $this->file_log );
-		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
-		$this->assertEquals( '', file_get_contents( $this->file_log ) );
+		$this->assertEquals( 0, $truncated_count );
+		$this->assertFileDoesNotExist( $this->file_log );
+		
 	}
 
 	/**
-	 * Test that after truncating, subsequent writes start clean (no leftover
-	 * bytes/null padding from before the truncate + rewind).
+	 * Test that truncate_files() returns 0 when the logger
+	 * only has a NullHandler (i.e. file logging disabled).
 	 */
-	public function test_truncate_files_allows_writes_after_truncate(): void {
-		$logger = FileLog::get_logger( 'test-truncate-then-write', $this->file_log );
-
-		$logger->info( 'First run content' );
-		FileLog::truncate_files( $logger );
-
-		$second_message = 'Second run content';
-		$logger->info( $second_message );
-
-		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
-		$log_content = file_get_contents( $this->file_log );
-
-		$this->assertStringContainsString( $second_message, $log_content );
-		$this->assertStringNotContainsString( 'First run content', $log_content );
-	}
-
-	/**
-	 * Test that truncate_files() is a no-op (returns 0, no error) when the
-	 * logger only has a NullHandler (i.e. file logging disabled).
-	 */
-	public function test_truncate_files_returns_zero_when_logger_disabled(): void {
+	public function test_truncate_files_with_null_handler(): void {
 		add_filter( 'newspack_migration_tools_enable_file_log', '__return_false' );
 
 		$logger = FileLog::get_logger( 'test-truncate-disabled', $this->file_log );
@@ -241,55 +209,4 @@ class LoggingTests extends WP_UnitTestCase {
 		$this->assertEquals( 0, $truncated_count );
 		$this->assertFileDoesNotExist( $this->file_log );
 	}
-
-	/**
-	 * Test that truncate_files() truncates every StreamHandler attached to
-	 * the logger when there are multiple handlers/files.
-	 */
-	public function test_truncate_files_with_multiple_handlers(): void {
-		$second_file_log = $this->log_dir . '/second-test-file-log.log';
-
-		$logger = MultiLog::get_logger(
-			'test-truncate-multi-handler',
-			[
-				FileLog::get_logger( 'first handler', $this->file_log ),
-				FileLog::get_logger( 'second handler', $second_file_log ),
-			]
-		);
-
-		$logger->info( 'Content in both files' );
-
-		$this->assertFileExists( $this->file_log );
-		$this->assertFileExists( $second_file_log );
-
-		$truncated_count = FileLog::truncate_files( $logger );
-
-		$this->assertEquals( 2, $truncated_count );
-		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
-		$this->assertEquals( '', file_get_contents( $this->file_log ) );
-		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
-		$this->assertEquals( '', file_get_contents( $second_file_log ) );
-
-		// Clean up the extra file since it isn't handled by tearDown()'s known filenames.
-		if ( file_exists( $second_file_log ) ) {
-			unlink( $second_file_log );
-		}
-	}
-
-	/**
-	 * Test that truncate_files() throws when the underlying handler is unable
-	 * to open/write to its file path (e.g. an unwritable directory).
-	 */
-	public function test_truncate_files_throws_on_unwritable_path(): void {
-		add_filter( 'newspack_migration_tools_log_dir', fn() => '/path/does/not/exist/and/is/unwritable' );
-
-		$logger = FileLog::get_logger( 'test-truncate-unwritable', 'unwritable.log' );
-
-		$this->expectException( \Throwable::class );
-		FileLog::truncate_files( $logger );
-	}
-
-
-
-
 }

--- a/tests/Util/Log/LoggingTests.php
+++ b/tests/Util/Log/LoggingTests.php
@@ -210,7 +210,7 @@ class LoggingTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test truncate_files() succeeds appropriatly when file path has scheme file://
+	 * Test truncate_files() succeeds appropriately when file path has scheme file://
 	 */
 	public function test_truncate_files_with_file_scheme(): void {
 
@@ -241,7 +241,7 @@ class LoggingTests extends WP_UnitTestCase {
 
 	/**
 	 *
-	 * Test truncate_files() fails appropriatly when file path has a scheme (://)
+	 * Test truncate_files() fails appropriately when file path has a scheme (://)
 	 * or other non file paths.
 	 *
 	 * ( For file:// scheme, see test_truncate_files_with_file_scheme above )

--- a/tests/Util/Log/LoggingTests.php
+++ b/tests/Util/Log/LoggingTests.php
@@ -158,4 +158,138 @@ class LoggingTests extends WP_UnitTestCase {
 		$plain_4 = PlainFileLog::get_logger( 'different', $this->plain_file_log );
 		$this->assertNotEquals( $plain, $plain_4 );
 	}
+
+	/**
+	 * Test that truncate_files() empties an existing log file's contents.
+	 */
+	public function test_truncate_files_truncates_existing_content(): void {
+		$logger = FileLog::get_logger( 'test-truncate-existing', $this->file_log );
+
+		$logger->info( 'Some content that should be wiped out' );
+
+		$this->assertFileExists( $this->file_log );
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		$this->assertNotEmpty( file_get_contents( $this->file_log ) );
+
+		$truncated_count = FileLog::truncate_files( $logger );
+
+		$this->assertEquals( 1, $truncated_count );
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		$this->assertEquals( '', file_get_contents( $this->file_log ) );
+	}
+
+
+
+
+
+
+
+
+
+
+
+
+	/**
+	 * Test that truncate_files() will open the underlying file resource even if
+	 * nothing has been logged yet (Monolog doesn't fopen until first write).
+	 */
+	public function test_truncate_files_opens_file_if_not_yet_opened(): void {
+		$logger = FileLog::get_logger( 'test-truncate-not-yet-opened', $this->file_log );
+
+		// Nothing has been logged, so the file shouldn't exist yet.
+		$this->assertFileDoesNotExist( $this->file_log );
+
+		$truncated_count = FileLog::truncate_files( $logger );
+
+		$this->assertEquals( 1, $truncated_count );
+		$this->assertFileExists( $this->file_log );
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		$this->assertEquals( '', file_get_contents( $this->file_log ) );
+	}
+
+	/**
+	 * Test that after truncating, subsequent writes start clean (no leftover
+	 * bytes/null padding from before the truncate + rewind).
+	 */
+	public function test_truncate_files_allows_writes_after_truncate(): void {
+		$logger = FileLog::get_logger( 'test-truncate-then-write', $this->file_log );
+
+		$logger->info( 'First run content' );
+		FileLog::truncate_files( $logger );
+
+		$second_message = 'Second run content';
+		$logger->info( $second_message );
+
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		$log_content = file_get_contents( $this->file_log );
+
+		$this->assertStringContainsString( $second_message, $log_content );
+		$this->assertStringNotContainsString( 'First run content', $log_content );
+	}
+
+	/**
+	 * Test that truncate_files() is a no-op (returns 0, no error) when the
+	 * logger only has a NullHandler (i.e. file logging disabled).
+	 */
+	public function test_truncate_files_returns_zero_when_logger_disabled(): void {
+		add_filter( 'newspack_migration_tools_enable_file_log', '__return_false' );
+
+		$logger = FileLog::get_logger( 'test-truncate-disabled', $this->file_log );
+
+		$truncated_count = FileLog::truncate_files( $logger );
+
+		$this->assertEquals( 0, $truncated_count );
+		$this->assertFileDoesNotExist( $this->file_log );
+	}
+
+	/**
+	 * Test that truncate_files() truncates every StreamHandler attached to
+	 * the logger when there are multiple handlers/files.
+	 */
+	public function test_truncate_files_with_multiple_handlers(): void {
+		$second_file_log = $this->log_dir . '/second-test-file-log.log';
+
+		$logger = MultiLog::get_logger(
+			'test-truncate-multi-handler',
+			[
+				FileLog::get_logger( 'first handler', $this->file_log ),
+				FileLog::get_logger( 'second handler', $second_file_log ),
+			]
+		);
+
+		$logger->info( 'Content in both files' );
+
+		$this->assertFileExists( $this->file_log );
+		$this->assertFileExists( $second_file_log );
+
+		$truncated_count = FileLog::truncate_files( $logger );
+
+		$this->assertEquals( 2, $truncated_count );
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		$this->assertEquals( '', file_get_contents( $this->file_log ) );
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		$this->assertEquals( '', file_get_contents( $second_file_log ) );
+
+		// Clean up the extra file since it isn't handled by tearDown()'s known filenames.
+		if ( file_exists( $second_file_log ) ) {
+			unlink( $second_file_log );
+		}
+	}
+
+	/**
+	 * Test that truncate_files() throws when the underlying handler is unable
+	 * to open/write to its file path (e.g. an unwritable directory).
+	 */
+	public function test_truncate_files_throws_on_unwritable_path(): void {
+		add_filter( 'newspack_migration_tools_log_dir', fn() => '/path/does/not/exist/and/is/unwritable' );
+
+		$logger = FileLog::get_logger( 'test-truncate-unwritable', 'unwritable.log' );
+
+		$this->expectException( \Throwable::class );
+		FileLog::truncate_files( $logger );
+	}
+
+
+
+
 }

--- a/tests/Util/Log/LoggingTests.php
+++ b/tests/Util/Log/LoggingTests.php
@@ -179,10 +179,10 @@ class LoggingTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that truncate_files() does not create file.
+	 * Test that truncate_files() does not create a file.
 	 */
 	public function test_truncate_files_does_not_create_file(): void {
-		
+
 		// Creating a logger does not create the file.
 		$logger = FileLog::get_logger( $this->file_log, $this->file_log );
 		$this->assertFileDoesNotExist( $this->file_log );
@@ -213,7 +213,7 @@ class LoggingTests extends WP_UnitTestCase {
 	 * Test truncate_files() succeeds appropriatly when file path has scheme file://
 	 */
 	public function test_truncate_files_with_file_scheme(): void {
-		
+
 		$file_path = 'file://' . $this->file_log;
 		$logger    = FileLog::get_logger( $file_path, $file_path );
 
@@ -240,16 +240,16 @@ class LoggingTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * 
+	 *
 	 * Test truncate_files() fails appropriatly when file path has a scheme (://)
 	 * or other non file paths.
-	 * 
+	 *
 	 * ( For file:// scheme, see test_truncate_files_with_file_scheme above )
-	 * 
+	 *
 	 * @dataProvider data_provider_truncate_files_with_failures
 	 */
 	public function test_truncate_files_with_failures( $stream_with_scheme ): void {
-		
+
 		$logger = FileLog::get_logger( 'test-truncate-scheme-failures' );
 
 		// Replace default handler with a testable handler with scheme (://) format.

--- a/tests/Util/Log/LoggingTests.php
+++ b/tests/Util/Log/LoggingTests.php
@@ -255,13 +255,8 @@ class LoggingTests extends WP_UnitTestCase {
 
 		// Replace default handler with a testable handler with scheme (://) format.
 		$logger->setHandlers( [ new \Monolog\Handler\StreamHandler( $stream_with_scheme ) ] );
-		
-		try {
-			$logger->info( 'Some content' );
-		} catch( \Throwable $e ) {
-			// Ignore any write failues, we're just testing the truncate function below.
-		}
 
+		// Truncate will skip if not is_file, not stream_is_local, not is_writable.
 		$truncated_count = FileLog::truncate_files( $logger );
 
 		$this->assertEquals( 0, $truncated_count );

--- a/tests/Util/Log/LoggingTests.php
+++ b/tests/Util/Log/LoggingTests.php
@@ -192,7 +192,6 @@ class LoggingTests extends WP_UnitTestCase {
 
 		$this->assertEquals( 0, $truncated_count );
 		$this->assertFileDoesNotExist( $this->file_log );
-		
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR adds the ability to truncate log files.  This can be helpful in cases where it's desired to truncate a log file between each CLI run instead of just adding to the existing log file.

I chose truncating as a way to empty out a file instead of deleting the file completely.  Truncating can be used at anytime, whereas deleting a file would require the file handle (stream) to be closed (ie: before any logging starts or after all logging ends).

## CLI Testing

* Install/activate NCCM with NMT as a symlink to this PR's branch.
* Create a `test.php` file in WP root:
```php
<?php

// Create a File Logger
$mylogger = \Newspack\MigrationTools\Util\Log\FileLog::get_logger( 'myfile' );

// Add text.
$mylogger->info( 'Hello' );
\WP_CLI::log( 'Filesize before truncate: ' . filesize( 'myfile.log' ) );

// Truncate.
\Newspack\MigrationTools\Util\Log\FileLog::truncate_files( $mylogger );
\WP_CLI::log( 'Filesize after truncate: ' . filesize( 'myfile.log' ) );
```
* Eval file: `wp eval-file test.php`
* Verify expected output:
```
Filesize before truncate: 43
Filesize after truncate: 0
```