### PR TITLE
Fix: Peg Newspack Plugin Test Version

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -100,7 +100,7 @@ install_contrib_plugins() {
   # Also see set_up_contrib_plugins() in ./bootstrap.php in this repo for how to activate plugins in the test suite.
   wget -nv -O $TMPDIR/co-authors-plus.zip https://downloads.wordpress.org/plugin/co-authors-plus.zip
   unzip -q -o $TMPDIR/co-authors-plus.zip -d $WP_CORE_DIR/wp-content/plugins/
-  wget -nv -O $TMPDIR/newspack-plugin.zip https://github.com/Automattic/newspack-plugin/releases/latest/download/newspack-plugin.zip
+  wget -nv -O $TMPDIR/newspack-plugin.zip https://github.com/Automattic/newspack-workspace/releases/download/newspack%406.47.2/newspack-plugin.zip
   unzip -q -o $TMPDIR/newspack-plugin.zip -d $WP_CORE_DIR/wp-content/plugins/
   wget -nv -O $TMPDIR/simple-local-avatars.zip https://downloads.wordpress.org/plugin/simple-local-avatars.zip
   unzip -q -o $TMPDIR/simple-local-avatars.zip -d $WP_CORE_DIR/wp-content/plugins/


### PR DESCRIPTION
## Problem

Our `phpunit` tests have a dependency for the Newspack Plugin.  Historically the zip file was fetched using github's dynamic `/releases/latest/download/` URL.  But the Newspack Plugin is now a private/deprecated repo.  

The new repo is Newspack Workspace.  But the Newspack Workspace doesn't respond the same way when fetching `/releases/latest/download/`.  The `newspack-plugin.zip` isn't guaranteed to be in the list of available zips.  It seems that the latest release list of zips only lists the individual plugin(s) that changed, not all the plugin zips.

So we'll need to peg the version to the latest release that has the `newspack-plugin.zip` file.  Pegging dependencies does have the advantage of testing with "known" code.  We can update the `newspack-plugin.zip` URL version as we see fit in the future.

## Solution

PHPUNIT build script is now pegged to a known release version such as `/newspack@6.47.2/`.