### PR TITLE
Fix Logging for Default Filters

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -100,7 +100,7 @@ install_contrib_plugins() {
   # Also see set_up_contrib_plugins() in ./bootstrap.php in this repo for how to activate plugins in the test suite.
   wget -nv -O $TMPDIR/co-authors-plus.zip https://downloads.wordpress.org/plugin/co-authors-plus.zip
   unzip -q -o $TMPDIR/co-authors-plus.zip -d $WP_CORE_DIR/wp-content/plugins/
-  wget -nv -O $TMPDIR/newspack-plugin.zip https://github.com/Automattic/newspack-plugin/releases/latest/download/newspack-plugin.zip
+  wget -nv -O $TMPDIR/newspack-plugin.zip https://github.com/Automattic/newspack-workspace/releases/download/newspack%406.47.2/newspack-plugin.zip
   unzip -q -o $TMPDIR/newspack-plugin.zip -d $WP_CORE_DIR/wp-content/plugins/
   wget -nv -O $TMPDIR/simple-local-avatars.zip https://downloads.wordpress.org/plugin/simple-local-avatars.zip
   unzip -q -o $TMPDIR/simple-local-avatars.zip -d $WP_CORE_DIR/wp-content/plugins/

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -459,7 +459,6 @@ class GhostCMSHelper {
 		/**
 		 * Write results to JSONL file.
 		 */
-		
 		foreach ( $elements as $element_data ) {
 			$data = [
 				'html_element'           => $element_data['html_element'],

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -363,6 +363,14 @@ class GhostCMSHelper {
 		// Init logger usage in this class.
 		$this->set_log_slug( $log_slug );
 
+		// Setup a logger. Be sure to use NMT's FileLog Util so that this log file will adhere to NMT's 
+		// logging filters such as `newspack_migration_tools_enable_file_log` and `newspack_migration_tools_log_dir`.
+		$output_file   = 'ghost_kg_elements.jsonl';
+		$output_logger = FileLog::get_logger( $output_file, $output_file, new PlainLineFormatter() );
+
+		// For each run, clear out any existing data already in file.
+		FileLog::truncate_files( $output_logger );
+
 		/**
 		 * Check all published posts migrated from Ghost for custom Ghost editor HTML content -- HTML elements with "kg-*" classes.
 		 */
@@ -451,14 +459,6 @@ class GhostCMSHelper {
 		/**
 		 * Write results to JSONL file.
 		 */
-
-		// Setup a logger. Be sure to use NMT's FileLog Util so that this log file will adhere to NMT's 
-		// logging filters such as `newspack_migration_tools_enable_file_log` and `newspack_migration_tools_log_dir`.
-		$output_file   = 'ghost_kg_elements.jsonl';
-		$output_logger = FileLog::get_logger( $output_file, $output_file, new PlainLineFormatter() );
-
-		// For each run, clear out any existing data already in file.
-		FileLog::truncate_files( $output_logger );
 		
 		foreach ( $elements as $element_data ) {
 			$data = [

--- a/src/Logic/GhostCMSHelper.php
+++ b/src/Logic/GhostCMSHelper.php
@@ -17,6 +17,7 @@ use Newspack\MigrationTools\Logic\GutenbergBlockGenerator;
 use Newspack\MigrationTools\NMT;
 use Newspack\MigrationTools\Util\Log\FileLog;
 use Newspack\MigrationTools\Util\Log\MultiLog;
+use Newspack\MigrationTools\Util\Log\PlainLineFormatter;
 use Monolog\Level;
 use Psr\Log\LogLevel;
 use simplehtmldom\HtmlDocument;
@@ -361,17 +362,6 @@ class GhostCMSHelper {
 
 		// Init logger usage in this class.
 		$this->set_log_slug( $log_slug );
-		
-		// Prepare output file.
-		$output_file = 'ghost_kg_elements.jsonl';
-		if ( file_exists( $output_file ) ) {
-			unlink( $output_file ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink.
-		}
-		$file_handle = fopen( $output_file, 'w' ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fopen.
-		if ( false === $file_handle ) {
-			$this->log( sprintf( 'Failed to open file "%s" for writing -- check file permissions and try running the custom Ghost content check command again.', $output_file ), LogLevel::ERROR );
-			return;
-		}
 
 		/**
 		 * Check all published posts migrated from Ghost for custom Ghost editor HTML content -- HTML elements with "kg-*" classes.
@@ -461,6 +451,15 @@ class GhostCMSHelper {
 		/**
 		 * Write results to JSONL file.
 		 */
+
+		// Setup a logger. Be sure to use NMT's FileLog Util so that this log file will adhere to NMT's 
+		// logging filters such as `newspack_migration_tools_enable_file_log` and `newspack_migration_tools_log_dir`.
+		$output_file   = 'ghost_kg_elements.jsonl';
+		$output_logger = FileLog::get_logger( $output_file, $output_file, new PlainLineFormatter() );
+
+		// For each run, clear out any existing data already in file.
+		FileLog::truncate_files( $output_logger );
+		
 		foreach ( $elements as $element_data ) {
 			$data = [
 				'html_element'           => $element_data['html_element'],
@@ -468,9 +467,13 @@ class GhostCMSHelper {
 				'first_example_full_tag' => $element_data['first_example_full_tag'],
 				'post_ids'               => $element_data['post_ids'],
 			];
-			fwrite( $file_handle, wp_json_encode( $data ) . PHP_EOL ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fwrite.
+			try {
+				$output_logger->info( wp_json_encode( $data ) );
+			} catch ( \Throwable $e ) {                   
+				$this->log( sprintf( 'Failed to write to "%s" -- check file permissions, newspack_migration_tools_enable_file_log and newspack_migration_tools_log_dir, then try running the custom Ghost content check command again.', $output_file ), LogLevel::ERROR );
+				return;
+			}
 		}
-		fclose( $file_handle ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fclose.
 
 		/**
 		 * Log summary.


### PR DESCRIPTION
## Problem:

A single log file `ghost_kg_elements.jsonl` was not adhering to the NMT logging filters during `phpunit` and was being left-over after running tests.

## Background:

NMT uses filters to determine if log files should be created or not.  When NMT is included by NCCM, [logging is on](https://github.com/Automattic/newspack-custom-content-migrator/blob/71fb242af3a5e9a26f4c62356e7ff917ef05b455/src/PluginSetup.php#L115-L123).  But when `phpunit` is run for just NMT, log files should not be created ([by default](https://github.com/Automattic/newspack-migration-tools/blob/88a0dbb42b6517e91648f1581a7e30863de40eb4/docs/logging.md)).

## Solution:

* This PR changes the log file to use the filters so that `phpunit` does not leave the file on disk after tests are run.
* Also, the previous code was deleting the log file each run so I changed this to use the new "truncate" method.  Truncating still allows emptying the log file, but can be used even if the file handle is open, whereas delete would only work before any logging happens

## Testing:

### Test 1 with NCCM:

Run the following two commands via WP CLI with NCCM plugin active and NMT symlinked.

Create a test post:
```
wp post create --post_title='test' --post_content='<div class="kg-unknown-value">test</div>' --post_status=publish --meta_input='{"newspack_ghostcms_id":123}'
```

Run command: 
```
wp newspack-migration-tools ghostcms-check-imported-posts-for-custom-html-content
```

Verify output file `ghost_kg_elements.jsonl` is created since NCCM has logging turned on.

### Test 2 with PHPUnit:

Run `phpunit` then verify file `ghost_kg_elements.jsonl` is **_not_** created since logging is off (by default).